### PR TITLE
Allow a figure handle to be explicitly specified

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -116,6 +116,25 @@ function matlab2tikz( varargin )
 
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   % scan the options
+
+  % optionally allow the first parameter to define the figure
+  if ischar(varargin{1})
+      m2t.currentHandles.gcf = gcf;
+      m2t.currentHandles.colormap = colormap;
+  else
+      m2t.currentHandles.gcf = varargin{1};
+      try
+          m2t.currentHandles.colormap = get(varargin{1},'colormap');
+      catch err
+          error( 'matlab2tikz:parse',...
+                 ['Expected a valid figure handle, filename, or a '...
+                  'parameter key as the first argument\n']...
+               );
+      end
+      varargin = varargin(2:end);
+  end
+  
+  % use the input parser for all remaining options
   m2t.opts = myInputParser;
   m2t.opts = m2t.opts.addOptional( m2t.opts, ...
                                    'filename', ...
@@ -157,10 +176,6 @@ function matlab2tikz( varargin )
 
   m2t.opts = m2t.opts.parse( m2t.opts, varargin{:} );
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-  % add global elements
-  m2t.currentHandles.gcf      = gcf;
-  m2t.currentHandles.colormap = colormap;
 
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   % handle output file handle/file name


### PR DESCRIPTION
Hi Nico -

I hacked in the ability to explicitly specify the figure handle before the filename or any options are given.  It works very similarly to many of MATLAB's built-in plot- and axis-handling functions; if the first argument is not a char array, then it is presumed to be the figure handle. I then shift the varargin array to be passed through the input parser.

I attempted to get this to work with your input parser, but I don't think such a feature can be easily coded through that scheme.

You're welcome to disregard this patch; it really is a hack. But the feature would be very welcome.  Thanks for all your hard work on this!

Matt
