### PR TITLE
[ACID]Fix testcase 114 imageOrientation_inline

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3588,7 +3588,7 @@ function [m2t, xcolor] = getColor(m2t, handle, color, mode)
 % check if the color is straight given in rgb
 % -- notice that we need the extra NaN test with respect to the QUIRK
 %    below
-    if isreal(color) && length(color)==3 && ~any(isnan(color))
+    if isreal(color) && numel(color)==3 && ~any(isnan(color))
         % everything alright: rgb color here
         [m2t, xcolor] = rgb2colorliteral(m2t, color);
     else


### PR DESCRIPTION
Inlining images in TikZ code is fixed by replacing `length` with `numel`. The error is caused by creating an image with `image(magic(3))`, since then `cData` has the dimensions `3x3`.

The change below tries to identify a RGB triplet. Thus `numel` should be used to check the size of `cData`.

R2014b:
![acid_imageorientation_r2014b_inline](https://cloud.githubusercontent.com/assets/4340267/4918834/e4a0a0f4-64f4-11e4-964e-d137ca7d56f2.png)
