### PR TITLE
Use `onCleanup` to close all files

### DIFF
--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -35,6 +35,7 @@ function figure2dot(filename)
   set(0, 'ShowHiddenHandles', 'on');
 
   filehandle = fopen(filename, 'w');
+  fclose_filehandle = onCleanup(@() fclose(filehandle));
 
   % start printing
   fprintf(filehandle, 'digraph simple_hierarchy {\n\n');
@@ -53,7 +54,6 @@ function figure2dot(filename)
 
   % finish off
   fprintf(filehandle, '}');
-  fclose(filehandle);
   set(0, 'ShowHiddenHandles', 'off');
 
 end

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -35,7 +35,7 @@ function figure2dot(filename)
   set(0, 'ShowHiddenHandles', 'on');
 
   filehandle = fopen(filename, 'w');
-  fclose_filehandle = onCleanup(@() fclose(filehandle));
+  finally_fclose_filehandle = onCleanup(@() fclose(filehandle));
 
   % start printing
   fprintf(filehandle, 'digraph simple_hierarchy {\n\n');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -492,13 +492,13 @@ function m2t = saveToFile(m2t, fid, fileWasOpen)
 
     m2t.content.colors = generateColorDefinitions(m2t.extraRgbColorNames, ...
                             m2t.extraRgbColorSpecs, m2t.colorFormat);
-    
+
     % Open file if was not open
     if ~fileWasOpen
         fid = fileOpenForWrite(m2t, m2t.tikzFileName);
-        fclose_fid = onCleanup(@() fclose(fid));
+        finally_fclose_fid = onCleanup(@() fclose(fid));
     end
-                        
+
     % Finally print it to the file
     addComments(fid, m2t.content.comment);
     addStandalone(m2t, fid, 'preamble');
@@ -4560,8 +4560,8 @@ function [m2t, table, opts] = makeTable(m2t, varargin)
 
         % write the data table to an external file
         fid = fileOpenForWrite(m2t, filename);
-        fclose_fid = onCleanup(@() fclose(fid));
-        
+        finally_fclose_fid = onCleanup(@() fclose(fid));
+
         fprintf(fid, '%s', table);
 
         % put the filename in the TikZ output

--- a/test/makeLatexReport.m
+++ b/test/makeLatexReport.m
@@ -4,6 +4,8 @@ function makeLatexReport(status)
     % first, initialize the tex output
     texfile = 'tex/acid.tex';
     fh = fopen(texfile, 'w');
+    fclose_fh = onCleanup(@() fclose(fh));
+    
     assert(fh ~= -1, 'Could not open TeX file ''%s'' for writing.', texfile);
     texfile_init(fh);
 
@@ -61,9 +63,7 @@ function makeLatexReport(status)
         fprintf(fh, '\n\\normalsize\n\n');
     end
 
-    % now, finish off the file and close file and window
     texfile_finish(fh, status);
-    fclose(fh);
 end
 % =========================================================================
 function texfile_init(texfile_handle)

--- a/test/makeLatexReport.m
+++ b/test/makeLatexReport.m
@@ -4,8 +4,8 @@ function makeLatexReport(status)
     % first, initialize the tex output
     texfile = 'tex/acid.tex';
     fh = fopen(texfile, 'w');
-    fclose_fh = onCleanup(@() fclose(fh));
-    
+    finally_fclose_fh = onCleanup(@() fclose(fh));
+
     assert(fh ~= -1, 'Could not open TeX file ''%s'' for writing.', texfile);
     texfile_init(fh);
 

--- a/test/private/VersionControlIdentifier.m
+++ b/test/private/VersionControlIdentifier.m
@@ -15,8 +15,8 @@ function [formatted,treeish] = VersionControlIdentifier()
     treeish     = [REFPREFIX 'HEAD'];
     try
         % get the matlab2tikz directory
-        m2tDir = fileparts(mfilename('fullpath'));
-        gitDir = fullfile(m2tDir,'..','.git');
+        privateDir = fileparts(mfilename('fullpath'));
+        gitDir = fullfile(privateDir,'..','..','.git');
 
         nIter = 1;
         while isReference(treeish)

--- a/test/private/VersionControlIdentifier.m
+++ b/test/private/VersionControlIdentifier.m
@@ -24,6 +24,10 @@ function [formatted,treeish] = VersionControlIdentifier()
             branchFile = fullfile(gitDir, refName);
 
             if exist(branchFile, 'file') && nIter < MAXITER
+                % The FID is reused in every iteration, so `onCleanup` cannot
+                % be used to `fclose(fid)`. But since there is very little that
+                % can go wrong in a single `fscanf`, it's probably best to leave
+                % this part as it is for the time being.
                 fid     = fopen(branchFile,'r');
                 treeish = fscanf(fid,'%s');
                 fclose(fid);

--- a/test/private/execute_save_stage.m
+++ b/test/private/execute_save_stage.m
@@ -40,6 +40,7 @@ function fixLineEndingsInWindows(filename)
 %  * http://tex.stackexchange.com/questions/208179
     if ispc
         fid = fopen(filename,'r+');
+        fclose_fid = onCleanup(@() fclose(fid));
         testline = fgets(fid);
         CRLF = sprintf('\r\n');
         endOfLine = testline(end-1:end);
@@ -55,6 +56,5 @@ function fixLineEndingsInWindows(filename)
             fseek(fid,0,'bof');
             fprintf(fid,'%s',str);
         end
-        fclose(fid);
     end
 end

--- a/test/private/execute_save_stage.m
+++ b/test/private/execute_save_stage.m
@@ -40,7 +40,7 @@ function fixLineEndingsInWindows(filename)
 %  * http://tex.stackexchange.com/questions/208179
     if ispc
         fid = fopen(filename,'r+');
-        fclose_fid = onCleanup(@() fclose(fid));
+        finally_fclose_fid = onCleanup(@() fclose(fid));
         testline = fgets(fid);
         CRLF = sprintf('\r\n');
         endOfLine = testline(end-1:end);

--- a/test/private/loadHashTable.m
+++ b/test/private/loadHashTable.m
@@ -5,8 +5,8 @@ function hashTable = loadHashTable(suite)
     filename = hashTableName(suite);
     if exist(filename, 'file')
         fid = fopen(filename, 'r');
-        fclose_fid = onCleanup(@() fclose(fid));
-        
+        finally_fclose_fid = onCleanup(@() fclose(fid));
+
         data = textscan(fid, '%s : %s');
         if ~isempty(data) && ~all(cellfun(@isempty, data))
             functions = cellfun(@strtrim, data{1},'UniformOutput', false);

--- a/test/private/loadHashTable.m
+++ b/test/private/loadHashTable.m
@@ -5,8 +5,9 @@ function hashTable = loadHashTable(suite)
     filename = hashTableName(suite);
     if exist(filename, 'file')
         fid = fopen(filename, 'r');
+        fclose_fid = onCleanup(@() fclose(fid));
+        
         data = textscan(fid, '%s : %s');
-        fclose(fid);
         if ~isempty(data) && ~all(cellfun(@isempty, data))
             functions = cellfun(@strtrim, data{1},'UniformOutput', false);
             hashes    = cellfun(@strtrim, data{2},'UniformOutput', false);

--- a/test/saveHashTable.m
+++ b/test/saveHashTable.m
@@ -18,8 +18,8 @@ function saveHashTable(status)
 
     % write to file
     fid = fopen(filename,'w+');
-    fclose_fid = onCleanup(@() fclose(fid));
-    
+    finally_fclose_fid = onCleanup(@() fclose(fid));
+
     for iFunc = 1:numel(status)
         S = status{iFunc};
         thisFunc = S.function;

--- a/test/saveHashTable.m
+++ b/test/saveHashTable.m
@@ -18,6 +18,8 @@ function saveHashTable(status)
 
     % write to file
     fid = fopen(filename,'w+');
+    fclose_fid = onCleanup(@() fclose(fid));
+    
     for iFunc = 1:numel(status)
         S = status{iFunc};
         thisFunc = S.function;
@@ -32,5 +34,4 @@ function saveHashTable(status)
             fprintf(fid, '%s : %s\n', thisFunc, thisHash);
         end
     end
-    fclose(fid);
 end


### PR DESCRIPTION
Some `try-catch` constructions -- that rethrew the error AFTER `fclose(fid)` --
were also removed, since these were no longer needed.

This will close #508 when merged.