### PR TITLE
[Fixes #294,#333] patch: index unique cdata into colormap and retrieve color

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1730,7 +1730,7 @@ function [m2t, str] = drawPatch(m2t, handle)
 
         % Add the proper color map even if the map data isn't directly used in
         % the plot to make sure that we get correct color bars.
-        if length(cData) == length(xData)
+        if ~all(cData == cData(1)) && length(cData) == length(xData)
             % Add the color map.
             m2t.axesContainers{end}.options = ...
                 addToOptions(m2t.axesContainers{end}.options, ...
@@ -1739,7 +1739,7 @@ function [m2t, str] = drawPatch(m2t, handle)
         % If full color data is provided, we can use point meta color data.
         % For some reason, this only works for filled contours in Pgfplots, so
         % fall back to explicit color specifications for line plots.
-        if length(cData) == length(xData) ...
+        if ~all(cData == cData(1)) && length(cData) == length(xData) ...
                 && ~isNone(get(handle, 'FaceColor'))
             data = [data, cData(:)];
             drawOptions{end+1} = 'patch';
@@ -1757,6 +1757,14 @@ function [m2t, str] = drawPatch(m2t, handle)
             % Find out color values.
             % fill color
             faceColor = get(handle, 'FaceColor');
+            
+            % If it still has 'interp', then the CData for the patch is
+            % just an index into the colormap. Convert to RGB
+            if strcmpi(faceColor,'interp')
+                    [m2t, index] = cdata2colorindex(m2t, cData(1),handle);
+                    faceColor    = m2t.currentHandles.colormap(index,:);
+            end
+            
             if ~isNone(faceColor)
                 [m2t, xFaceColor] = getColor(m2t, handle, faceColor, 'patch');
                 drawOptions{end+1} = sprintf('fill=%s', xFaceColor);


### PR DESCRIPTION
I am picking the RGB color from the colormap if the `cData` for the patch doesn't change. This solves through the fill option the problem with triangular patches. 

**Note**: creating the colormap and leaving `'point meta=\thisrow{c}'` in the table doesn't index correctly into the colormap because we need to convert `cdata2colorindex` (and extract the colours?). I just decided to go with the `fill=...` option using the existing API.

I test with if it has unique `cData` with:

```
 ~all(cData == cData(1)) && length(cData) == length(xData) 
```

where the initial logical operation is equal to `numel(unique(cData)) ~= 1` but I am avoiding `unique()` for performance considerations.

Later, I am converting the `faceColor = 'interp'` (when CData is not empty) to an RGB color. 

Potential issues: 
- Haven't checked the ACID tests, but shouldn't break anything
- Using the fill option avoids creating triangular patches but doesn't close the borders as in 
  
  ```
  patch([2 2 5 5],[1 2 2 1],'red')
  axis([0,6,0,6])
  matlab2tikz('patchNonClosedBorder.tex','standalone',true)
  ```
  
  the proper (?) way to go would be to create a `patch type=rectangle`?
