### PR TITLE
Two new testfunctions for testing textual annotations

### DIFF
--- a/test/testfunctions.m
+++ b/test/testfunctions.m
@@ -2243,7 +2243,7 @@ Y1 = log(X1.^2+1);
 set(gcf,'Position', [100 100 1000 700]);
 
 % Otherwise the axes is plotted wrongly
-pause(0.1);
+drawnow();
 
 % Create axes
 axes1 = axes('Parent',gcf);
@@ -2321,7 +2321,7 @@ set(gcf,'Units', 'inches');
 set(gcf,'Position', [1.03125, 1.03125, 10.416666666666666, 7.291666666666666 ]);
 
 % Otherwise the axes is plotted wrongly
-pause(0.1);
+drawnow();
 
 % Create axes
 axes1 = axes('Parent',gcf,'Units','centimeters',...


### PR DESCRIPTION
Here I add two new test figures.

annotationText is a collection of text annotations with different properties. This demonstrates some problems with the current annotations.
annotationTextUnits should be the same figure (on my system it is, but maybe someone can have a look at it on another system and with a newer Matlab version than my old 2012b). The only difference is, that I changed the "units" property, stressing the positioning capability of m2t. And I have to say that it goes very wrong (the tex code compiles with lots of errors). 
I use both figures for my current branch for annotations, but since the latter one breaks the smooth compiling of acid.tex, we might include it later into the master branch.

Some more things to mention:
1. I had to change the size of the figure to include several different text elements. This only works with the included `pause(0.1)`; command. I feel not happy with this line, but did not find a better solution.
2. The exported pdf figure also has some differences to the original plots. 
3. Matlab reacted a bit weird with the text arrows. By changing the angle of the arrow (and keeping all other properties), the text is differently connected to the arrow. Is this a bug of my old R2012b?
