### PR TITLE
Fix \figureheight regression

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -629,7 +629,8 @@ function m2t = drawAxes( m2t, handle, alignmentOptions )
   end
   if dim.y.unit(1)=='\' && dim.y.value==1.0
       % only return \figureheight instead of 1.0\figureheight
-      m2t.axesContainers{end}.options = sprintf('height=%s', dim.y.unit);
+      m2t.axesContainers{end}.options{end+1} = ...
+          sprintf('height=%s', dim.y.unit);
   else
       m2t.axesContainers{end}.options{end+1} = ...
           sprintf('height=%.15g%s', dim.y.value, dim.y.unit);


### PR DESCRIPTION
Commit e3cb8f88 introduced a different way to extend cell arrays.
This caused an error at least in Octave 3.6.1 if matlab2tikz was
called with the parameter height='\figureheight' (or something
else starting with a backslash) because in that case the initial
value assignment was to a string, not a cell. When the cell
element 'scale only axis' was supposed to be added afterwards,
Octave aborted with an error, saying "sq_string cannot be indexed
with {".

This commit fixes that bug.
