### PR TITLE
Rehash in place and continue conversion with new version

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -333,9 +333,12 @@ if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
     m2t.cmdOpts.Results.showInfo, ...
     m2t.env...
     );
-    % Terminate conversion if update was successful (the user is notified
-    % by the updater)
-    if isUpdateInstalled, return, end
+    % Reload updated version and execute m2t conversion with that
+    if isUpdateInstalled
+        rehash
+        matlab2tikz(varargin{:})
+        return
+    end
 end
 
 %% print some version info to the screen

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -147,9 +147,9 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
               end
               
               upgradeSuccess = true; %~isempty(unzippedFiles);
-              userInfo(verbose, 'UPDATED: the current conversion will be terminated. Please, re-run it.');
+              userInfo(verbose, 'UPDATED.');
           catch
-              userInfo(verbose, ['FAILED: continuing with the' name ' conversion.']);
+              userInfo(verbose, ['FAILED: continuing with the old ' name]);
           end
       end
       userInfo(verbose, '');


### PR DESCRIPTION
Inspired/fixes #172: rehashes the updated version in place and continues with the conversion using the newest version.

The rehasing is tested with the following suite of functions (save the 3 functions in some folders and make a copy somewhere else):
```matlab
function main(flag)
if flag
    delete('plotrectangle.m')
    movefile('plotrectangle_2.m','plotrectangle.m')
    rehash
    main(false)
    return
end
plotrectangle
end

function plotrectangle
    plot(1:10)
end

function plotrectangle
% Save it as plotrectangle_2.m
    rectangle
end
```

Then calling from cmd window:

    main(true)