### PR TITLE
Fix issues #392 and #400 caused by cleanfigure

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -383,6 +383,7 @@ function movePointsCloser(meta, handle)
     return;
   end
 
+  numberOfPoints = length(xData);
   data = [xData(:), yData(:)];
 
   xlim = get(meta.gca, 'XLim');
@@ -452,23 +453,30 @@ function movePointsCloser(meta, handle)
      else
          rep = r{k};
      end
-     if isempty(d) && ~isempty(rep) && lastEntryIsReplacement
-         % The last entry was a replacment, and the first one now is.
-         % Prepend a NaN.
-         rep = [NaN(1, size(r{k}, 2)); ...
-                rep];
+
+     % If the current handle is a simple line of exactly two points the continue
+     % without the following check, since such a straight line has should not be
+     % discontinued by a 'NaN' entry.
+     if numberOfPoints > 2
+         % If the last entry was a replacement and it is followed now by another
+         % replacment, then prepend a 'NaN' to prevent drawing of a connecting line.
+         if isempty(d) && ~isempty(rep) && lastEntryIsReplacement
+             rep = [NaN(1, size(r{k}, 2)); ...
+                    rep];
+         end
      end
-     % Add the data.
-     if ~isempty(d)
-         dataNew = [dataNew; ...
-                    d];
+
+     % Add the data, depending if it is a valid point or a replacement
+     if ~isempty(d)     % Add current point from valid point 'd'
+         dataNew = [dataNew; d];
          lastEntryIsReplacement = false;
      end
-     if ~isempty(rep)
-         dataNew = [dataNew; ...
-                    rep];
+     if ~isempty(rep)   % Add current point from replacement point 'rep'
+         dataNew = [dataNew; rep];
          lastEntryIsReplacement = true;
      end
+
+     % Store last replacement index
      lastReplIndex = replaceIndices(k);
   end
   dataNew = [dataNew; ...

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -476,9 +476,11 @@ function movePointsCloser(meta, handle)
          % achieved by adding a NaN and necessary, because the two points are
          % moved close to the axis limits and thus would afterwards show a
          % connecting line in the axis.
-         if bLineOutsideAxis
-             rep = [NaN(1, size(r{k}, 2)); rep];
-         end
+
+         % The last entry was a replacment, and the first one now is.
+         % Prepend a NaN.
+         rep = [NaN(1, size(r{k}, 2)); ...
+                rep];
      end
 
      % Add the data, depending if it is a valid point or a replacement

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -383,7 +383,6 @@ function movePointsCloser(meta, handle)
     return;
   end
 
-  numberOfPoints = length(xData);
   data = [xData(:), yData(:)];
 
   xlim = get(meta.gca, 'XLim');
@@ -439,11 +438,7 @@ function movePointsCloser(meta, handle)
   % Insert all r{k}{:} at replaceIndices[k].
   dataNew = [];
   lastReplIndex = 0;
-  lastEntryIsReplacement = false;
   for k = 1:m
-     % Make sure that two subsequent moved points are separated by a NaN entry.
-     % This is to make sure that there is no visible line between two moved
-     % points that wasn't there before.
      d = data(lastReplIndex+1:replaceIndices(k)-1,:);
      if size(r{k}, 1) == 2
          % Two replacement entries -- pad them with a NaN.
@@ -454,26 +449,12 @@ function movePointsCloser(meta, handle)
          rep = r{k};
      end
 
-     % If the current handle is a simple line of exactly two points the continue
-     % without the following check, since such a straight line has should not be
-     % discontinued by a 'NaN' entry.
-     if numberOfPoints > 2
-         % If the last entry was a replacement and it is followed now by another
-         % replacment, then prepend a 'NaN' to prevent drawing of a connecting line.
-         if isempty(d) && ~isempty(rep) && lastEntryIsReplacement
-             rep = [NaN(1, size(r{k}, 2)); ...
-                    rep];
-         end
-     end
-
      % Add the data, depending if it is a valid point or a replacement
      if ~isempty(d)     % Add current point from valid point 'd'
          dataNew = [dataNew; d];
-         lastEntryIsReplacement = false;
      end
      if ~isempty(rep)   % Add current point from replacement point 'rep'
          dataNew = [dataNew; rep];
-         lastEntryIsReplacement = true;
      end
 
      % Store last replacement index

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -479,8 +479,12 @@ function movePointsCloser(meta, handle)
 
          % The last entry was a replacment, and the first one now is.
          % Prepend a NaN.
-         rep = [NaN(1, size(r{k}, 2)); ...
-                rep];
+         
+         % Only do this, if the original segment was not visible either
+         if ~segmentVisible(data([lastReplIndex,replaceIndices(k)],:), [false;false], xlim, ylim)
+             rep = [NaN(1, size(r{k}, 2)); ...
+                    rep];
+         end
      end
 
      % Add the data, depending if it is a valid point or a replacement

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -454,15 +454,30 @@ function movePointsCloser(meta, handle)
          rep = r{k};
      end
 
-     % If the current handle is a simple line of exactly two points the continue
-     % without the following check, since such a straight line has should not be
-     % discontinued by a 'NaN' entry.
-     if numberOfPoints > 2
-         % If the last entry was a replacement and it is followed now by another
-         % replacment, then prepend a 'NaN' to prevent drawing of a connecting line.
-         if isempty(d) && ~isempty(rep) && lastEntryIsReplacement
-             rep = [NaN(1, size(r{k}, 2)); ...
-                    rep];
+     % Don't draw line, if connecting line would be completely outside axis.
+     % We can check this using a line clipping algorithm.
+     % Illustration of the problem:
+     % http://www.cc.gatech.edu/grads/h/Hao-wei.Hsieh/Haowei.Hsieh/sec1_example.html
+     % This boils down to a line intersects line test, where all four lines of
+     % the axis rectangle need to be considered.
+     %
+     % First consider two easy cases:
+     % 1. This can't be the case, if last point was not replaced, because it is
+     %    inside the axis limits ('lastEntryIsReplacement == 0').
+     % 2. This can't be the case, if the current point will not be replace,
+     %    because it is inside the axis limits.
+     %    ( (isempty(d) && ~isempty(rep) == 0 ).
+     if lastEntryIsReplacement && (isempty(d) && ~isempty(rep))
+         % Now check if the connecting line goes through the axis rectangle.
+         % TODO: Code that check!
+         bLineOutsideAxis = 0;
+
+         % If line is completly outside the axis, don't draw the line. This is
+         % achieved by adding a NaN and necessary, because the two points are
+         % moved close to the axis limits and thus would afterwards show a
+         % connecting line in the axis.
+         if bLineOutsideAxis
+             rep = [NaN(1, size(r{k}, 2)); rep];
          end
      end
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -469,21 +469,17 @@ function movePointsCloser(meta, handle)
      %    ( (isempty(d) && ~isempty(rep) == 0 ).
      if lastEntryIsReplacement && (isempty(d) && ~isempty(rep))
          % Now check if the connecting line goes through the axis rectangle.
-         % TODO: Code that check!
-         bLineOutsideAxis = 0;
+         % OR: Only do this, if the original segment was not visible either
+         bLineOutsideAxis = ~segmentVisible(...
+             data([lastReplIndex,replaceIndices(k)],:), ...
+             [false;false], xlim, ylim);
 
          % If line is completly outside the axis, don't draw the line. This is
          % achieved by adding a NaN and necessary, because the two points are
          % moved close to the axis limits and thus would afterwards show a
          % connecting line in the axis.
-
-         % The last entry was a replacment, and the first one now is.
-         % Prepend a NaN.
-         
-         % Only do this, if the original segment was not visible either
-         if ~segmentVisible(data([lastReplIndex,replaceIndices(k)],:), [false;false], xlim, ylim)
-             rep = [NaN(1, size(r{k}, 2)); ...
-                    rep];
+         if bLineOutsideAxis
+             rep = [NaN(1, size(r{k}, 2)); rep];
          end
      end
 

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -132,7 +132,8 @@ function [status] = ACID(k)
                            @colorbarLabelTitle  , ...
                            @textAlignment       , ...
                            @overlappingPlots    ,...
-                           @histogramPlot
+                           @histogramPlot       ,...
+                           @cleanfigure_movePointsCloser
                          };
 
 
@@ -2467,6 +2468,36 @@ function [stat] = histogramPlot()
   hold on
   h = histogram(y);
   set(h, 'orientation', 'horizontal');
+end
+% =========================================================================
+function [stat] = cleanfigure_movePointsCloser()
+  % test function 'movePiontsClose' that is part of 'cleanfigure'
+  stat.description = ['Test function \texttt{movePointsCloser()} ', ...
+                        'of \texttt{cleanfigure()}.'];
+  stat.issues      = [392,400];
+
+  % all points are outside visible axis
+  points1 = [2 2 3 3 4 4; ... % x coordinates
+             2 6 2 6 2 6];    % y coordinates
+  % some points are outside visible axis
+  points2 = [1 2 2.5 3 4; ... % x coordinates
+             2 3 3.5 5 1];    % y coordinates
+
+  % unzoomed subplot
+  subplot(2,1,1);
+  plot(points1(1,:),points1(2,:),'b-x'); hold on;
+  plot(points2(1,:),points2(2,:),'r-o');
+  title('unzoomed subplot');
+
+  % zoomed subplot (vertically)
+  subplot(2,1,2);
+  plot(points1(1,:),points1(2,:),'b-x'); hold on;
+  plot(points2(1,:),points2(2,:),'r-o');
+  axis([1 4 2.5 4]);
+  title('vertically zoomed subplot');
+
+  % force application of 'cleanfigure()'; don't rely on testsuite
+  cleanfigure();
 end
 % =========================================================================
 function env = getEnvironment

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -132,8 +132,7 @@ function [status] = ACID(k)
                            @colorbarLabelTitle  , ...
                            @textAlignment       , ...
                            @overlappingPlots    ,...
-                           @histogramPlot       ,...
-                           @cleanfigure_movePointsCloser
+                           @histogramPlot
                          };
 
 
@@ -2468,36 +2467,6 @@ function [stat] = histogramPlot()
   hold on
   h = histogram(y);
   set(h, 'orientation', 'horizontal');
-end
-% =========================================================================
-function [stat] = cleanfigure_movePointsCloser()
-  % test function 'movePiontsClose' that is part of 'cleanfigure'
-  stat.description = ['Test function \texttt{movePointsCloser()} ', ...
-                        'of \texttt{cleanfigure()}.'];
-  stat.issues      = [392,400];
-
-  % all points are outside visible axis
-  points1 = [2 2 3 3 4 4; ... % x coordinates
-             2 6 2 6 2 6];    % y coordinates
-  % some points are outside visible axis
-  points2 = [1 2 2.5 3 4; ... % x coordinates
-             2 3 3.5 5 1];    % y coordinates
-
-  % unzoomed subplot
-  subplot(2,1,1);
-  plot(points1(1,:),points1(2,:),'b-x'); hold on;
-  plot(points2(1,:),points2(2,:),'r-o');
-  title('unzoomed subplot');
-
-  % zoomed subplot (vertically)
-  subplot(2,1,2);
-  plot(points1(1,:),points1(2,:),'b-x'); hold on;
-  plot(points2(1,:),points2(2,:),'r-o');
-  axis([1 4 2.5 4]);
-  title('vertically zoomed subplot');
-
-  % force application of 'cleanfigure()'; don't rely on testsuite
-  cleanfigure();
 end
 % =========================================================================
 function env = getEnvironment

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -282,6 +282,7 @@ end
 function [stat] = linesWithOutliers()
     stat.description = 'Lines with outliers.';
     stat.md5 = 'ea2084452c49d1a6e0379739371b2e0a';
+    stat.issues = [392,400];
 
     far = 200;
     x = [ -far, -1,   -1,  -far, -10, -0.5, 0.5, 10,  far, 1,   1,    far, 10,   0.5, -0.5, -10,  -far ];
@@ -559,8 +560,9 @@ end
 % =========================================================================
 function [stat] = zoom()
     stat.description = ['Test function \texttt{pruneOutsideBox()} ', ...
+                        'and \texttt{movePointsCloser()} ', ...
                         'of \texttt{cleanfigure()}.'];
-    stat.issues = 226;
+    stat.issues = [226,392,400];
 
     % Setup
     subplot(311)


### PR DESCRIPTION
Existing ACID(21) `pruneOutsideBox()` is fixed and ACID(7) `linesWithOutliers` keeps working:
![image](https://cloud.githubusercontent.com/assets/4340267/6379445/a040d85c-bd32-11e4-8669-a9919817748a.png)
![image](https://cloud.githubusercontent.com/assets/4340267/6379478/ee80e0b6-bd32-11e4-8216-777a25737483.png)

Fixes issues #392 and #400.

**edit:** Thanks go to @akloeckner for providing the missing real fix (PR #547). I incorporated it here, since I added quite some comments and restructured the code a little bit.