### PR TITLE
Fix updater

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -333,6 +333,8 @@ if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
     m2t.cmdOpts.Results.showInfo, ...
     m2t.env...
     );
+    % Terminate conversion if update was successful (the user is notified
+    % by the updater)
     if status, return, end
 end
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -326,7 +326,7 @@ userInfo(m2t, '\nThis is %s %s.\n', m2t.name, m2t.versionFull)
 
 %% Check for a new matlab2tikz version outside version control
 if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
-  status = m2tUpdater(...
+  isUpdateInstalled = m2tUpdater(...
     m2t.name, ...
     m2t.website, ...
     m2t.version, ...
@@ -335,7 +335,7 @@ if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
     );
     % Terminate conversion if update was successful (the user is notified
     % by the updater)
-    if status, return, end
+    if isUpdateInstalled, return, end
 end
 
 %% print some version info to the screen

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -165,7 +165,7 @@ m2t.version = '0.6.0';
 m2t.author = 'Nico Schlömer';
 m2t.authorEmail = 'nico.schloemer@gmail.com';
 m2t.years = '2008--2014';
-m2t.website = 'http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz';
+m2t.website = 'http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz';
 VCID = VersionControlIdentifier();
 m2t.versionFull = strtrim(sprintf('v%s %s', m2t.version, VCID));
 
@@ -326,13 +326,14 @@ userInfo(m2t, '\nThis is %s %s.\n', m2t.name, m2t.versionFull)
 
 %% Check for a new matlab2tikz version outside version control
 if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
-  m2tUpdater(...
+  status = m2tUpdater(...
     m2t.name, ...
     m2t.website, ...
     m2t.version, ...
     m2t.cmdOpts.Results.showInfo, ...
     m2t.env...
     );
+    if status, return, end
 end
 
 %% print some version info to the screen

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -130,16 +130,19 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
                   for ii = 1:numel(unzippedFiles)
                       movefile(unzippedFiles{ii}, unzippedFilesTarget{ii})
                   end
-                  % Remove topZipFolder
-                  rmdir(fullfile(targetPath, topZipFolder{1}),'s');
+                  % Add topZipFolder to current folder structure
+                  currentFolderFiles = [currentFolderFiles; fullfile(targetPath, topZipFolder{1})];
               end
               
               % Cleanup
-              filesToDelete = setdiff(currentFolderFiles, unzippedFilesTarget);
-              for ii = 1:numel(filesToDelete)
-                  x = filesToDelete{ii};
+              newFolderStructure = [getFolders(unzippedFilesTarget);  unzippedFilesTarget];
+              deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
+              for ii = 1:numel(deleteFolderFiles)
+                  x = deleteFolderFiles{ii};
                   if exist(x, 'file') == 2
                       delete(x);
+                  elseif exist(x, 'dir') == 7
+                      rmdir(x,'s')
                   end
               end
               
@@ -224,5 +227,16 @@ function list = rdirfiles(rootdir)
   
   % Drop directories
   list(pdir) = [];
+end
+% =========================================================================
+function list = getFolders(list) 
+  % Extract the folder structure from a list of files and folders
+  
+  for ii = 1:numel(list)
+      if exist(list{ii},'file') == 2
+          list{ii} = fileparts(list{ii});
+      end
+  end
+  list = unique(list);
 end
 % =========================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -105,7 +105,7 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
           % Try upgrading
           try
               % List current folder structure. Will use last for cleanup
-              currentFolderFiles = rdir(targetPath);
+              currentFolderFiles = rdirfiles(targetPath);
               
               % The FEX now forwards the download request to Github.
               % Go through the forwarding to update the download count and
@@ -130,18 +130,16 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
                   for ii = 1:numel(unzippedFiles)
                       movefile(unzippedFiles{ii}, unzippedFilesTarget{ii})
                   end
-                  % Add topZipFolder to current folder structure
-                  currentFolderFiles = [currentFolderFiles; fullfile(targetPath, topZipFolder{1})];
+                  % Remove topZipFolder
+                  rmdir(fullfile(targetPath, topZipFolder{1}),'s');
               end
               
               % Cleanup
-              deleteFolderFiles = setdiff(currentFolderFiles, unzippedFilesTarget);
-              for ii = 1:numel(deleteFolderFiles)
-                  x = deleteFolderFiles{ii};
+              filesToDelete = setdiff(currentFolderFiles, unzippedFilesTarget);
+              for ii = 1:numel(filesToDelete)
+                  x = filesToDelete{ii};
                   if exist(x, 'file') == 2
                       delete(x);
-                  elseif exist(x, 'dir') == 7
-                      rmdir(x,'s')
                   end
               end
               
@@ -207,8 +205,8 @@ function userInfo(verbose, message, varargin)
 
 end
 % =========================================================================
-function list = rdir(rootdir)
-  % Recursive directory listing
+function list = rdirfiles(rootdir)
+  % Recursive files listing
   s    = dir(rootdir);
   list = {s.name}';
   
@@ -221,8 +219,10 @@ function list = rdir(rootdir)
   % Loop for sub-directories
   pdir = find([s(idx).isdir]);
   for ii = pdir
-      list = [list; rdir(list{ii})]; %#ok<AGROW>
+      list = [list; rdirfiles(list{ii})]; %#ok<AGROW>
   end
   
+  % Drop directories
+  list(pdir) = [];
 end
 % =========================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -102,12 +102,13 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
               tmp           = regexp(tmp, filesep,'split','once');
               tmp           = cat(1,tmp{:});
               topZipFolder  = unique(tmp(:,1));
+              
               if numel(topZipFolder) == 1
                   unzippedFilesTarget = fullfile(targetPath, tmp(:,2));
                   for ii = 1:numel(unzippedFiles)
                       movefile(unzippedFiles{ii}, unzippedFilesTarget{ii})
                   end
-                  delete(fullfile(targetPath, topZipFolder{1}));
+                  rmdir(fullfile(targetPath, topZipFolder{1}),'s');
               end
               
               versionFile = fullfile(targetPath,['version-', version]);

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -139,10 +139,10 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
               deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
               for ii = 1:numel(deleteFolderFiles)
                   x = deleteFolderFiles{ii};
-                  if exist(x, 'file') == 2
+                  if exist(x, 'file')
                       delete(x);
-                  elseif exist(x, 'dir') == 7
-                      rmdir(x,'s')
+                  elseif exist(x, 'dir')
+                      rmdir(x,'s');
                   end
               end
               

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -67,6 +67,7 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
       mostRecentVersion = '';
   end
   
+  upgradeSuccess = false;
   if ~isempty(mostRecentVersion)
       userInfo(verbose, '**********************************************\n');
       userInfo(verbose, 'New version available! (%s)\n', mostRecentVersion);
@@ -101,7 +102,6 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
           userInfo(verbose, ['Downloading and unzipping to ''', printPath, ''' ...']);
           
           % Try upgrading
-          upgradeSuccess = false;
           try
               % The FEX now forwards the download request to Github.
               % Go through the forwarding to update the download count and

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -1,4 +1,4 @@
-function m2tUpdater(name, fileExchangeUrl, version, verbose, env)
+function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, env)
 %UPDATER   Auto-update matlab2tikz.
 %   Only for internal usage.
 
@@ -68,7 +68,7 @@ function m2tUpdater(name, fileExchangeUrl, version, verbose, env)
       userInfo(verbose, '**********************************************\n');
       
       reply = input([' *** Would you like ', name, ' to self-upgrade? y/n [n]:'],'s');
-      if strcmp(reply, 'y')
+      if strcmpi(reply, 'y')
           % Download the files and unzip its contents into the folder
           % above the folder that contains the current script.
           % This assumes that the file structure is something like
@@ -89,7 +89,7 @@ function m2tUpdater(name, fileExchangeUrl, version, verbose, env)
           else
               printPath = targetPath;
           end
-          userInfo(verbose, ['Downloading and unzipping to ', printPath, '...']);
+          userInfo(verbose, ['Downloading and unzipping to ''', printPath, ''' ...']);
           upgradeSuccess = false;
           
           try
@@ -107,18 +107,18 @@ function m2tUpdater(name, fileExchangeUrl, version, verbose, env)
                   for ii = 1:numel(unzippedFiles)
                       movefile(unzippedFiles{ii}, unzippedFilesTarget{ii})
                   end
-                  delete(topZipFolder{1});
+                  delete(fullfile(targetPath, topZipFolder{1}));
               end
               
-              versionFile = [pathstr, filesep, 'version-', version];
+              versionFile = fullfile(targetPath,['version-', version]);
               if exist(versionFile, 'file') == 2
                   delete(versionFile);
               end
               
               upgradeSuccess = true; %~isempty(unzippedFiles);
-              userInfo(verbose, 'DONE: ');
+              userInfo(verbose, 'UPDATED: the current conversion will be terminated. Please, re-run it.');
           catch
-              userInfo(verbose, 'FAILED:');
+              userInfo(verbose, ['FAILED: continuing with the' name ' conversion.']);
           end
       end
       userInfo(verbose, '');

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -111,8 +111,9 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
               url           = regexp(html, expression,'match','once');
               unzippedFiles = unzip(url, targetPath);
               
-              % Github packs the folder structure into an additional folder.
-              % Retrieve the top folder name
+              % The folder structure is additionally packed into the 
+              % 'MATLAB Search Path' folder deifned in FEX. Retrieve the 
+              % top folder name
               tmp          = strrep(unzippedFiles,[targetPath, filesep],'');
               tmp          = regexp(tmp, filesep,'split','once');
               tmp          = cat(1,tmp{:});


### PR DESCRIPTION
(same as #499)

Practically rewrote the updater, since the FEX forwards the download request to Github latest master. 
Also, the folder structure is packed into an additional folder, the MATLAB Search Path 	`/matlab2tikz-matlab2tikz-76c2ac0` (see [FEX](http://uk.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz)). If we were to remove it from FEX, we could simplify things a bit.