### PR TITLE
[Add] missing getEnv and isVerBelow added to test suite

### DIFF
--- a/test/suites/testSurfshader.m
+++ b/test/suites/testSurfshader.m
@@ -101,3 +101,45 @@ stat.description = 'mesh | Fc: none | Ec: RGB';
 surf(X,Y,Z,'FaceColor','none','EdgeColor','green')
 end
 % =========================================================================
+function env = getEnvironment
+  if ~isempty(ver('MATLAB'))
+     env = 'MATLAB';
+  elseif ~isempty(ver('Octave'))
+     env = 'Octave';
+  else
+     env = [];
+  end
+end
+% =========================================================================
+function [below, noenv] = isVersionBelow ( env, threshMajor, threshMinor )
+  % get version string for `env' by iterating over all toolboxes
+  versionData = ver;
+  versionString = '';
+  for k = 1:max(size(versionData))
+      if strcmp( versionData(k).Name, env )
+          % found it: store and exit the loop
+          versionString = versionData(k).Version;
+          break
+      end
+  end
+
+  if isempty( versionString )
+      % couldn't find `env'
+      below = true;
+      noenv = true;
+      return
+  end
+
+  majorVer = str2double(regexprep( versionString, '^(\d+)\..*', '$1' ));
+  minorVer = str2double(regexprep( versionString, '^\d+\.(\d+\.?\d*)[^\d]*.*', '$1' ));
+
+  if (majorVer < threshMajor) || (majorVer == threshMajor && minorVer < threshMinor)
+      % version of `env' is below threshold
+      below = true;
+  else
+      % version of `env' is same as or above threshold
+      below = false;
+  end
+  noenv = false;
+end
+% =========================================================================


### PR DESCRIPTION
The test suite was missing two generic functions from ACID to run the second test
