### PR TITLE
Small bug in scatterplot with dot-marker + scaling changed again

### DIFF
--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -39,6 +39,7 @@ function [desc, extraOpts, extraCFOptions, funcName, numFunctions] = testfunctio
                            @plain_cos           , ...
                            @sine_with_markers   , ...
                            @markerSizes         , ...
+                           @markerSizes2        , ...
                            @sine_with_annotation, ...
                            @linesWithOutliers   , ...
                            @peaks_contour       , ...
@@ -271,6 +272,31 @@ function [description, extraOpts] = markerSizes()
   plot([0],[0],'bo','Markersize',14,'LineWidth',1)
 
   description = 'Marker sizes.';
+  extraOpts = {};
+end
+% =========================================================================
+function [description, extraOpts] = markerSizes2()
+  n = 1:10;
+  d = 10;
+  s = round(linspace(6,25,10));
+  e = d * ones(size(n));
+
+  style = {'bx','rd','go','c.','m+','y*','bs','mv','k^','r<','g>','cp','bh'};
+
+  nStyles = numel(style);
+  figure
+  hold on;
+  grid on;
+  for ii = 1:nStyles
+      for jj = 1:10
+        plot(n(jj), ii * e(jj),style{ii},'MarkerSize',s(jj));
+      end
+  end
+  xlim([min(n)-1 max(n)+1]);
+  ylim([0 d*(nStyles+1)]);
+  set(gca,'XTick',n,'XTickLabel',s,'XTickLabelMode','manual');
+
+  description = 'Line plot with with different marker sizes.';
   extraOpts = {};
 end
 % =========================================================================


### PR DESCRIPTION
Sorry to drag this up again; I see you have changed it to `sData = sqrt(sData/pi)` in the most up to date version. This scaling is incorrect (if it was correct, it would only apply to circular marker types). Did some more tests now, and if you're satisfied with how markers are handled for regular line plots, etc, the best approximation to that is the following;

```
      sData = sqrt(sData);
      [sData, dummy] = translateMarkerSize(m2t, matlabMarker, sData); % must use matlabMarker here to avoid errors in translateMarkerSize as translateMarker changes e.g., 'pentagram' to 'star', which isn't recognized by translateMarkerSize
```

Try yourself with the following code for different types of markers.

```
n = 1:100;
s = 1000*rand(length(n),1);
figure;
P = scatter(n,n,s,n.^8,'x');
box on;
grid on;
matlab2tikz('scatter.tex','standalone',true);
figure;
hold on;
for k = 1:100
    plot(n(k),n(k),'x','MarkerSize',sqrt(s(k)));
end
box on;
grid on;
matlab2tikz('marker_lineplot.tex','standalone',true);
```

You will see that with the present code, there will be a **huge** difference between the two compiled  outputs (pdf of LaTeX document), whereas with the suggested code above they will be almost identical. This applies to all regular marker types. Hence, I find the above code to give a more correct representation of the scatter group plots.

On the other hand, the compiled output with this code will differ slightly more from the reference rending of `matlab2tikz_acidtest(60)` than the present code. I'm not sure what the best solution to that "problem" is, but if it is a problem, then it also applies to the handling of regular markers in line plots as the compiled output of the above code for scatter group plots, and regular line plots with markers are nearly identical. One solution may be to adjust the code in the `translateMarkerSize` function; in that way it will apply to both scatter group plots and regular line plots with markers.

During the tests I also discovered that one needs an additional if-test to handle the case of dot-markers (`markerType='.'`) as they don't have any `faceColor`, yet they are filled with `markerEdgeColor`. 
