### PR TITLE
Fixing bounding box problem

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4654,8 +4654,8 @@ function [relevantAxesHandles, axesBoundingBox] = getRelevantAxes(m2t, axesHandl
         % Compute width and height of the bounding box
         axesBoundingBox(:,[3 4]) = axesBoundingBox(:,[3 4]) - axesBoundingBox(:,[1 2]);
     else
-        % Otherwise take the whole figure as bounding box => lengths are nor
-        % changed in tikz
+        % Otherwise take the whole figure as bounding box => lengths are
+        % not changed in tikz
         axesBoundingBox = [0, 0, 1, 1];
     end
 end


### PR DESCRIPTION
This PR addresses the problem, that it is not possible to plan the size of figures in Matlab.
Now the bounding box is only used if at least one size is specified as parameter for m2t. In that case, sizes of matlab are changed anyway when exporting to tikz.

@okomarov : I tried your example and it worked well to preserve the axis size, but maybe you also want to have a look.
