### PR TITLE
Output arguments

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1,4 +1,4 @@
-function matlab2tikz(varargin)
+function varargout = matlab2tikz(varargin)
 %MATLAB2TIKZ    Save figure in native LaTeX (TikZ/Pgfplots).
 %   MATLAB2TIKZ() saves the current figure as LaTeX file.
 %   MATLAB2TIKZ comes with several options that can be combined at will.
@@ -386,9 +386,12 @@ function matlab2tikz(varargin)
   userInfo(m2t, versionInfo, m2t.website, m2t.name);
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   % Save the figure as pgf to file -- here's where the work happens
-  saveToFile(m2t, fid, fileWasOpen);
+  m2t = saveToFile(m2t, fid, fileWasOpen);
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  if nargout>=1
+      varargout{1} = m2t;
+  end
 end
 % =========================================================================
 % validates the optional argument 'filename' to not be another

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -92,6 +92,10 @@ function varargout = matlab2tikz(varargin)
 %   check for updates of matlab2tikz.
 %   (default: true)
 %
+%   FH = MATLAB2TIKZ('localfunction', CHAR) returns a function handle FH to the
+%   local matlab2tikz function. No other actions will be performed. This is
+%   for development purposes only! (default: '')
+%
 %   Example
 %      x = -pi:pi/10:pi;
 %      y = tan(sin(x)) - sin(tan(x));
@@ -270,6 +274,9 @@ function varargout = matlab2tikz(varargin)
 
   % Automatic updater.
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'checkForUpdates', true, @islogical);
+  
+  % Output local function handle
+  m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'localfunction', '', @ischar);
 
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   % deprecated parameters (will auto-generate warnings upon parse)
@@ -286,6 +293,11 @@ function varargout = matlab2tikz(varargin)
                        'This may produce undesirable string output. For full control over output\n', ...
                        'strings please set the parameter ''parseStrings'' to false.\n', ...
                        '==========================================================================']);
+  end
+  
+  if ~isempty(m2t.cmdOpts.Results.localfunction)
+      varargout{1} = eval(sprintf('@%s',m2t.cmdOpts.Results.localfunction));
+      return % just return the handle to the local function
   end
 
   % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Added output arguments to `matlab2tikz`. This is mainly for development purposes.
Practically, when one output argument is used, the `m2t` object is the output. Together with #285, this allows to read the preamble from `matlab2tikz`.

Next to that, I added functionality to obtain a handle to any local function. Unfortunately, this has to use `eval`, but I think that's the only way. By adding this functionality, we can eventually develop unit tests for each local function. Personally, I mostly use the ACID test as some kind of acceptance test, but ideally unit tests should do the job for many parts of the code.