### PR TITLE
Legend entries, label positions

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -899,7 +899,7 @@ function m2t = drawAxes(m2t, handle)
         elseif strcmp(xloc, 'top')
             m2t.axesContainers{end}.options = ...
                 opts_add(m2t.axesContainers{end}.options, ...
-                'axis x line*', 'top');
+                'axis x line', 'top');
         else
             error('matlab2tikz:drawAxes', ...
                 'Illegal axis location ''%s''.', xloc);
@@ -916,7 +916,7 @@ function m2t = drawAxes(m2t, handle)
         elseif strcmp(yloc, 'right')
             m2t.axesContainers{end}.options = ...
                 opts_add(m2t.axesContainers{end}.options, ...
-                'axis y line*', 'right');
+                'axis y line', 'right');
         else
             error('matlab2tikz:drawAxes', ...
                 'Illegal axis location ''%s''.', yloc);
@@ -924,7 +924,7 @@ function m2t = drawAxes(m2t, handle)
     else % box off
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, ...
-            'axis y line*', yloc);
+            'axis y line', yloc);
     end
     if m2t.currentAxesContain3dData
         % There's no such attribute as 'ZAxisLocation'.


### PR DESCRIPTION
- Legends: If there is an empty legend string, legends/plots became assigned incorrectlly. The decisions to "forget the plot" in drawLine / draw\* and to add a legend entry in src/matlab2tikz.m:712 were not coherent.
- Axis label: Axis ticks and labels should be at the same position (left/right, top/bottom). Only the axis position was set as in Matlab, but the label was not. A simple plot with two y axes created the two labels at the left, on top of each other:
  `x=0:0.1:2*pi; [AX] = plotyy(x, sin(x), x, cos(x)); set(get(AX(1),'Ylabel'),'String','sin'); set(get(AX(2),'Ylabel'),'String','cos');`
