### PR TITLE
Improve code style of inline image code

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1977,11 +1977,14 @@ function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
     % Still, a bug has been filed on MathWorks to allow for one-line
     % sprintf'ing with (string+num) cells (Request ID: 1-9WHK4W);
     % <http://www.mathworks.de/support/service_requests/Service_Request_Detail.do?ID=183481&filter=&sort=&statusorder=0&dateorder=0>.
+    % An alternative approach could be to use 'surf' or 'patch' of pgfplots
+    % with inline tables.
+
     for i = 1:m
         for j = 1:n
-            str = strcat(str, ...
-                sprintf(['\\fill [%s] (axis cs:', m2t.ff,',', m2t.ff,') rectangle (axis cs:',m2t.ff,',',m2t.ff,');\n'], ...
-                xcolor{m-i+1,j}, Y(j)-hY/2,  X(i)-hX/2, Y(j)+hY/2, X(i)+hX/2 ));
+            str = [str, ...
+                sprintf(['\t\\fill [%s] (axis cs:', m2t.ff,',', m2t.ff,') rectangle (axis cs:',m2t.ff,',',m2t.ff,');\n'], ...
+                xcolor{m-i+1,j}, Y(j)-hY/2,  X(i)-hX/2, Y(j)+hY/2, X(i)+hX/2 )];
         end
     end
 end


### PR DESCRIPTION
Please forgive the removal of the line ending ^M below.
I tried for at least half an hour to convince git to ignore this.

Test this by running
`close all; matlab2tikz_acidtest('testsuite', @ACID, 'testFunctionIndices', [114], 'figureVisible', true);`
and inspecting `test114-converted.tex`.

Before:

```
...
\fill [mycolor7] (axis cs:0.5,0.5) rectangle (axis cs:1.5,1.5);\fill [mycolor8] (axis cs:1.5,0.5) rectangle (axis cs:2.5,1.5);\fill [mycolor9] (axis cs:2.5,0.5) rectangle (axis cs:3.5,1.5);\fill [mycolor4] (axis cs:0.5,1.5) rectangle (axis cs:1.5,2.5);\fill [mycolor5] (axis cs:1.5,1.5) rectangle (axis cs:2.5,2.5);\fill [mycolor6] (axis cs:2.5,1.5) rectangle (axis cs:3.5,2.5);\fill [mycolor1] (axis cs:0.5,2.5) rectangle (axis cs:1.5,3.5);\fill [mycolor2] (axis cs:1.5,2.5) rectangle (axis cs:2.5,3.5);\fill [mycolor3] (axis cs:2.5,2.5) rectangle (axis cs:3.5,3.5);\end{axis}
...
```

Now:

```
...
    \fill [mycolor7] (axis cs:0.5,0.5) rectangle (axis cs:1.5,1.5);
    \fill [mycolor8] (axis cs:1.5,0.5) rectangle (axis cs:2.5,1.5);
    \fill [mycolor9] (axis cs:2.5,0.5) rectangle (axis cs:3.5,1.5);
    \fill [mycolor4] (axis cs:0.5,1.5) rectangle (axis cs:1.5,2.5);
    \fill [mycolor5] (axis cs:1.5,1.5) rectangle (axis cs:2.5,2.5);
    \fill [mycolor6] (axis cs:2.5,1.5) rectangle (axis cs:3.5,2.5);
    \fill [mycolor1] (axis cs:0.5,2.5) rectangle (axis cs:1.5,3.5);
    \fill [mycolor2] (axis cs:1.5,2.5) rectangle (axis cs:2.5,3.5);
    \fill [mycolor3] (axis cs:2.5,2.5) rectangle (axis cs:3.5,3.5);
...
```

It might be possible to create better output by using the capabilities `surf` or `patch` of pgfplots (not handled by this pull request).
