### PR TITLE
Fix updater

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -325,7 +325,7 @@ userInfo(m2t, '\nThis is %s %s.\n', m2t.name, m2t.versionFull)
 
 %% Check for a new matlab2tikz version outside version control
 if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
-  status = m2tUpdater(...
+  isUpdateInstalled = m2tUpdater(...
     m2t.name, ...
     m2t.website, ...
     m2t.version, ...
@@ -334,7 +334,7 @@ if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
     );
     % Terminate conversion if update was successful (the user is notified
     % by the updater)
-    if status, return, end
+    if isUpdateInstalled, return, end
 end
 
 %% print some version info to the screen

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -67,6 +67,7 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
       mostRecentVersion = '';
   end
   
+  upgradeSuccess = false;
   if ~isempty(mostRecentVersion)
       userInfo(verbose, '**********************************************\n');
       userInfo(verbose, 'New version available! (%s)\n', mostRecentVersion);
@@ -101,7 +102,6 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
           userInfo(verbose, ['Downloading and unzipping to ''', printPath, ''' ...']);
           
           % Try upgrading
-          upgradeSuccess = false;
           try
               % The FEX now forwards the download request to Github.
               % Go through the forwarding to update the download count and


### PR DESCRIPTION
Practically rewrote the updater, since the FEX forwards the download request to Github latest master. 
Also, the folder structure is packed into an additional folder, the MATLAB Search Path  `/matlab2tikz-matlab2tikz-76c2ac0` (see [FEX](http://uk.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz)). If we were to remove it from FEX, we could simplify things a bit.
