### PR TITLE
Annotation: Rectangles

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2100,6 +2100,10 @@ function [m2t, str] = drawHggroup(m2t, h)
         case 'scribe.textarrow'
             % Annotation: text arrow
             [m2t, str] = drawTextarrow(m2t, h);
+
+        case 'scribe.scriberect'
+            % Annotation: rectangle
+            [m2t, str] = drawRectangle(m2t, h);
             
         case 'unknown'
             % Weird spurious class from Octave.


### PR DESCRIPTION
Adding the missing annotation: rectangles.

A test case for the acid test will follow soon to replace some of the old annotation figures. For the moment try

```
figure1 = figure;
axes1 = axes('Parent',figure1);
annotation(figure1,'rectangle',...
      [0.358142857142857 0.757142857142858 0.0829285714285714 0.097619047619051],...
      'FaceColor',[0 0.498039215686275 0]);
```

to see the gain of this PR
