### PR TITLE
Do not escape dollar in replacement string (e.g., "\$$2\$")

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5042,7 +5042,9 @@ function c = prettyPrint(m2t, strings, interpreter)
                 % untouched.
                 % Displaymath \[...\] seems to be unsupported by TikZ/PGF.
                 % If this changes, use '\\[$2\\]' as replacement below.
-                string = regexprep(s, '(\$\$)(.*?)(\$\$)', '\$$2\$');
+                % Do not escape dollar in replacement string (e.g., "\$$2\$"),
+                % since this is not properly handled by octave 3.8.2.
+                string = regexprep(s, '(\$\$)(.*?)(\$\$)', '$$2$');
 
             case 'tex' % Subset of plain TeX markup language
 


### PR DESCRIPTION
This is not properly handled by octave 3.8.2 and produces the literal
output "$$2$", when the testsuite was executed.

The change does not affect the bahavior of MATLAB.

ACID(68) octave
![image](https://cloud.githubusercontent.com/assets/4340267/5702684/2ab9a0d4-9a5d-11e4-9b16-dccc31ba9565.png)

ACID(68) R2014b
![image](https://cloud.githubusercontent.com/assets/4340267/5702729/8310b3b2-9a5d-11e4-8475-60724598b17d.png)
