### PR TITLE
Extra colors

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -441,17 +441,10 @@ function l = isCellOrChar(x, p) %#ok
 end
 % =========================================================================
 function isValid = iscolordefinitions(colors)
-    isValid = iscell(colors);
-    nColors = numel(colors);
-    iColor = 1;
-    while isValid && iColor <= nColors
-        color = colors{iColor};
-        isValid = iscell(color)      && ... % nested cell of ...
-                  ischar(color{1})   && ... % CHAR as color name AND
-                  numel(color{2})==3 && ... % RGB values between 0 and 1
-                  max(color{2})<=1   && min(color{2})>=0;
-        iColor = iColor + 1;
-    end
+    isRGBTuple   = @(c)( numel(c) == 3 && all(0<=c & c<=1) );
+    isValidEntry = @(e)( iscell(e) && ischar(e{1}) && isRGBTuple(e{2}) );
+    
+    isValid = iscell(colors) && all(cellfun(isValidEntry, colors));
 end
 % =========================================================================
 function deprecatedParameter(m2t, oldParameter, varargin)


### PR DESCRIPTION
This implements a solution to issue #261 by using a nested cell.
I noticed the color definitions were much too detailed for any practical use. In the output, I limit the definitions to 6 decimals (60 bit color space) instead of double precision (15 decimals or 150 bit colorspace), while e.g. Photoshop is limited to 32 bit RGB.
So it is still overkill for practical use, but a lot less. The definitions look nicer that way as well :-)
