### PR TITLE
[Fixes #322, #330] scatter: 'mark size=' if one size for all markers

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2471,21 +2471,23 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     [tikzMarker, markOptions] = translateMarker(m2t, matlabMarker, ...
         markOptions, hasFaceColor);
 
-    if length(sData) == 1
-        constMarkerkSize = true; % constant marker size
-    else % changing marker size; rescale the size data according to the marker
-        constMarkerkSize = false;
-        % MathWorks says
-        % <http://www.mathworks.se/help/matlab/ref/scattergroupproperties.html>:
-        % SizeData
-        % Size of markers in square points. Area of the marker in the scatter
-        % graph in units of points. Since there are 72 points to one inch, to
-        % specify a marker that has an area of one square inch you would use a
-        % value of 72^2.
-        %
-        % Pgfplots on the other hand uses the radius.
-        sData = sqrt(sData / pi);
-    end
+    % Re-scale marker size
+    % MathWorks says:
+    % <http://www.mathworks.se/help/matlab/ref/scattergroupproperties.html>:
+    % SizeData
+    % Size of markers in square points. Area of the marker in the scatter
+    % graph in units of points. Since there are 72 points to one inch, to
+    % specify a marker that has an area of one square inch you would use a
+    % value of 72^2.
+    % 
+    % <http://www.mathworks.com/matlabcentral/answers/101738> clarifies:
+    % The SCATTER function expects its 'S' parameter to contain the marker 
+    % area in points squared. This area corresponds to the area of a square 
+    % bounding box around the marker.
+    %
+    % Pgfplots on the other hand uses the radius.
+    sData = translateMarkerSize(m2t, matlabMarker, sqrt(sData)/1.5);
+%     sData = sqrt(sData)/2;
 
     if length(cData) == 3
         % No special treatment for the colors or markers are needed.
@@ -2500,10 +2502,11 @@ function [m2t, str] = drawScatterPlot(m2t, h)
         else
             [m2t, ecolor] = getColor(m2t, h, cData, 'patch');
         end
-        if constMarkerkSize % if constant marker size, do nothing special
+        if numel(sData) == 1 % do nothing special
             drawOptions = { 'only marks', ...
                 ['mark=' tikzMarker], ...
-                ['mark options={', join(m2t, markOptions, ','), '}'] };
+                ['mark options={', join(m2t, markOptions, ','), '}'],...
+                sprintf('mark size=%.4fpt', sData)};
             if hasFaceColor && hasEdgeColor
                 drawOptions{end+1} = { ['draw=' ecolor], ...
                     ['fill=' xcolor] };
@@ -2583,7 +2586,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
             data = applyHgTransform(m2t, [xData(:),yData(:),zData(:),sData(:)]);
         end
     end
-    if ~constMarkerkSize %
+    if numel(sData) > 1 
         drawOptions{end+1} = { ['visualization depends on={\thisrowno{', num2str(sColumn), '} \as \perpointmarksize}'], ...
             'scatter/@pre marker code/.append style={/tikz/mark size=\perpointmarksize}' };
     end

--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -1415,7 +1415,7 @@ function [description, extraOpts] = scatterPlotMarkers()
   ylim([0 d*(nStyles+1)]);
   set(gca,'XTick',n,'XTickLabel',s,'XTickLabelMode','manual');
 
-  legend(names{:});
+%   legend(names{:});
 
   description = 'Scatter plot with with different marker sizes and legend.';
   extraOpts = {};


### PR DESCRIPTION
I am always specifying `mark size=` if the size is unique for all scatter points. This means that the rescaling is always performed. 

However, it seems #316 is open again, since I cannot reproduce with the acid tests the graphs that @nidrosianDeath shows in one of the last [comments](https://github.com/nschloe/matlab2tikz/pull/316#issuecomment-35383893) and (the previous one).
