### PR TITLE
[Fix] fixes #342: creating patches with literal color errors

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1693,6 +1693,12 @@ function [m2t, str] = drawPatch(m2t, handle)
 
     numPatches = size(XData, 2);
 
+    % Ensure that if we have multiple patches and only FaceColor is
+    % specified, that it doesn't error when creating each patch with cData = CData(:, k);;
+    if isempty(CData)
+        CData = zeros(1,numPatches);
+    end
+    
     for k = 1:numPatches
         xData = XData(:, k);
         yData = YData(:, k);


### PR DESCRIPTION
Fixes issue #342

Minimal example:

```
x = [2 3; 2 3; 5 7;5 7];
y = [1 10; 2 11; 2 11; 1 10];
patch(x,y,'red')
matlab2tikz('patchMultipleLiteralColor.tex','standalone',true)
```
