### PR TITLE
Fix #415 acid octave

### DIFF
--- a/test/ACID.m
+++ b/test/ACID.m
@@ -647,11 +647,11 @@ end
 function [stat] = groupbars()
   stat.description = 'Plot with bars in groups.';
 
-  rng('default'); % initialize random numbers to default state
-  
   X = [1,2,3,4,5];
   Y = round(rand(5,2)*20);
-  bar(X,Y,'group','BarWidth',1.0);
+  %    bar(X,Y,'group','BarWidth',1.0);
+  makebars(X,Y,1.0,'grouped');
+  %    set(gca,'XTick',[4,4.2,4.25,4.3,4.4,4.45,4.5]);
   title 'Group';
 end
 % =========================================================================


### PR DESCRIPTION
Now ACID tests 1 and 2 work. Number 3 makes ghostscript hang (running windows 7) during creation of reference output, the m2t output looks fine. This makes it hard to run the whole testsuite.
