### PR TITLE
Alt pos

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3779,22 +3779,19 @@ function [m2t, key, lOpts] = getLegendOpts(m2t, handle)
             position = [-dist, 0];
             anchor = 'south east';
         case 'none'
-            % TODO handle position with pixels
             legendPos = get(handle, 'Position');
             unit = get(handle, 'Units');
-            switch unit
-                case 'normalized'
-                    position = legendPos(1:2);
-                case 'pixels'
-                    % Calculate where the legend is located w.r.t. the axes.
-                    axesPos = get(m2t.currentHandles.gca, 'Position');
-                    % By default, the axes position is given w.r.t. to the figure,
-                    % and so is the legend.
-                    position = (legendPos(1:2)-axesPos(1:2)) ./ axesPos(3:4);
-                otherwise
-                    position = pos(1:2);
-                    userWarning(m2t, [' Unknown legend length unit ''', unit, '''' ...
-                        '. Handling like ''normalized''.']);
+            if isequal(unit, 'normalized')
+                position = legendPos(1:2);
+            else
+                % Calculate where the legend is located w.r.t. the axes.
+                axesPos = get(m2t.currentHandles.gca, 'Position');
+                axesUnit = get(m2t.currentHandles.gca, 'Units');
+                % Convert to legend unit
+                axesPos = convertUnits(axesPos, axesUnit, unit);
+                % By default, the axes position is given w.r.t. to the figure,
+                % and so is the legend.
+                position = (legendPos(1:2)-axesPos(1:2)) ./ axesPos(3:4);
             end
             anchor = 'south west';
         case {'best','bestoutside'}


### PR DESCRIPTION
As mentioned before, here is an alternative way for aligning axes. This fixes the wrong positions of the annotations - at least on my computer. It also uses \figurewidth (or what other value was given as a parameter) for the size of the whole figure. The previous system assigned this to the size of a subplot.

This alternative alignment basically uses the property 'Position' of the axes to compute an axis position relative to the figure. Doing so allows to place the axis at the same position in the tikz picture without the need to align it before with other axes.
Since the property 'Position' never covers the whole figure, the resulting plots were too small. The alternative use of 'OuterPosition' caused intersecting axes, so I introduced the use of a Bounding Box around all axes in 1d26533 to rescale the size.

I know that this code might interfere with the work on 2014b (which I unfortunately can not test, yet) and, thus, might not be useful for further versions. But it works fine with my 2012b version, so I think you might as well have a look.
I do not know how easily you can run this on a version < 2014b, so here is the result of the acid test on my machine: https://www.dropbox.com/s/krqq3kyp5b5yxa2/acid_0cd3d1b.pdf?dl=0

I hope this code does not interfere too much with you current work on 2014b,
    Klaus
