### PR TITLE
join now works for nested cellstrs as well

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3889,25 +3889,24 @@ function newstr = join(m2t, cellstr, delimiter)
   % given delimiter inbetween two strings, if desired).
   %
   % Example of usage:
-  %              join(cellstr, ',')
-
-  if ~all(cellfun(@(x)(isnumeric(x) || ischar(x)), cellstr))
-      % display value of cellstr as debug information
-      disp(cellstr)
-      error('matlab2tikz:join:NotCellstrOrNumeric',...
-            'Expected cellstr or numeric.');
-  end
+  %              join(m2t, cellstr, ',')
 
   if isempty(cellstr)
     newstr = [];
     return
   end
 
-  % convert all numeric values to strings first
+  % convert all values to strings first
   nElem = numel(cellstr);
   for k = 1:nElem
       if isnumeric(cellstr{k})
           cellstr{k} = sprintf(m2t.ff, cellstr{k});
+      elseif iscell(cellstr{k})
+          cellstr{k} = join(m2t, cellstr{k}, delimiter);
+          % this will fail for heavily nested cells
+      elseif ~ischar(cellstr{k})
+          error('matlab2tikz:join:NotCellstrOrNumeric',...
+                'Expected cellstr or numeric.');
       end
   end
 


### PR DESCRIPTION
This fixes https://github.com/nschloe/matlab2tikz/issues/229, https://github.com/nschloe/matlab2tikz/issues/246, https://github.com/nschloe/matlab2tikz/issues/234 (at least the original issue reported).

What happens in my branch, is that the type check is not performed  in advance anymore. The code accepts any cell array, as long as each item is either a char or a numeric or a cell array that conforms to those same (recursive) requirements. When a non-conformance is detected, the original error is thrown.

In case of a nested `cell`, `join` is called again with the same delimiter (maybe it makes more sense to have another one in different cases).

I'm thinking about the e.g. TikZ options (key value pairs) that are sometimes stored in cell, but where the delimiter between keys and values is `=` and between options is `,`. I, however, haven't looked more into that part of the code.
