### PR TITLE
Deal with some todos

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3779,22 +3779,19 @@ function [m2t, key, lOpts] = getLegendOpts(m2t, handle)
             position = [-dist, 0];
             anchor = 'south east';
         case 'none'
-            % TODO handle position with pixels
             legendPos = get(handle, 'Position');
             unit = get(handle, 'Units');
-            switch unit
-                case 'normalized'
-                    position = legendPos(1:2);
-                case 'pixels'
-                    % Calculate where the legend is located w.r.t. the axes.
-                    axesPos = get(m2t.currentHandles.gca, 'Position');
-                    % By default, the axes position is given w.r.t. to the figure,
-                    % and so is the legend.
-                    position = (legendPos(1:2)-axesPos(1:2)) ./ axesPos(3:4);
-                otherwise
-                    position = pos(1:2);
-                    userWarning(m2t, [' Unknown legend length unit ''', unit, '''' ...
-                        '. Handling like ''normalized''.']);
+            if isequal(unit, 'normalized')
+                position = legendPos(1:2);
+            else
+                % Calculate where the legend is located w.r.t. the axes.
+                axesPos = get(m2t.currentHandles.gca, 'Position');
+                axesUnit = get(m2t.currentHandles.gca, 'Units');
+                % Convert to legend unit
+                axesPos = convertUnits(axesPos, axesUnit, unit);
+                % By default, the axes position is given w.r.t. to the figure,
+                % and so is the legend.
+                position = (legendPos(1:2)-axesPos(1:2)) ./ axesPos(3:4);
             end
             anchor = 'south west';
         case {'best','bestoutside'}


### PR DESCRIPTION
So here is a small fix for the two TODOs. I use a lightweight convertUnits function for that. There is another piece of code that had a TODO which was going in the same direction. So I also work on that one.

@egeerardyn: I was considering to use a handle to the source object. This would also allow to deal with normalized units. But note, that normalized units can have a different conversion factor for x and y direction. This could be solved by using as vector srcValue with two elements, x and y. Still, for the moment I just wrote a lightweight function. If more functionality is needed, we can extend convertUnits() for that.

@okomarov: I did not store the converted / original units, yet. I think at the moment, the source is coming from a get(..., 'Position'), and is converted towards something else. I do not see any forward - backward conversion that might gain from such storage.

At the end: I just started to use git / github (before I only used svn) and still try to establish a good workflow. So I'm not sure what is the best praxis when changing something in a pull request, that is still in discussion. I now created a new branch upon it and did the quick change in it.
