### PR TITLE
Use dummy in place of ~ in out

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3208,7 +3208,7 @@ function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
     if isHG2(m2t)
         bargroup = bargroup(end:-1:1);
     end
-    [~, barSeriesId] = ismember(handle(h), bargroup);
+    [dummy, barSeriesId] = ismember(handle(h), bargroup); %#ok
 end
 % ==============================================================================
 function [m2t, drawOptions] = getFaceColorOfBar(m2t, h, drawOptions)
@@ -5321,7 +5321,7 @@ function string = parseTexSubstring(m2t, string)
     end
 
     % Replace Fontnames
-    [~, ~, ~, ~, fonts, ~, subStrings] = regexp(string, '\\fontname{(\w*)}');
+    [dummy, dummy, dummy, dummy, fonts, dummy, subStrings] = regexp(string, '\\fontname{(\w*)}'); %#ok
     fonts = fonts2tex(fonts);
     subStrings = [subStrings; fonts, {''}];
     string = cell2mat(subStrings(:)');


### PR DESCRIPTION
Improve backwards compatibility in Matlab up to 2008a (ACID compiles). 