### PR TITLE
Octave fixes

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -969,14 +969,12 @@ function legendhandle = getAssociatedLegend(m2t, handle)
     legendhandle = [];
     switch m2t.env
         case 'Octave'
-            if ~isempty(m2t.legendHandles)
-                % Make sure that m2t.legendHandles is a row vector.
-                for lhandle = m2t.legendHandles(:)'
-                    ud = get(lhandle, 'UserData');
-                    if any(handle == ud.handle)
-                        legendhandle = lhandle;
-                        break;
-                    end
+            % Make sure that m2t.legendHandles is a row vector.
+            for lhandle = m2t.legendHandles(:)'
+                ud = get(lhandle, 'UserData');
+                if isVisible(lhandle) && any(handle == ud.handle)
+                    legendhandle = lhandle;
+                    break;
                 end
             end
         case 'MATLAB'

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5539,7 +5539,7 @@ end
 function opts = opts_add(opts, key, value)
 % add a key-value pair to an options array (with duplication check)
     if ~exist('value','var')
-        value = [];
+        value = '';
     end
     value = char(value);
 
@@ -5573,9 +5573,10 @@ function value = opts_get(opts, key)
 end
 function opts = opts_append(opts, key, value)
 % append a key-value pair to an options array (duplicate keys allowed)
-    if ~exist('value','var') || isempty(value)
-        value = [];
+    if ~exist('value','var')
+        value = '';
     end
+    value = char(value);
     if ~(opts_has(opts, key) && isequal(opts_get(opts, key), value))
         opts = cat(1, opts, {key, value});
     end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3962,11 +3962,14 @@ function [m2t, xcolor] = patchcolor2xcolor(m2t, color, patchhandle)
     else
         switch color
             case 'flat'
-                cdata = getCDataWithFallbacks(patchhandle);
-
-                col1 = cdata(1,1);
-                if all(isnan(cdata) | abs(cdata-col1)<1.0e-10)
-                    [m2t, colorindex] = cdata2colorindex(m2t, col1, patchhandle);
+                cdata  = getCDataWithFallbacks(patchhandle);
+                color1 = cdata(1,1);
+                % RGB cdata
+                if ndims(cdata) == 3 && all(size(cdata) == [1,1,3])
+                    [m2t,xcolor] = rgb2colorliteral(m2t, cdata);
+                % All same color
+                elseif all(isnan(cdata) | abs(cdata-color1)<1.0e-10)
+                    [m2t, colorindex] = cdata2colorindex(m2t, color1, patchhandle);
                     [m2t, xcolor] = rgb2colorliteral(m2t, m2t.currentHandles.colormap(colorindex, :));
                 else
                     % Don't return anything meaningful and count on the caller

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1890,7 +1890,8 @@ function [m2t, str] = drawPatch(m2t, handle)
         rowsCData = size(fvCData,1);
         
         % We have CData
-        if rowsCData ~= 0
+        if rowsCData > 1
+            
             % Add the color map
             m2t.axesContainers{end}.options = ...
                 opts_add(m2t.axesContainers{end}.options, ...
@@ -1932,6 +1933,9 @@ function [m2t, str] = drawPatch(m2t, handle)
                 ptType = 'patch table with point meta';
                 Faces  = [Faces fvCData];
             end
+        else
+            [m2t,xFaceColor] = getColor(m2t, handle, s.faceColor, 'patch');
+            drawOptions      = opts_add(drawOptions,'fill',xFaceColor);
         end
     end
     

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2307,12 +2307,12 @@ function [stat] = stackedBarsWithOther()
   yVals = min((xVals).^2, sum(Y,2));
 
   subplot(2,1,1); hold on;
-  bar(Y,'stack');
+  bar(Y,'stacked');
   plot(xVals, yVals, 'Color', 'r', 'LineWidth', 2);
   legend('show');
 
   subplot(2,1,2); hold on;
-  b2 = barh(Y,'stack','BarWidth', 0.75);
+  b2 = barh(Y,'stacked','BarWidth', 0.75);
   plot(yVals, xVals, 'Color', 'b', 'LineWidth', 2);
 
   set(b2(1),'FaceColor','c','EdgeColor','none')


### PR DESCRIPTION
These fixes are mostly relevant for Octave and are preliminary to conclude #503 (so that I can post the bar plot rendering in Octave).
Fixes the short term part of #507 and handles scalar `cdata` when drawing patches (which are used to draw bar plots in Octave)