### PR TITLE
Fix transparency

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2095,7 +2095,7 @@ function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
             hX = (xData(end)-xData(1)) / (length(xData)-1);
         otherwise
             error('drawImage:arrayLengthMismatch', ...
-                'Array lengths not matching (%d = size(cdata,1) ~= length(xData) = %d).', m, length(xData));
+                'Array lengths not matching (%d = size(cdata,1) ~= length(xData) = %d).', size(cData,1), length(xData));
     end
     X = xData(1):hX:xData(end);
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2023,8 +2023,10 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
     [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData);
     
     % Write an indexed or a truecolor image
+    hasAlpha = true;
     if isfloat(alphaData) && all(alphaData(:) == 1)
         alphaOpts = {};
+        hasAlpha = false;
     else
         alphaOpts = {'Alpha', alphaData};
     end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4072,7 +4072,7 @@ function [m2t, xcolor] = getColor(m2t, handle, color, mode)
                             xcolor{i, j} = xc;
                         end
                     end
-                else
+                elseif ndims(color) <= 2
                     [m2t, colorindex] = cdata2colorindex(m2t, color, handle);
                     for i = 1:m
                         for j = 1:n
@@ -4080,6 +4080,9 @@ function [m2t, xcolor] = getColor(m2t, handle, color, mode)
                             xcolor{i, j} = xc;
                         end
                     end
+                else
+                    error('matlab2tikz:getColor:image:colorDims',...
+                        'Image color data cannot have more than 3 dimensions');
                 end
             otherwise
                 error(['matlab2tikz:getColor', ...

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1988,10 +1988,6 @@ function [m2t, str] = drawImage(m2t, handle)
     yData = get(handle, 'YData');
     cData = get(handle, 'CData');
 
-    % Flip the image over as the PNG gets written starting at (0,0),
-    % which is the top left corner.
-    %cData = cData(end:-1:1,:,:);
-
     if (m2t.cmdOpts.Results.imagesAsPng)
         [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData);
     else

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2015,23 +2015,17 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
 
     m = size(cData, 1);
     n = size(cData, 2);
-    
-    [colorData,flippedDim] = flipImageIfAxesReversed(m2t, colorData);
+
+    alphaData = normalizedAlphaValues(m2t, get(handle,'AlphaData'), handle);
+    if numel(alphaData)==1
+        alphaData = alphaData(ones(size(colorData(:,:,1))));
+    end
+    [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData);
     
     % Write an indexed or a truecolor image
-    alpha = normalizedAlphaValues(m2t, get(handle,'AlphaData'), handle);
-    if flippedDim(1)
-        alpha=alpha(end:-1:1,:);
-    end
-    if flippedDim(2)
-        alpha=alpha(:,end:-1:1);
-    end
-    if numel(alpha)==1
-        alpha = alpha(ones(size(colorData(:,:,1))));
-    end
-    hasAlpha = ~all(alpha(:)==1);
+    hasAlpha = ~all(alphaData(:)==1);
     if hasAlpha
-        alphaOpts = {'Alpha', alpha};
+        alphaOpts = {'Alpha', alphaData};
     else
         alphaOpts = {};
     end
@@ -2138,16 +2132,15 @@ function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
     end
 end
 % ==============================================================================
-function [colorData,flippedDim] = flipImageIfAxesReversed(m2t, colorData)
+function [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData)
 % flip the image if reversed
-flippedDim=[false,false];
     if m2t.xAxisReversed
         colorData = colorData(:, end:-1:1, :);
-        flippedDim(2)=true;
+        alphaData = alphaData(:, end:-1:1);
     end
     if ~m2t.yAxisReversed % y-axis direction is revesed normally for images, flip otherwise
         colorData = colorData(end:-1:1, :, :);
-        flippedDim(1)=true;
+        alphaData = alphaData(end:-1:1, :);
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1991,7 +1991,7 @@ function [m2t, str] = drawImage(m2t, handle)
     if (m2t.cmdOpts.Results.imagesAsPng)
         [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData);
     else
-        [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData);
+        [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData(end:-1:1,:));
     end
 
     % Make sure that the axes are still visible above the image.

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1990,7 +1990,7 @@ function [m2t, str] = drawImage(m2t, handle)
 
     % Flip the image over as the PNG gets written starting at (0,0),
     % which is the top left corner.
-    cData = cData(end:-1:1,:,:);
+    %cData = cData(end:-1:1,:,:);
 
     if (m2t.cmdOpts.Results.imagesAsPng)
         [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData);
@@ -2019,11 +2019,17 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
 
     m = size(cData, 1);
     n = size(cData, 2);
-
-    colorData = flipImageIfAxesReversed(m2t, colorData);
-
+    
+    [colorData,flippedDim] = flipImageIfAxesReversed(m2t, colorData);
+    
     % Write an indexed or a truecolor image
     alpha = normalizedAlphaValues(m2t, get(handle,'AlphaData'), handle);
+    if flippedDim(1)
+        alpha=alpha(end:-1:1,:);
+    end
+    if flippedDim(2)
+        alpha=alpha(:,end:-1:1);
+    end
     if numel(alpha)==1
         alpha = alpha(ones(size(colorData(:,:,1))));
     end
@@ -2128,13 +2134,16 @@ function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
     end
 end
 % ==============================================================================
-function [colorData] = flipImageIfAxesReversed(m2t, colorData)
+function [colorData,flippedDim] = flipImageIfAxesReversed(m2t, colorData)
 % flip the image if reversed
+flippedDim=[false,false];
     if m2t.xAxisReversed
         colorData = colorData(:, end:-1:1, :);
+        flippedDim(2)=true;
     end
-    if m2t.yAxisReversed
+    if ~m2t.yAxisReversed % y-axis direction is revesed normally for images, flip otherwise
         colorData = colorData(end:-1:1, :, :);
+        flippedDim(1)=true;
     end
 end
 % ==============================================================================
@@ -2156,7 +2165,10 @@ function alpha = normalizedAlphaValues(m2t, alpha, handle)
             error('matlab2tikz:UnknownAlphaMapping', ...
                   'Unknown alpha mapping "%s"', alphaMapping);
     end
-    alpha = min(1,max(alpha,0)); % clip at range [0, 1]
+    
+    if isfloat(alpha) %important, alpha data can have integer type which should not be scaled
+        alpha = min(1,max(alpha,0)); % clip at range [0, 1]
+    end
 end
 % ==============================================================================
 function [m2t, str] = drawContour(m2t, h)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1991,7 +1991,7 @@ function [m2t, str] = drawImage(m2t, handle)
     if (m2t.cmdOpts.Results.imagesAsPng)
         [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData);
     else
-        [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData(end:-1:1,:));
+        [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData);
     end
 
     % Make sure that the axes are still visible above the image.
@@ -2082,6 +2082,14 @@ end
 function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
 % writes an image as raw TikZ commands (STRONGLY DISCOURAGED)
     str = '';
+    
+    % set up cData
+    if ndims(cData) == 3
+        cData = cData(end:-1:1,:,:);
+    else
+        cData = cData(end:-1:1,:);
+    end
+    
 
     % Generate uniformly distributed X, Y, although xData and yData may be
     % non-uniform.

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4066,14 +4066,25 @@ function [m2t, xcolor] = getColor(m2t, handle, color, mode)
             case 'patch'
                 [m2t, xcolor] = patchcolor2xcolor(m2t, color, handle);
             case 'image'
-                [m2t, colorindex] = cdata2colorindex(m2t, color, handle);
-                m = size(colorindex, 1);
-                n = size(colorindex, 2);
+                
+                m = size(color,1);
+                n = size(color,2);
                 xcolor = cell(m, n);
-                for i = 1:m
-                    for j = 1:n
-                        [m2t, xc] = rgb2colorliteral(m2t, m2t.currentHandles.colormap(colorindex(i,j), :));
-                        xcolor{i, j} = xc;
+                
+                if ndims(color) == 3
+                    for i = 1:m
+                        for j = 1:n
+                            [m2t, xc] = rgb2colorliteral(m2t, color(i,j, :));
+                            xcolor{i, j} = xc;
+                        end
+                    end
+                else
+                    [m2t, colorindex] = cdata2colorindex(m2t, color, handle);
+                    for i = 1:m
+                        for j = 1:n
+                            [m2t, xc] = rgb2colorliteral(m2t, m2t.currentHandles.colormap(colorindex(i,j), :));
+                            xcolor{i, j} = xc;
+                        end
                     end
                 end
             otherwise

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2017,13 +2017,13 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
     n = size(cData, 2);
 
     alphaData = normalizedAlphaValues(m2t, get(handle,'AlphaData'), handle);
-    if numel(alphaData)==1
+    if numel(alphaData) == 1
         alphaData = alphaData(ones(size(colorData(:,:,1))));
     end
     [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData);
     
     % Write an indexed or a truecolor image
-    hasAlpha = ~all(alphaData(:)==1);
+    hasAlpha = ~all(alphaData(:) == 1);
     if hasAlpha
         alphaOpts = {'Alpha', alphaData};
     else

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2023,11 +2023,10 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
     [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData);
     
     % Write an indexed or a truecolor image
-    hasAlpha = ~all(alphaData(:) == 1);
-    if hasAlpha
-        alphaOpts = {'Alpha', alphaData};
-    else
+    if isfloat(alphaData) && all(alphaData(:) == 1)
         alphaOpts = {};
+    else
+        alphaOpts = {'Alpha', alphaData};
     end
     if (ndims(colorData) == 2) %#ok don't use ismatrix (cfr. #143)
         if size(m2t.currentHandles.colormap, 1) <= 256 && ~hasAlpha


### PR DESCRIPTION
Fixes two bugs related to the handling of transparent images: 

1. alpha data needs to be flipped along with color data if axis direction is reversed

2. integer alpha data should not be clipped to [0,1]

Here is a small example to illustrate the problems:

```matlab
figure;
line([0.5,2.5],[0.5,2.5],'linewidth',2,'color','k');
line([0.5,2.5],[2.5,0.5],'linewidth',2,'color','k');
hold on
imagesc([0,1;2,3],'AlphaData',uint8([64,128;192,256]))
```

This is what the output should look like in Matlab:
![test_matlab](https://cloud.githubusercontent.com/assets/7434177/6462807/730e1130-c1a4-11e4-94e4-5f09a0883a34.png)

This is what the tikz ouput looks like before the fix:
![test_old](https://cloud.githubusercontent.com/assets/7434177/6462835/ab7aeca0-c1a4-11e4-8eb0-c5951fce5f81.png)
(rendering may vary depending on pdf reader)

and after:
![test_fixed](https://cloud.githubusercontent.com/assets/7434177/6462866/cd5db7f8-c1a4-11e4-9b18-f657b0e8840d.png)

