### PR TITLE
Histogram support

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3042,22 +3042,26 @@ function [m2t, str] = drawHistogram(m2t, h)
         opts = opts_add(opts, 'draw', xEdgeColor);
     end
     
-    % Bar type
-    opts = opts_add(opts, 'ybar interval');
-    
     % Data
     binEdges = get(h, 'BinEdges');
     binValue = get(h, 'Values');
     data     = [binEdges(:), [binValue(:); binValue(end)]];
-        
+    
+    % Bar type (depends on orientation)
+    isVertical = strcmp(get(h,'Orientation'),'vertical');
+    if isVertical
+        opts = opts_add(opts, 'ybar interval');
+    else
+        opts = opts_add(opts, 'xbar interval');
+        data = fliplr(data);
+    end
+    
     % Make table
     [m2t, table] = makeTable(m2t, {'x','y'},data);
     
-    % Add 'area legend' to the options as otherwise the legend indicators
-    % will just highlight the edges.
-    m2t.axesContainers{end}.options = ...
-        opts_add(m2t.axesContainers{end}.options, 'area legend');
-
+    % Add 'area legend' (x/ybar interval legend do not seem to work)
+    opts = opts_add(opts, 'area legend');
+    
     % Print out
     drawOpts = opts_print(m2t, opts, ',');
     str      = sprintf('\\addplot[%s] plot table[row sep=crcr] {%s};\n', drawOpts, table);
@@ -3181,8 +3185,7 @@ function [m2t, str] = drawBarseries(m2t, h)
 
     % Add 'area legend' to the options as otherwise the legend indicators
     % will just highlight the edges.
-    m2t.axesContainers{end}.options = ...
-        opts_add(m2t.axesContainers{end}.options, 'area legend');
+    drawOptions = opts_add(drawOptions, 'area legend');
 
     % plot the thing
     if isHoriz

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -676,6 +676,9 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, handle)
 
             case 'rectangle'
                 [m2t, str] = drawRectangle(m2t, child);
+                
+            case 'histogram'
+                [m2t, str] = drawHistogram(m2t, child);
 
             case {'uitoolbar', 'uimenu', 'uicontextmenu', 'uitoggletool',...
                     'uitogglesplittool', 'uipushtool', 'hgjavacomponent'}
@@ -3003,6 +3006,61 @@ function [m2t, xcolor, hasColor] = getColorOfMarkers(m2t, h, name, cData)
     else
         [m2t, xcolor] = getColor(m2t, h, cData, 'patch');
     end
+end
+% ==============================================================================
+function [m2t, str] = drawHistogram(m2t, h)
+    
+    if ~isVisible(h)
+        str = '';
+        return;
+    end
+
+    % Init options 
+    opts = opts_new();
+    
+    % Face
+    faceColor = get(h,'FaceColor');
+    if isNone(faceColor)
+        opts = opts_add(opts, 'fill', 'none');
+    else
+        [m2t, xFaceColor] = getColor(m2t, h, faceColor, 'patch');
+        opts = opts_add(opts, 'fill', xFaceColor);
+    end
+    
+    % FaceAlpha
+    faceAlpha = get(h, 'FaceAlpha');
+    if ~isNone(faceColor) && isnumeric(faceAlpha) && faceAlpha ~= 1.0
+        opts = opts_add(opts,'fill opacity', sprintf(m2t.ff,faceAlpha));
+    end
+    
+    % Edge
+    edgeColor = get(h, 'EdgeColor');
+    if isNone(edgeColor)
+        opts = opts_add(opts, 'draw', 'none');
+    else
+        [m2t, xEdgeColor] = getColor(m2t, h, edgeColor, 'patch');
+        opts = opts_add(opts, 'draw', xEdgeColor);
+    end
+    
+    % Bar type
+    opts = opts_add(opts, 'ybar interval');
+    
+    % Data
+    binEdges = get(h, 'BinEdges');
+    binValue = get(h, 'Values');
+    data     = [binEdges(:), [binValue(:); binValue(end)]];
+        
+    % Make table
+    [m2t, table] = makeTable(m2t, {'x','y'},data);
+    
+    % Add 'area legend' to the options as otherwise the legend indicators
+    % will just highlight the edges.
+    m2t.axesContainers{end}.options = ...
+        opts_add(m2t.axesContainers{end}.options, 'area legend');
+
+    % Print out
+    drawOpts = opts_print(m2t, opts, ',');
+    str      = sprintf('\\addplot[%s] plot table[row sep=crcr] {%s};\n', drawOpts, table);
 end
 % ==============================================================================
 function [m2t, str] = drawBarseries(m2t, h)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3937,7 +3937,13 @@ function [m2t, xcolor] = patchcolor2xcolor(m2t, color, patchhandle)
                 end
 
             case 'auto'
-                color = get(patchhandle, 'Color');
+                try
+                    color = get(patchhandle, 'Color');
+                catch
+                    % From R2014b use an undocumented property if Color is 
+                    % not present
+                    color = get(patchhandle, 'AutoColor');
+                end
                 [m2t, xcolor] = rgb2colorliteral(m2t, color);
 
             case 'none'

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -132,7 +132,8 @@ function [status] = ACID(k)
                            @stackedBarsWithOther, ...
                            @colorbarLabelTitle  , ...
                            @textAlignment       , ...
-                           @overlappingPlots
+                           @overlappingPlots    ,...
+                           @histogramPlot
                          };
 
 
@@ -2432,6 +2433,24 @@ function [stat] = overlappingPlots()
     % axis background color: ax2 = default, ax3 = green, ax4 = transparent
     set(ax3, 'Color', 'green');
     set(ax4, 'Color', 'none');
+end
+% =========================================================================
+function [stat] = histogramPlot()
+
+  if ~exist('histogram')
+      fprintf('histogram() not found. Skipping.\n\n' );
+      stat.skip = true;
+      return;
+  end
+  stat.description = 'overlapping histogram() plots and custom size bins';
+  stat.issues      = 525;
+
+  x     = randn(1000,1);
+  edges = [-10 -2:0.25:2 10];
+  histogram(x,edges);
+  hold on
+  y     = 3 + randn(1000,1);
+  histogram(y);
 end
 % =========================================================================
 function env = getEnvironment

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2437,7 +2437,10 @@ end
 % =========================================================================
 function [stat] = histogramPlot()
 
-  if ~exist('histogram')
+  % histogram() was introduced in Matlab R2014b, hence skip if we a re in
+  % Octave or version lower Matlab version.
+  env = getEnvironment();
+  if strcmpi(env,'MATLAB') && isVersionBelow(env, 8,4)
       fprintf('histogram() not found. Skipping.\n\n' );
       stat.skip = true;
       return;

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2445,11 +2445,13 @@ function [stat] = histogramPlot()
   stat.description = 'overlapping histogram() plots and custom size bins';
   stat.issues      = 525;
 
-  x     = randn(1000,1);
-  edges = [-10 -2:0.25:2 10];
+  x     = [-0.2, -0.484, 0.74, 0.632, -1.344, 0.921, -0.598, -0.727,...
+           -0.708, 1.045, 0.37, -1.155, -0.807, 1.027, 0.053, 0.863,...
+           1.131, 0.134, -0.017, -0.316];
+  y     = x.^2;
+  edges = [-2 -1:0.25:3];
   histogram(x,edges);
   hold on
-  y     = 3 + randn(1000,1);
   histogram(y);
 end
 % =========================================================================


### PR DESCRIPTION
Fixes #525 by adding support for `histogram()`.

![capture](https://cloud.githubusercontent.com/assets/3731173/5794001/e065146e-9f52-11e4-9a9e-efe5abc4f97e.PNG)

On the left side the transparency is lost possibly due to `cleanfigure()`