### PR TITLE
deprecatedParameter moved into inputParser

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -298,11 +298,12 @@ function matlab2tikz(varargin)
   % Automatic updater.
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'checkForUpdates', true, @islogical);
 
+  % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  % deprecated parameters (will auto-generate warnings upon parse)
+  %m2t.cmdOpts.deprecateParam(m2t.cmdOpts,'mathmode',{'parseStrings','parseStringsAsMath'});
+
   % Finally parse all the elements.
   m2t.cmdOpts = m2t.cmdOpts.parse(m2t.cmdOpts, varargin{:});
-  % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  % warn for deprecated options
-  %deprecatedParameter(m2t,'mathmode','parseStrings','parseStringsAsMath');
 
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   % inform users of potentially dangerous options
@@ -430,30 +431,6 @@ end
 % =========================================================================
 function l = isCellOrChar(x, p) %#ok
     l = iscell(x) || ischar(x);
-end
-% =========================================================================
-function deprecatedParameter(m2t, oldParameter, varargin)
-  if any(ismember(m2t.cmdOpts.Parameters, oldParameter))
-      switch numel(varargin)
-          case 0
-              replacements = '';
-          case 1
-              replacements = ['''' varargin{1} ''''];
-          otherwise
-              replacements = deblank(sprintf('''%s'' and ',varargin{:}));
-              replacements = regexprep(replacements,' and$','');
-      end
-      if ~isempty(replacements)
-          replacements = sprintf('From now on, please use %s to control the output.\n',replacements);
-      end
-
-      message = ['\n===============================================================================\n', ...
-                  'You are using the deprecated parameter ''%s''.\n', ...
-                  '%s', ...
-                  '==============================================================================='];
-      warning('matlab2tikz:deprecatedParameter', ...
-                message, oldParameter, replacements);
-  end
 end
 % =========================================================================
 function m2t = saveToFile(m2t, fid, fileWasOpen)


### PR DESCRIPTION
The parameter deprecation methods have been moved to the
inputParser, where they are a more relevant.

Warnings regarding the deprecation of used parameters will then
happen automatically by calling the parse function.
This means that declaring a parameter as deprecated should happen
before that.

There is one disadvantage, in that this design deviates from MATLAB's `inputParser` design. So if Octave one day decides to implement a counterpart for MATLAB's version, this change has to be reverted before we can drop in the MATLAB/Octave implementation (or subclass it).
