### PR TITLE
Fix issue273

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2077,7 +2077,13 @@ function [m2t, str] = drawHggroup(m2t, h)
 
       otherwise
           userWarning(m2t, 'Don''t know class ''%s''. Default handling.', cl);
-          [m2t, str] = handleAllChildren(m2t, h);
+          try
+            m2tBackup = m2t;
+            [m2t, str] = handleAllChildren(m2t, h);
+          catch ME
+            userWarning(m2t, 'Default handling for ''%s'' failed. Continuing as if it did not occur. \n Original Message:\n %s', cl, getReport(ME));
+            [m2t, str] = deal(m2tBackup, ''); % roll-back
+          end
   end
 
 end


### PR DESCRIPTION
When an unknown handle graphics element is encountered,
execute the default handling using back-tracking.
Whenever an error occurs, roll back the state of `m2t` to before
encountering the hg-object and continue with the next element.

The original error message is shown for debugging purposes, but
this allows one to run `matlab2tikz` on figures that have
unsupported elements, as was the case in #273.

I'm not that familiar with the `'unknown'` class from Octave, but maybe these cases can be merged. In that case, I would suggest just to leave out the case for `'unknown'`.

This means that instead of getting no output, the output will be partial.
