### PR TITLE
Support for multiple line text

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2279,8 +2279,7 @@ function [m2t, str] = drawText(m2t, handle)
     String = get(handle, 'String');
     Interpreter = get(handle, 'Interpreter');
     String = prettyPrint(m2t, String, Interpreter);
-    % For now, don't handle multiline strings.
-    % Sometimes, the cells are nested; take care of this, too.
+    % Concatenate multiple lines
     String = join(m2t, String, '\\');
     VerticalAlignment = get(handle, 'VerticalAlignment');
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This is a short one:
Using `join` to combine multiple lines. According to the tikz documentation, `\\` only works when nodes have the `align` attribute set. So this is the second change here.

**BUT** there is a downside: this pull request breaks the compiling of figure 75 of the acid test. The problem is, that figure 75 contains text with multiple lines that has a different font in the last line. LaTeX complains about this font.

While m2t without support for multiple lines just ignores these lines, this pull request now includes the lines into the tikz output ... and by doing so breaks it. 
Maybe this is just a problem of my LaTeX installation (I'm always a bit careful to generalize results tested on just one system), so can someone else try figure 75 with this pull request?
