### PR TITLE
minor fix in drawSurface()

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2035,7 +2035,7 @@ function [m2t,env] = drawSurface( m2t, handle )
         dx = dx';
         dy = dy';
         for i = 1:row
-            str_data = sprintf('%s', num2str([dx(i,:) dy(i,:) dz(i,:)],'(%.15g,%.15g,%.15g)')');
+            str_data = sprintf('%s', num2str([dx(i,:)' dy(i,:)' dz(i,:)'],'(%.15g,%.15g,%.15g)')');
             % Remove the white space.
             str_data = str_data(~isspace(str_data));
             str = [str, str_data];


### PR DESCRIPTION
Fixes small bug that was present in `drawSurface()`. Instead of printing `(x1,y1,z1)....(xn,yn,zn)`, it printed `(x1,x2,x3)...(xn-2,xn-1,xn)(y1,y2,y3)...(yn-2,yn-1,yn)(z1,z2,z3)...(zn-2,zn-1,zn)`.

There is, however, still a bug with the error bar plots (the `@herrorbarPlot`) test fails to compile, but I haven't figured out why yet. Will make a bug report about this one.
