### PR TITLE
fix handling of colorbars in R2014b

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4687,14 +4687,15 @@ end
 % ==============================================================================
 function [relevantAxesHandles, axesBoundingBox] = getRelevantAxes(m2t, axesHandles)
 % Returns relevant axes. These are defines as visible axes that are no
-% colorbars. In addition, a bounding box around all relevant Axes is
+% colorbars. Function 'findPlotAxes()' ensures that 'axesHandles' does not
+% contain colorbars. In addition, a bounding box around all relevant Axes is
 % computed. This can be used to avoid undesired borders.
 % This function is the remaining code of alignSubPlots() in the alternative
 % positioning system.
     relevantAxesHandles = [];
     for axesHandle = axesHandles(:)'
-        % Only handle visible non-colorbar handles.
-        if axisIsVisible(axesHandle) && ~strcmp(get(axesHandle,'Tag'), 'Colorbar')
+        % Only handle visible handles.
+        if axisIsVisible(axesHandle)
             relevantAxesHandles(end+1) = axesHandle;
         end
     end


### PR DESCRIPTION
- E.g., testcase 96 `colorbarLabelTitle` failed due to the colorbar being filtered in R2014b
- The filter was extended to properly handle colorbars in R2014b
- Comments were updated a little bit

Issue https://github.com/matlab2tikz/matlab2tikz/issues/429 is related.
