### PR TITLE
New test function for marker types and sizes for regular line plots.

### DIFF
--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -276,17 +276,16 @@ function [description, extraOpts] = markerSizes()
 end
 % =========================================================================
 function [description, extraOpts] = markerSizes2()
+  hold on;
+  grid on;
+  
   n = 1:10;
   d = 10;
   s = round(linspace(6,25,10));
   e = d * ones(size(n));
-
   style = {'bx','rd','go','c.','m+','y*','bs','mv','k^','r<','g>','cp','bh'};
-
   nStyles = numel(style);
-  figure
-  hold on;
-  grid on;
+
   for ii = 1:nStyles
       for jj = 1:10
         plot(n(jj), ii * e(jj),style{ii},'MarkerSize',s(jj));


### PR DESCRIPTION
New test that shows the flaws in the present size translation for marker sizes in regular line plots. (NB; I replaced my files with the most up to date code earlier today, so the test is performed with the code as it is in @nschloe 's master brancho per now.)

![acid_page_1](https://f.cloud.github.com/assets/380049/2346464/30136576-a542-11e3-9018-7f5ec88a057d.png)
