### PR TITLE
fix issue in findLegendInformation with `addaxes`

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -694,23 +694,25 @@ switch m2t.env
                 else
                     plotChildren = getOrDefault(legendHandle, 'PlotChildren', []);
                 end
-                k = find(child == plotChildren);
-                if isempty(k)
-                    % Lines of error bar plots are not referenced
-                    % directly in legends as an error bars plot contains
-                    % two "lines": the data and the deviations. Here, the
-                    % legends refer to the specgraph.errorbarseries
-                    % handle which is 'Parent' to the line handle.
-                    k = find(get(child,'Parent') == plotChildren);
-                end
-                if ~isempty(k)
-                    % Legend entry found. Add it to the plot.
-                    hasLegend = true;
-                    interpreter = get(legendHandle, 'Interpreter');
-                    if ~isempty(ud) && isfield(ud,'strings')
-                        legendString = ud.lstrings(k);
-                    else
-                        legendString = get(child, 'DisplayName');
+                if ~isempty(child)
+                    k = find(child == plotChildren);
+                    if isempty(k)
+                        % Lines of error bar plots are not referenced
+                        % directly in legends as an error bars plot contains
+                        % two "lines": the data and the deviations. Here, the
+                        % legends refer to the specgraph.errorbarseries
+                        % handle which is 'Parent' to the line handle.
+                        k = find(get(child,'Parent') == plotChildren);
+                    end
+                    if ~isempty(k)
+                        % Legend entry found. Add it to the plot.
+                        hasLegend = true;
+                        interpreter = get(legendHandle, 'Interpreter');
+                        if ~isempty(ud) && isfield(ud,'strings')
+                            legendString = ud.lstrings(k);
+                        else
+                            legendString = get(child, 'DisplayName');
+                        end
                     end
                 end
             end


### PR DESCRIPTION
consider this example:

```
data = magic(3); 
h(1) = plot(data(1,:),'r-'); hold on; 
h(2) = plot(data(2,:),'k--'); 
legend('plot1','plot2');  

% add additional x-axis with nonlinear scaling 
xFun = @(x) x.^2; 
addaxes('XFun',xFun);
```

m2t has an issue in function `findLegendInformation` when adding an additional x-axis with nonlinear scaling using the FileExchange contribution `addaxes` (http://www.mathworks.com/matlabcentral/fileexchange/24875-addaxes-m-v1-1--sep-2009-). Note: A legend needs to be present.

For some reason `child` might be empty. This would cause an error during the comparison with `plotChildren`. The issue is circumvented by checking for empty children.
--> `if ~isempty(child)` with accompanying `end` is the only change.

R2014b:
![image](https://cloud.githubusercontent.com/assets/4340267/5182180/c359a9ae-749e-11e4-8965-6fe8ca010ef5.png)
