### PR TITLE
Scaling of cdata at the axis level

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -826,7 +826,7 @@ function m2t = drawAxes(m2t, handle)
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Add color scaling
     CLimMode = get(handle,'CLimMode');
-    if strcmpi(CLimMode,'manual')
+    if strcmpi(CLimMode,'manual') || ~isempty(m2t.cbarHandles)
         clim = caxis(handle);
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, 'point meta min', sprintf(m2t.ff, clim(1)));


### PR DESCRIPTION
Basically, use `point meta min/max` at the axis level, following the comment:

```
% TODO Use caxis not only for color bars.
```

And https://github.com/matlab2tikz/matlab2tikz/pull/386#issuecomment-64223356 in `rewritePatch`.
