### PR TITLE
Annotations HG2

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2766,22 +2766,22 @@ function [m2t,posString] = getPositionOfText(m2t, h)
     end
 end
 % ==============================================================================
-function [m2t, str] = drawRectangle(m2t, handle)
+function [m2t, str] = drawRectangle(m2t, h)
     str = '';
 
     % there may be some text objects floating around a Matlab figure which
     % are handled by other subfunctions (labels etc.) or don't need to be
     % handled at all
-    if     strcmp(get(handle, 'Visible'), 'off') ...
-            || strcmp(get(handle, 'HandleVisibility'), 'off')
+    if ~isVisible(h) ||...
+            strcmp(get(h, 'HandleVisibility'), 'off')
         return;
     end
 
     % TODO handle Curvature = [0.8 0.4]
 
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    lineStyle = get(handle, 'LineStyle');
-    lineWidth = get(handle, 'LineWidth');
+    lineStyle = get(h, 'LineStyle');
+    lineWidth = get(h, 'LineWidth');
     if isNone(lineStyle) || lineWidth==0
         return
     end
@@ -2791,22 +2791,24 @@ function [m2t, str] = drawRectangle(m2t, handle)
 
     colorOptions = cell(0);
     % fill color
-    faceColor  = get(handle, 'FaceColor');
-    if ~isNone(faceColor)
-        [m2t, xFaceColor] = getColor(m2t, handle, faceColor, 'patch');
+    faceColor  = get(h, 'FaceColor');
+    isFlatAnnotation = strcmpi(class(handle(h)),'scribe.scriberect') &&...
+                       strcmpi(faceColor, 'flat');
+    if ~(isNone(faceColor) || isFlatAnnotation)
+        [m2t, xFaceColor] = getColor(m2t, h, faceColor, 'patch');
         colorOptions{end+1} = sprintf('fill=%s', xFaceColor);
     end
     % draw color
-    edgeColor = get(handle, 'EdgeColor');
-    lineStyle = get(handle, 'LineStyle');
+    edgeColor = get(h, 'EdgeColor');
+    lineStyle = get(h, 'LineStyle');
     if isNone(lineStyle) || isNone(edgeColor)
         colorOptions{end+1} = 'draw=none';
     else
-        [m2t, xEdgeColor] = getColor(m2t, handle, edgeColor, 'patch');
+        [m2t, xEdgeColor] = getColor(m2t, h, edgeColor, 'patch');
         colorOptions{end+1} = sprintf('draw=%s', xEdgeColor);
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    pos = pos2dims(get(handle, 'Position'));
+    pos = pos2dims(get(h, 'Position'));
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     drawOptions = [lineOptions, colorOptions];
     % plot the thing

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2814,7 +2814,7 @@ function [m2t, str] = drawRectangle(m2t, h)
     colorOptions = cell(0);
     % fill color
     faceColor    = get(h, 'FaceColor');
-    isAnnotation = strcmp(get(h,'type'),'rectangleshape') || strcmp(get(h,'ShapeType'),'rectangle');
+    isAnnotation = strcmp(get(h,'type'),'rectangleshape') || strcmp(getOrDefault(h,'ShapeType',''),'rectangle');
     isFlatColor  = strcmp(faceColor, 'flat');
     if ~(isNone(faceColor) || (isAnnotation && isFlatColor))
         [m2t, xFaceColor] = getColor(m2t, h, faceColor, 'patch');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2389,10 +2389,6 @@ function m2t = drawAnnotations(m2t)
         return
     end
 
-    % Create fake simplified axes overlay
-    scribeLayer = axes('Units','Normalized','Position',[0,0,1,1],'Visible','off');
-    m2t         = drawAxes(m2t, scribeLayer);
-
     % Get annotation handles
     if isHG2(m2t)
         annotPanes   = findobj(m2t.currentHandles.gcf,'Tag','scribeOverlay');
@@ -2400,7 +2396,18 @@ function m2t = drawAnnotations(m2t)
     else
         annotHandles = findobj(m2t.scribeLayer,'-depth',1,'Visible','on');
     end
-
+    
+    % There are no anotations
+    if isempty(annotHandles)
+        return
+    end
+    
+    % Create fake simplified axes overlay (no children)
+    warning('off', 'matlab2tikz:NoChildren')
+    scribeLayer = axes('Units','Normalized','Position',[0,0,1,1],'Visible','off');
+    m2t         = drawAxes(m2t, scribeLayer);
+    warning('on', 'matlab2tikz:NoChildren')
+    
     % Plot in reverse to preserve z-ordering and assign the converted 
     % annotations to the converted fake overlay
     for ii = numel(annotHandles):-1:1

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -629,11 +629,11 @@ function addCustomCode(fid, before, code, after)
     end
 end
 % ==============================================================================
-function [m2t, pgfEnvironments] = handleAllChildren(m2t, handle)
+function [m2t, pgfEnvironments] = handleAllChildren(m2t, h)
 % Draw all children of a graphics object (if they need to be drawn).
 % #COMPLEX: mainly a switch-case
     str = '';
-    children = get(handle, 'Children');
+    children = get(h, 'Children');
 
     % prepare cell array of pgfEnvironments
     pgfEnvironments = cell(0);
@@ -696,7 +696,7 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, handle)
             case ''
                 warning('matlab2tikz:NoChildren',...
                         ['No children found for handle %d. ',...
-                         'Carrying on as if nothing happened'], handle);
+                         'Carrying on as if nothing happened'], double(h));
 
             otherwise
                 error('matlab2tikz:handleAllChildren',                 ...

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2459,9 +2459,9 @@ function m2t = drawAnnotationsHelper(m2t,h)
     m2t.axesContainers{end} = addChildren(m2t.axesContainers{end}, str);
 end
 % ==============================================================================
-function [m2t,env] = drawSurface(m2t, handle)
+function [m2t,str] = drawSurface(m2t, h)
 
-    [m2t, opts, s] = shaderOpts(m2t, handle,'surf');
+    [m2t, opts, s] = shaderOpts(m2t, h,'surf');
 
     % Allow for empty surf
     if isNone(s.plotType)
@@ -2469,9 +2469,9 @@ function [m2t,env] = drawSurface(m2t, handle)
         return
     end
 
-    dx = get(handle, 'XData');
-    dy = get(handle, 'YData');
-    dz = get(handle, 'ZData');
+    dx = get(h, 'XData');
+    dy = get(h, 'YData');
+    dz = get(h, 'ZData');
     if any(~isfinite(dx(:))) || any(~isfinite(dy(:))) || any(~isfinite(dz(:)))
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, ...
@@ -2500,7 +2500,7 @@ function [m2t,env] = drawSurface(m2t, handle)
     % - hist3D plots should not be z-sorted or the highest bars will cover
     %   the shortest one even if positioned in the back
     isShaderFlat = isempty(strfind(opts_get(opts, 'shader'),'interp'));
-    isHist3D     = strcmpi(get(handle,'tag'),'hist3');
+    isHist3D     = strcmpi(get(h,'tag'),'hist3');
     is3D         = m2t.axesContainers{end}.is3D;
     if is3D && isShaderFlat && ~isHist3D
         opts = opts_add(opts, 'z buffer','sort');
@@ -2524,8 +2524,8 @@ function [m2t,env] = drawSurface(m2t, handle)
     %    * implicitly through a color map with a given coordinate (e.g., z).
     %
 
-    % Check if we need extra CData
-    CData = get(handle, 'CData');
+    % Check if we need extra CData.
+    CData = get(h, 'CData');
     if length(size(CData)) == 3 && size(CData, 3) == 3
         
         % Create additional custom colormap

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2435,11 +2435,18 @@ function m2t = drawAnnotationsHelper(m2t,h)
         % Ellipse
         case {'scribe.scribeellipse','matlab.graphics.shape.Ellipse'}
             [m2t, str] = drawEllipse(m2t, h);
-
+        
+        % Arrows 
         case {'scribe.arrow', 'scribe.doublearrow',...
               'matlab.graphics.shape.Arrow', 'matlab.graphics.shape.DoubleEndArrow'}
             % Annotation: single and double Arrow, line
-            % These annotations are fully represented by their children
+            % TODO: 
+            % - write a drawArrow(). Handle all info info directly
+            %   without using handleAllChildren() since HG2 does not have
+            %   children (so no shortcut). 
+            % - It would be good if drawArrow() was callable on a 
+            %   matlab.graphics.shape.TextArrow object to draw the arrow 
+            %   part.
             [m2t, str] = handleAllChildren(m2t, h);
 
         % Text box
@@ -2449,8 +2456,9 @@ function m2t = drawAnnotationsHelper(m2t,h)
         % Tetx arrow
         case {'scribe.textarrow'}%,'matlab.graphics.shape.TextArrow'}
             % TODO: rewrite drawTextarrow. Handle all info info directly
-            % without using handleAllChildren() since HG2 does not have
-            % children (so no shortcut) as used for scribe.textarrow.
+            %       without using handleAllChildren() since HG2 does not 
+            %       have children (so no shortcut) as used for 
+            %       scribe.textarrow.
             [m2t, str] = drawTextarrow(m2t, h);
 
         % Rectangle

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2437,8 +2437,8 @@ function m2t = drawAnnotationsHelper(m2t,h)
             [m2t, str] = drawEllipse(m2t, h);
         
         % Arrows 
-        case {'scribe.arrow', 'scribe.doublearrow',...
-              'matlab.graphics.shape.Arrow', 'matlab.graphics.shape.DoubleEndArrow'}
+        case {'scribe.arrow', 'scribe.doublearrow'}%,...
+              %'matlab.graphics.shape.Arrow', 'matlab.graphics.shape.DoubleEndArrow'}
             % Annotation: single and double Arrow, line
             % TODO: 
             % - write a drawArrow(). Handle all info info directly
@@ -2813,10 +2813,10 @@ function [m2t, str] = drawRectangle(m2t, h)
 
     colorOptions = cell(0);
     % fill color
-    faceColor  = get(h, 'FaceColor');
-    isFlatAnnotation = strcmpi(class(handle(h)),'scribe.scriberect') &&...
-                       strcmpi(faceColor, 'flat');
-    if ~(isNone(faceColor) || isFlatAnnotation)
+    faceColor    = get(h, 'FaceColor');
+    isAnnotation = strcmp(get(h,'type'),'rectangleshape') || strcmp(get(h,'ShapeType'),'rectangle');
+    isFlatColor  = strcmp(faceColor, 'flat');
+    if ~(isNone(faceColor) || (isAnnotation && isFlatColor))
         [m2t, xFaceColor] = getColor(m2t, h, faceColor, 'patch');
         colorOptions{end+1} = sprintf('fill=%s', xFaceColor);
     end

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -121,9 +121,8 @@ function [status] = ACID(k)
                            @multiplePatches     , ...
                            @logbaseline         , ...
                            @alphaImage          , ...
-                           @annotation1         , ...
-                           @annotation2         , ...
-                           @annotation3         , ...
+                           @annotationAll       , ...
+                           @annotationSubplots  , ...
                            @annotationText      , ...
                            @annotationTextUnits , ...
                            @imageOrientation_PNG, ...
@@ -1971,57 +1970,50 @@ function [stat] = alphaImage()
   set(gca, 'ALim', [-1,1]);
 end
 % =========================================================================
-function [stat] = annotation1()
-
-  stat.description = 'Annotations only';
-
-  if ~exist('annotation')
-    fprintf( 'annotation() not found. Skipping.\n\n' );
-    stat.skip = true;
-    return;
-  end
-
-  annotation(gcf,'arrow',[0.192857142857143 0.55],...
-    [0.729952380952381 0.433333333333333]);
-
-  annotation(gcf,'ellipse',...
-    [0.538499999999999 0.240476190476191 0.157928571428572 0.2452380952381]);
-
-  annotation(gcf,'textbox',...
-    [0.3 0.348251748251748 0.0328486806677437 0.0517482517482517],...
-    'String',{'y-x'},...
-    'FontSize',16);
-end
-% =========================================================================
-function [stat] = annotation2()
-  stat.description = 'Annotations over plot';
+function stat = annotationAll()
+  stat.description = 'All possible annotations with edited properties';
 
   if ~exist('annotation')
-    fprintf( 'annotation() not found. Skipping.\n\n' );
-    stat.skip = true;
-    return;
+      fprintf( 'annotation() not found. Skipping.\n\n' );
+      stat.skip = true;
+      return;
   end
 
-  axes1 = axes('Parent',gcf);
-  hold(axes1,'all');
+  % Create plot
+  X1 = -5:0.1:5;
+  plot(X1,log(X1.^2+1));
 
-  plot(0:pi/20:2*pi,sin(0:pi/20:2*pi))
+  % Create line
+  annotation('line',[0.21 0.26], [0.63 0.76], 'Color',[0.47 0.3 0.44],...
+             'LineWidth',4, 'LineStyle',':');
 
-  annotation(gcf,'arrow',[0.192857142857143 0.55],...
-    [0.729952380952381 0.433333333333333]);
+  % Create arrow
+  annotation('arrow',[0.25 0.22], [0.96 0.05], 'LineStyle','-.',...
+             'HeadStyle','cback2');
 
-  annotation(gcf,'ellipse',...
-    [0.538499999999999 0.240476190476191 0.157928571428572 0.2452380952381]);
+  % Create textarrow
+  annotation('textarrow',[0.46 0.35], [0.41 0.50],...
+             'Color',[0.92 0.69 0.12], 'TextBackgroundColor',[0.92 0.83 0.83],...
+             'String',{'something'}, 'LineWidth',2, 'FontWeight','bold',...
+             'FontSize',20, 'FontName','Helvetica');
 
-  annotation(gcf,'textbox',...
-    [0.3 0.348251748251748 0.0328486806677437 0.0517482517482517],...
-    'String',{'y-x'},...
-    'FontSize',16,...
-    'FitBoxToText','off',...
-    'LineStyle','none');
+  % Create doublearrow
+  annotation('doublearrow',[0.33 0.7], [0.56 0.55]);
+
+  % Create textbox
+  annotation('textbox', [0.41 0.69 0.17 0.10], 'String',{'something'},...
+             'FitBoxToText','off');
+
+  % Create ellipse
+  annotation('ellipse',  [0.70 0.44 0.15 0.51], 'Color',[0.63 0.07 0.18],...
+            'LineWidth',3, 'FaceColor',[0.80 0.87 0.96]);
+
+  % Create rectangle
+  annotation('rectangle', [0.3 0.26 0.53 0.58], 'LineWidth',8,...
+             'LineStyle',':');
 end
 % =========================================================================
-function [stat] = annotation3()
+function [stat] = annotationSubplots()
   stat.description = 'Annotated and unaligned subplots';
 
   if ~exist('annotation')


### PR DESCRIPTION
Introducing annotations for HG2 with some work left to do (not in this PR).
Also, re-organized a bit the annotations tests inside ACID, to include all possible annotations.

TODO (will submit as feature request but listing here to keep in mind):
* write a `drawArrow()` to handle (both) arrow annotations. Handle all info info directly without using `handleAllChildren()` since in HG2 arrow annotations have no children (so no shortcut as used in R2014a). 
It would be good if `drawArrow()` was callable on a `matlab.graphics.shape.TextArrow` object to draw the arrow part.
* rewrite drawTextarrow. Handle all info info directly without using `handleAllChildren()` for same reason as above. 