### PR TITLE
A new test figure with unaligned subplots and some annotations.

### DIFF
--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -143,7 +143,8 @@ function [desc, extraOpts, extraCFOptions, funcName, numFunctions] = testfunctio
                            @surfMeshInterp      , ...
                            @surfMeshRGB         , ...
                            @annotation1         , ...
-                           @annotation2
+                           @annotation2         , ...
+                           @annotation3
                          };
 
 
@@ -2461,6 +2462,52 @@ annotation(gcf,'textbox',...
     'LineStyle','none');
 
 description = 'Annotation over plot';
+extraOpts = {};
+end
+function [description, extraOpts] = annotation3()
+X1 = 0:0.01:1;
+Y1 = X1.^2;
+Y2 = Y1.^2;
+Y3 = X1.^(1/4);
+
+figure1 = figure('Position', [100 100 1500 600]);
+
+axes1 = axes('Parent',figure1,...
+    'Position',[0.0700053850296176 0.401537112724727 0.248788368336026 0.514600139082057]);
+box(axes1,'on');
+hold(axes1,'all');
+
+title('f(x)=x^2');
+
+plot(X1,Y1,'Parent',axes1,'DisplayName','(0:0.05:1).^2 vs 0:0.05:1');
+
+axes2 = axes('Parent',figure1,...
+    'OuterPosition',[0.406159779040075 0 0.276547327461914 0.631411213597616]);
+box(axes2,'on');
+hold(axes2,'all');
+
+plot(X1,Y2,'Parent',axes2,'DisplayName','(0:0.05:1).^4 vs 0:0.05:1');
+
+axes3 = axes('Parent',figure1,...
+    'Position',[0.742057081313947 0.318497913769124 0.210016155088853 0.54798331015299]);
+box(axes3,'on');
+hold(axes3,'all');
+
+plot(X1,Y3,'Parent',axes3,'DisplayName','(0:0.05:1).^(1/4) vs 0:0.05:1');
+
+annotation(figure1,'textbox',...
+    [0.366720516962843 0.552155771905424 0.0123855681206247 0.0393337969401941],...
+    'String',{'f^2'},...
+    'FitBoxToText','off');
+
+annotation(figure1,'arrow',[0.326332794830372 0.4281098546042],...
+    [0.660639777468707 0.351877607788595]);
+
+annotation(figure1,'textarrow',[0.676587301587302 0.722883597883598],...
+    [0.310751104565538 0.633284241531664],'TextEdgeColor','none',...
+    'HorizontalAlignment','center',...
+    'String',{'invert'});
+description = 'Annotated and unaligned subplots';
 extraOpts = {};
 end
 % =========================================================================


### PR DESCRIPTION
After writing the alternative positioning method, I came up with a test figure that strongly demonstrates the gain of this new method. It is not a nice images, just something clicked together that contains totally unaligned axes.

At my system, the reference rendering image in the acid test has the wrong ration between width and height (compared to the actual figure from testfunctions(110)). The reason might be, that figure height and width are set manually. Shall I change the test in order to create an easier acid testing?
