### PR TITLE
Color mixtures & import custom colors

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3893,19 +3893,19 @@ function [m2t, colorLiteral] = rgb2colorliteral(m2t, rgb)
   tolColor = 1000*eps(1); % tolerance (inf-norm) on color representation
   
   %% check if rgb is a predefined color
-  for iColr = 1:length(colorSpecs)
-      Ci = colorSpecs{iColr}(:);
+  for iColor = 1:length(colorSpecs)
+      Ci = colorSpecs{iColor}(:);
       if max(abs(Ci - rgb(:)) < tolColor)
-          colorLiteral = colorNames{iColr};
+          colorLiteral = colorNames{iColor};
           return % exact color was predefined
       end
   end
 
   %% check if the color is a linear combination of two already defined colors
-  for iColr = 1:length(colorSpecs)
-      for jColr = iColr+1:length(colorSpecs)
-          Ci = colorSpecs{iColr}(:);
-          Cj = colorSpecs{jColr}(:);
+  for iColor = 1:length(colorSpecs)
+      for jColor = iColor+1:length(colorSpecs)
+          Ci = colorSpecs{iColor}(:);
+          Cj = colorSpecs{jColor}(:);
           
           % solve color mixing equation `Ck = p * Ci + (1-p) * Cj` for p
           p  = (Ci-Cj) \ (rgb(:)-Cj);
@@ -3913,8 +3913,8 @@ function [m2t, colorLiteral] = rgb2colorliteral(m2t, rgb)
           Ck = p * Ci + (1-p)*Cj; % approximated mixed color
           
           if p <= 1 && p >= 0 && max(abs(Ck(:) - rgb(:))) < tolColor    
-              colorLiteral = sprintf('%s!%d!%s', colorNames{iColr}, p*100, ...
-                                                 colorNames{jColr});
+              colorLiteral = sprintf('%s!%d!%s', colorNames{iColor}, p*100, ...
+                                                 colorNames{jColor});
               return % linear combination found
           end
       end


### PR DESCRIPTION
Next to the extraColors feature (as in #268), this branch contains an implementation for color mixtures such as `red!70!green`.
The main implementation was in e8bf7b8, the code may be somewhat terse, but a more elaborate mathematical derivation is present in the commit message.
Some points of attention:
- it is conservative in making a color mix: when it is in doubt (i.e. one R/G/B component deviates too much), it will not make the mixture,
- it depends on the ordering of the colors: if `red` appears before `green` in the defined color list, a combination `green!40!red` will never be made (but `red!60!green` will), this can also affect runtime, as in general, the runtime is O(n^2) with n the number of defined colors. 

The runtime issue is mitigated pragmatically in e2a23b3: `white` and `black` should be the most commonly used, so they have been put at the beginning: resulting in a reduced runtime for those.

In 23960ed, it was made sure that defined colors are preferred over mixtures, otherwise, colors such as `darkgray` (i.e. mixture between black and white) would be dead code. More resulting dead code was removed in 94a4135.
