### PR TITLE
fix #401 mandrillaImage being reversed

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1845,12 +1845,9 @@ function [m2t, str] = drawImage(m2t, handle)
     m = size(cData, 1);
     n = size(cData, 2);
 
-    if ~strcmp(get(m2t.currentHandles.gca,'Visible'), 'off')
-        % Flip the image over as the PNG gets written starting at (0,0) that is,
-        % the top left corner.
-        % MATLAB quirk: In case the axes are invisible, don't do this.
-        cData = cData(m:-1:1,:,:);
-    end
+    % Flip the image over as the PNG gets written starting at (0,0),
+    % which is the top left corner.
+    cData = cData(m:-1:1,:,:);
 
     if (m2t.cmdOpts.Results.imagesAsPng)
         m2t.imageAsPngNo = m2t.imageAsPngNo + 1;

--- a/test/ACID.m
+++ b/test/ACID.m
@@ -1068,11 +1068,10 @@ function [stat] = mandrillImage()
   end
 
   data = load( 'mandrill' );
-  set( gcf, 'color', 'k' )
-  image( data.X )
-  colormap( data.map )
-  axis off
-  axis image
+  image( data.X )       % show image
+  colormap( data.map )  % adapt colormap
+  axis image            % pixels should be square
+  axis off              % disable axis
 end
 % =========================================================================
 function [stat] = besselImage()


### PR DESCRIPTION
Reversing the image if axis is invisible is not needed.
Manual test with R2011b and R2014b by commenting out `axis off` in test case.
Removed black background to allow visual control, if axis is really of.
