### PR TITLE
Fix math textgreater

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5242,8 +5242,8 @@ function string = parseTexSubstring(m2t, string)
     % '\textless' and '\textgreater' in textmode
     % This is handled better, if 'parseStringsAsMath' is activated
     if m2t.cmdOpts.Results.parseStringsAsMath == 0
-        string = regexprep(string, '<', '\\textless');
-        string = regexprep(string, '>', '\\textgreater');
+        string = regexprep(string, '<', '\\textless{}');
+        string = regexprep(string, '>', '\\textgreater{}');
     end
 
     % Move font styles like \bf into the \text{} command.

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1330,7 +1330,7 @@ function [stat] = decayingharmonic()
   t = 0:901;
   y = A * exp(-alpha*t) .* sin(beta*t);
   plot(t, y)
-  title('{\itAe}^{-\alpha\itt}sin\beta{\itt}, \alpha<<\beta, \beta>>\alpha, \alpha<\beta, \beta>\alpha')
+  title('{\itAe}^{-\alpha\itt}sin\beta{\itt}, \alpha<<\beta, \beta>>\alpha, \alpha<\beta, \beta>\alpha, b>a')
   xlabel('Time \musec.')
   ylabel('Amplitude')
 end


### PR DESCRIPTION
Code
```
plot(magic(3))
title('a>O');
```
would fail.

Testcase ACID(64) is slightly extended to cover that issue.