### PR TITLE
Small fixes in eps2pdf function

### DIFF
--- a/test/eps2pdf.m
+++ b/test/eps2pdf.m
@@ -114,7 +114,7 @@ if ~ok
     if nargout > 1,  msg = status;  else disp(status); end;
 else
     % Run Ghostscript
-    comandLine = [fullGsPath ' ' GS_PARAMETERS ' -sOutputFile=' '"' target '"' ' -f ' '"' tmpFile '"'];
+    comandLine = ['"' fullGsPath '"' ' ' GS_PARAMETERS ' -sOutputFile=' '"' target '"' ' -f ' '"' tmpFile '"'];
     [stat, result] = system(comandLine);
     if stat
         status = ['pdf file not created - error running Ghostscript - check GS path: ' result];


### PR DESCRIPTION
Some small fixes on Matlab syntax, and also a temp. solution for PCs win 64bit GS installed. Goal is to find a way to determine if 32bit or 64bit GS is installed, as it's possible to use 32bit GS with Windows 64bit.
