### PR TITLE
Explicitly cast mixing percentage to an int

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3955,7 +3955,7 @@ function [m2t, colorLiteral] = rgb2colorliteral(m2t, rgb)
             Ck = p * Ci + (1-p)*Cj; % approximated mixed color
 
             if p <= 1 && p >= 0 && max(abs(Ck(:) - rgb(:))) < m2t.colorPrecision
-                colorLiteral = sprintf('%s!%d!%s', colorNames{iColor}, p*100, ...
+                colorLiteral = sprintf('%s!%d!%s', colorNames{iColor}, uint8(p*100), ...
                     colorNames{jColor});
                 return % linear combination found
             end


### PR DESCRIPTION
There is a very occasional bug in which matlab seems to ignore int format specifiers and print in exponential notation instead (i.e. printing `red!5.500000e+01!mycolor1` instead of `red!55!mycolor1`). This breaks xcolor, which doesn't parse this notation. Since p*100 is a percentage in the range [0,100], it is safe to cast this to an int and guarantee that matlab will correctly output the mixed colour.
