### PR TITLE
Bar width in units, retrieve bar peers directly

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3050,7 +3050,7 @@ function [m2t, str] = drawBarseries(m2t, h)
             prop               = switchMatOct(m2t, 'BarPeers', 'bargroup');
             bargroup           = get(h, prop);
             numBars            = numel(bargroup);
-            [~, m2t.barplotId] = ismember(h, bargroup);
+            [~, m2t.barplotId] = ismember(handle(h), bargroup);
 
             % Maximum group width relative to the minimum distance between two
             % x-values. See <MATLAB>/toolbox/matlab/specgraph/makebars.m

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -829,15 +829,20 @@ function m2t = drawAxes(m2t, handle)
             opts_add(m2t.axesContainers{end}.options, ...
             'scale only axis', []);
     end
-    % Add the physical dimension of one unit of length in the coordinate system.
-    % This is used later on to translate lengths to physical units where
-    % necessary (e.g., in bar plots).
-    m2t.unitlength.x.unit = pos.w.unit;
-    xLim = get(m2t.currentHandles.gca, 'XLim');
-    m2t.unitlength.x.value = pos.w.value / (xLim(2)-xLim(1));
-    m2t.unitlength.y.unit = pos.h.unit;
-    yLim = get(m2t.currentHandles.gca, 'YLim');
-    m2t.unitlength.y.value = pos.h.value / (yLim(2)-yLim(1));
+    
+%     NOT USED IN BARPLOTS ANYMORE (if re-introduced make it
+%     m2t.axesContainer{end}.<field>)
+%     % Add the physical dimension of one unit of length in the coordinate system.
+%     % This is used later on to translate lengths to physical units where
+%     % necessary (e.g., in bar plots).
+%     m2t.unitlength.x.unit = pos.w.unit;
+%     xLim = get(m2t.currentHandles.gca, 'XLim');
+%     m2t.unitlength.x.value = pos.w.value / (xLim(2)-xLim(1));
+%     m2t.unitlength.y.unit = pos.h.unit;
+%     yLim = get(m2t.currentHandles.gca, 'YLim');
+%     m2t.unitlength.y.value = pos.h.value / (yLim(2)-yLim(1));
+    
+    % Axis direction
     for axis = 'xyz'
         m2t.([axis 'AxisReversed']) = ...
             strcmp(get(handle,[upper(axis),'Dir']), 'reverse');
@@ -3043,10 +3048,10 @@ function [m2t, str] = drawBarseries(m2t, h)
             % Maximum group width relative to the minimum distance between two
             % x-values. See <MATLAB>/toolbox/matlab/specgraph/makebars.m
             maxGroupWidth = 0.8;
-            if numBars == 1
+            if numBarSeries == 1
                 groupWidth = 1.0;
             else
-                groupWidth = min(maxGroupWidth, numBars/(numBars+1.5));
+                groupWidth = min(maxGroupWidth, numBarSeries/(numBarSeries+1.5));
             end
 
             % Calculate the width of each bar and the center point shift as in
@@ -3056,8 +3061,8 @@ function [m2t, str] = drawBarseries(m2t, h)
             % In case of numBars==2, this returns [-1/4, 1/4],
             % In case of numBars==3, this returns [-1/3, 0, 1/3],
             % and so forth.
-            barWidth = groupWidth/numBars; % assumption
-            barShift = (m2t.barplotId - 0.5) * barWidth - groupWidth/2;
+            assumedBarWidth = groupWidth/numBarSeries; % assumption
+            barShift        = (barSeriesId - 0.5) * assumedBarWidth - groupWidth/2;
 
             % From http://www.mathworks.com/help/techdoc/ref/bar.html:
             % bar(...,width) sets the relative bar width and controls the
@@ -3065,7 +3070,7 @@ function [m2t, str] = drawBarseries(m2t, h)
             % you do not specify X, the bars within a group have a slight
             % separation. If width is 1, the bars within a group touch one
             % another. The value of width must be a scalar.
-            barWidth = get(h, 'BarWidth') * groupWidth / numBars;
+            barWidth = get(h, 'BarWidth') * assumedBarWidth;
 
             % Bar type
             drawOptions = opts_add(drawOptions, barType);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3037,11 +3037,8 @@ function [m2t, str] = drawBarseries(m2t, h)
     switch barlayout
         case 'grouped'  % grouped bar plots
             
-            % Get bar peers, number of bars and barId
-            prop               = switchMatOct(m2t, 'BarPeers', 'bargroup');
-            bargroup           = get(h, prop);
-            numBars            = numel(bargroup);
-            [~, m2t.barplotId] = ismember(handle(h), bargroup);
+            % Get number of bars series and bar series id
+            [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h);
 
             % Maximum group width relative to the minimum distance between two
             % x-values. See <MATLAB>/toolbox/matlab/specgraph/makebars.m
@@ -3134,6 +3131,17 @@ function [m2t, str] = drawBarseries(m2t, h)
     drawOpts = opts_print(m2t, drawOptions, ',');
     [m2t, table ] = makeTable(m2t, '', xDataPlot, '', yDataPlot);
     str = sprintf('\\addplot[%s] plot table[row sep=crcr] {%s};\n', drawOpts, table);
+end
+% ==============================================================================
+function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
+% Get number of bars series and bar series id
+    prop         = switchMatOct(m2t, 'BarPeers', 'bargroup');
+    bargroup     = get(h, prop);
+    numBarSeries = numel(bargroup);
+    if isHG2(m2t)
+        bargroup = bargroup(end:-1:1);
+    end
+    [~, barSeriesId] = ismember(handle(h), bargroup);
 end
 % ==============================================================================
 function [m2t, drawOptions] = getFaceColorOfBar(m2t, h, drawOptions)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -172,7 +172,6 @@ m2t.versionFull = strtrim(sprintf('v%s %s', m2t.version, VCID));
 m2t.tol = 1.0e-15; % numerical tolerance (e.g. used to test equality of doubles)
 m2t.imageAsPngNo = 0;
 m2t.dataFileNo   = 0;
-m2t.barplotId    = 0; % identification flag for bar plots
 m2t.quiverId     = 0; % identification flag for quiver plot styles
 m2t.automaticLabelIndex = 0;
 
@@ -803,10 +802,8 @@ function m2t = drawAxes(m2t, handle)
     % update gca
     m2t.currentHandles.gca = handle;
 
-    % Bar plots need to have some values counted per axis. Setting
-    % m2t.barplotId to 0 makes sure these are recomputed in drawBarSeries()
-    % TODO: find nicer approach for barplots
-    m2t.barplotId = 0;
+    % Flag if axis contains barplot
+    m2t.axesContainers{end}.barAddedAxisOption = false;
 
     m2t.gcaAssociatedLegend = getAssociatedLegend(m2t, handle);
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3015,13 +3012,6 @@ function [m2t, str] = drawBarseries(m2t, h)
         return; % don't bother drawing invisible things
     end
 
-    % drawAxes sets m2t.barplotId to 0, so all values are recomputed for subplots.
-    if m2t.barplotId == 0
-        % 'barplotId' provides a consecutively numbered ID for each
-        % barseries plot. This allows for a proper handling of multiple bars.
-        m2t.barAddedAxisOption = false;
-    end
-
     % Add 'log origin = infty' if BaseValue differs from zero (log origin=0 is
     % the default behaviour since Pgfplots v1.5).
     baseValue = get(h, 'BaseValue');
@@ -3096,12 +3086,12 @@ function [m2t, str] = drawBarseries(m2t, h)
             % Pass option to parent axis & disallow anything but stacked plots
             % Make sure this happens exactly *once*.
 
-            if ~m2t.barAddedAxisOption
+            if ~m2t.axesContainers{end}.barAddedAxisOption;
                 barWidth = get(h, 'BarWidth');
                 m2t.axesContainers{end}.options = ...
                     opts_add(m2t.axesContainers{end}.options, ...
                     'bar width', formatDim(barWidth,''));
-                m2t.barAddedAxisOption = true;
+                m2t.axesContainers{end}.barAddedAxisOption = true;
             end
 
             % Somewhere between pgfplots 1.5 and 1.8 and starting

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2803,8 +2803,9 @@ function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
         elseif strcmpi(s.faceColor, 'interp');
             opts = opts_add(opts,'shader','interp');
         else
-            [m2t,xFaceColor] = getColor(m2t, handle, s.faceColor, 'patch');
-            opts             = opts_add(opts,'fill',xFaceColor);
+            s.hasOneFaceColor = true;
+            [m2t,xFaceColor]  = getColor(m2t, handle, s.faceColor, 'patch');
+            opts              = opts_add(opts,'fill',xFaceColor);
         end
         
     % Edge 'interp'
@@ -3096,10 +3097,10 @@ function [m2t, str] = drawBarseries(m2t, h)
             % Make sure this happens exactly *once*.
 
             if ~m2t.barAddedAxisOption
-                BarWidth = get(h, 'BarWidth');
+                barWidth = get(h, 'BarWidth');
                 m2t.axesContainers{end}.options = ...
                     opts_add(m2t.axesContainers{end}.options, ...
-                    'bar width', formatDim(BarWidth,''));
+                    'bar width', formatDim(barWidth,''));
                 m2t.barAddedAxisOption = true;
             end
 


### PR DESCRIPTION
Fixes #443 and #338, i.e. uses now axis units for bar width/shift. This implicitly deals with multiple barplots created with hold on (thus fixes #338).

Also, I am getting rid of `countBarplotSiblings()` and retrieving the  bar group directly when plotting grouped. Octave 's property is 'bargroup' and Matlab's hidden property is 'BarPeers', which exists in both R2014a and b.

`Shift` and `barId` are calculated locally from the bargroup. This avoids popping up some properties into the `m2t` container. 

Tested on R2014a,b and Octave. Gonna submit .pdfs next days.