### PR TITLE
Handle "no ticks" setting correctly

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3608,6 +3608,9 @@ function [ticks, tickLabels, hasMinorTicks] = getIndividualAxisTicks( m2t, handl
       isAxisLog = strcmp( get(handle,keywordScale), 'log' );
       [ticks, tickLabels] = matlabTicks2pgfplotsTicks( m2t, tick, tickLabel, isAxisLog );
       % overwrite if empty
+      if length(ticks)==0
+          ticks = '\empty';
+      end
       if length(tickLabel)==1 && isempty(tickLabel{1})
           tickLabels = '\empty';
       end


### PR DESCRIPTION
When axis ticks have been disabled in MATLAB via
  set(gca, 'YTick', [])
then ticks have not been removed from matlab2tikz's output
previously. This commit changes that.
