### PR TITLE
Fix for legend with both lines and patches

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1747,10 +1747,6 @@ function [m2t, str] = drawPatch(m2t, handle)
   % This is for a quirky workaround for stacked bar plots.
   m2t.axesContainers{end}.nonbarPlotsPresent = true;
 
-  % Make sure that legends are shown in area mode.
-  m2t.axesContainers{end}.options = ...
-    addToOptions(m2t.axesContainers{end}.options, 'area legend', []);
-
   % MATLAB's patch elements are matrices in which each column represents a
   % a distinct graphical object. Usually there is only one column, but
   % there may be more (-->hist plots, although they are now handled
@@ -1771,7 +1767,8 @@ function [m2t, str] = drawPatch(m2t, handle)
   end
   % -----------------------------------------------------------------------
   % gather the draw options
-  drawOptions = cell(0);
+  % Make sure that legends are shown in area mode.
+  drawOptions = {'area legend'};
 
   % see if individual color values are present
   cData = get(handle, 'CData');


### PR DESCRIPTION
Area legend is a property of the plot trace (i.e. `draw`) and not
a property of the whole `axis`.

This means that we can now support axes containing both lines and patches.

This fixes #271 and #272. The fix has been tested against the code example from #271, #272 was not tested due to code misformatting.
