### PR TITLE
Version check bug

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4763,7 +4763,15 @@ function isBelow = isVersionBelow(env, versionA, versionB)
   m = min(length(vA), length(vB));
   vA = vA(1:m);
   vB = vB(1:m);
-  isBelow = any(vA(:) < vB(:));
+  
+  isBelow = true;
+  for i = 1:m
+    if vA(i) > vB(i)
+      isBelow = false;
+      break;
+    end
+  end
+  
   function arr = versionArray(env,str)
     if ischar(str)
       % Translate version string from '2.62.8.1' to [2, 62, 8, 1].


### PR DESCRIPTION
The code comparing the MATLAB/Octave version contained duplication and a bug.
It considered version 8.x.x < 7.x.x. With the pending release of MATLAB 8, this could confuse users, so please pull this fix.

Feel free to write it a bit more MATLAB-y, but this was the easiest implementation I could think of.
