### PR TITLE
matlab2tikz produced uncompilable code if NaN was used in a text field as position

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2227,7 +2227,10 @@ function [m2t, str] = drawText(m2t, handle)
   % Most of those entities are captured by matlab2tikz one way or
   % another, but sometimes they are not. This is the case, for
   % example, with polar plots and the axis descriptions therein.
-  if strcmp(get(handle, 'Visible'), 'off') ...
+  % Also, Matlab treats text objects with a NaN in the position as
+  % invisible.
+  if any(isnan(get(handle, 'Position')) | isnan(get(handle, 'Rotation'))) ... 
+     || strcmp(get(handle, 'Visible'), 'off') ...
      || (strcmp(get(handle, 'HandleVisibility'), 'off') && ~m2t.cmdOpts.Results.showHiddenStrings)
     return;
   end


### PR DESCRIPTION
Matlab does not render text fields with a NaN in position-vector. matlab2tikz does now the same (priorly it produced uncompilable tex code where pgfplot got NaNs where it could not handle it).
