### PR TITLE
Axis background

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -996,15 +996,11 @@ end
 function m2t = drawBackgroundOfAxes(m2t, handle)
 % draw the background color of the current axes
     backgroundColor = get(handle, 'Color');
-    if ~isNone(backgroundColor)
+    if ~isNone(backgroundColor) && isVisible(handle)
         [m2t, col] = getColor(m2t, handle, backgroundColor, 'patch');
-        % Fill background if not just white or if multiple axes and current
-        % is visible
-        if ~strcmp(col, 'white') || (numel(m2t.relevantAxesHandles) > 1 && isVisible(handle))
-            m2t.axesContainers{end}.options = ...
-                opts_add(m2t.axesContainers{end}.options, ...
-                'axis background/.style', sprintf('{fill=%s}', col));
-        end
+        m2t.axesContainers{end}.options = ...
+            opts_add(m2t.axesContainers{end}.options, ...
+            'axis background/.style', sprintf('{fill=%s}', col));
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4891,12 +4891,14 @@ function [m2t, axesBoundingBox] = getRelevantAxes(m2t, axesHandles)
 % This function is the remaining code of alignSubPlots() in the alternative
 % positioning system.
     
-    % Only handle visible handles.
+    % List only visible axes 
     N   = numel(axesHandles);
     idx = false(N,1);
     for ii = 1:N
        idx(ii) = isAxisVisible(axesHandles(ii));
     end
+    % Store the relevant axes in m2t to simplify querying e.g. positions
+    % of subplots
     m2t.relevantAxesHandles = double(axesHandles(idx));
 
     % Compute the bounding box if width or height of the figure are set by

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -998,7 +998,9 @@ function m2t = drawBackgroundOfAxes(m2t, handle)
     backgroundColor = get(handle, 'Color');
     if ~isNone(backgroundColor)
         [m2t, col] = getColor(m2t, handle, backgroundColor, 'patch');
-        if ~strcmp(col, 'white') || numel(m2t.relevantAxesHandles) > 1
+        % Fill background if not just white or if multiple axes and current
+        % is visible
+        if ~strcmp(col, 'white') || (numel(m2t.relevantAxesHandles) > 1 && isVisible(handle))
             m2t.axesContainers{end}.options = ...
                 opts_add(m2t.axesContainers{end}.options, ...
                 'axis background/.style', sprintf('{fill=%s}', col));
@@ -1364,7 +1366,7 @@ function options = setAxisLimits(m2t, handle, axis, options)
     end
 end
 % ==============================================================================
-function bool = axisIsVisible(axisHandle)
+function bool = isAxisVisible(axisHandle)
     if ~isVisible(axisHandle)
         % An invisible axes container *can* have visible children, so don't
         % immediately bail out here.
@@ -4897,7 +4899,7 @@ function [m2t, axesBoundingBox] = getRelevantAxes(m2t, axesHandles)
     N   = numel(axesHandles);
     idx = false(N,1);
     for ii = 1:N
-       idx(ii) = axisIsVisible(axesHandles(ii));
+       idx(ii) = isAxisVisible(axesHandles(ii));
     end
     m2t.relevantAxesHandles = double(axesHandles(idx));
 


### PR DESCRIPTION
Together with #509 fixes #6 since enforces color bg of axis when there are multiple axes and the current one is visible. Basically, complex plot with axes overlays, see `ACID(14)`, will mantain transparency while still plotting the children (lines). 

Also:
* renamed `axisIsVisible` to `isAxisVisible`
* in `getRelevantAxes` made double conversion of axes handles explicit
* store `relevantAxesHandles` in `m2t`, which is needed for the multiple axes check in `drawBackgroundOfAxes`