### PR TITLE
[Fix #330, #322] scatter: single scatter non default size

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2489,23 +2489,13 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     markOptions = cell(0);
     [tikzMarker, markOptions] = translateMarker(m2t, matlabMarker, ...
         markOptions, hasFaceColor);
-
-    if length(sData) == 1
-        constMarkerkSize = true; % constant marker size
-    else % changing marker size; rescale the size data according to the marker
-        constMarkerkSize = false;
-        % MathWorks says
-        % <http://www.mathworks.se/help/matlab/ref/scattergroupproperties.html>:
-        % SizeData
-        % Size of markers in square points. Area of the marker in the scatter
-        % graph in units of points. Since there are 72 points to one inch, to
-        % specify a marker that has an area of one square inch you would use a
-        % value of 72^2.
-        %
-        % Pgfplots on the other hand uses the radius.
-        sData = sqrt(sData / pi);
-    end
-
+    
+    constMarkerkSize = length(sData) == 1; % constant marker size
+    
+    % Rescale marker size (not definitive, follow discussion on:
+    % https://github.com/nschloe/matlab2tikz/pull/316)
+    sData = translateMarkerSize(m2t, matlabMarker, sqrt(sData)/2);
+    
     if length(cData) == 3
         % No special treatment for the colors or markers are needed.
         % All markers have the same color.
@@ -2519,10 +2509,11 @@ function [m2t, str] = drawScatterPlot(m2t, h)
         else
             [m2t, ecolor] = getColor(m2t, h, cData, 'patch');
         end
-        if constMarkerkSize % if constant marker size, do nothing special
+        if constMarkerkSize 
             drawOptions = { 'only marks', ...
                 ['mark=' tikzMarker], ...
-                ['mark options={', join(m2t, markOptions, ','), '}'] };
+                ['mark options={', join(m2t, markOptions, ','), '}'],...
+                sprintf('mark size=%.4fpt', sData)};
             if hasFaceColor && hasEdgeColor
                 drawOptions{end+1} = { ['draw=' ecolor], ...
                     ['fill=' xcolor] };

--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -1244,7 +1244,6 @@ function [stat] = scatterPlotMarkers()
   ylim([0 d*(nStyles+1)]);
   set(gca,'XTick',n,'XTickLabel',s,'XTickLabelMode','manual');
 
-  legend(names{:});
 end
 % =========================================================================
 function [stat] = scatter3Plot()


### PR DESCRIPTION
Similar to my previous pull request, just re-did the pull properly (?).

Note, the issues arised in the previous code if there was a single point. In that case it was never re-scaled even if the user set a specific size. Here, I just resize every time that one size is specifie, even if default (to be sure, also cleaner code).

The fix produces:

![fix330](https://cloud.githubusercontent.com/assets/3731173/4774740/3cfb1c0a-5bb0-11e4-83b0-32dd6a3a3234.PNG)

compare with
![unfixed](https://cloud.githubusercontent.com/assets/7280989/2689758/fa4b5104-c31b-11e3-8727-61dad81305fe.png)

Aslo, I re-introduced partly the changes by @nidrosianDeath. Somehow his work got lost, but even I cannot reproduce teh result in his [comment](ttps://github.com/nschloe/matlab2tikz/pull/316#issuecomment-35383893), using 

```
sData = translateMarkerSize(m2t, matlabMarker, sqrt(sData)/2);
```

already improves the situation.

Follow a bunch of tests that show how it improves *line marker size unaffected):

![linemarkersize](https://cloud.githubusercontent.com/assets/3731173/4774759/70e5b67e-5bb0-11e4-8af5-491e85d5a48f.PNG)
![test62-scatter](https://cloud.githubusercontent.com/assets/3731173/4774763/79299288-5bb0-11e4-8ea0-545c7349d6b9.PNG)
![scattermarkersize](https://cloud.githubusercontent.com/assets/3731173/4774764/7b9910ac-5bb0-11e4-8cc6-7a6e963b2601.PNG)

scatter Marker Sizes improved as per the discussion in #316
