### PR TITLE
Refactor environment

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -464,7 +464,7 @@ function m2t = saveToFile(m2t, fid, fileWasOpen)
     set(0, 'ShowHiddenHandles', 'off');
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % actually print the stuff
-    minimalPgfplotsVersion = formatPgfplotsVersion(m2t, m2t.pgfplotsVersion);
+    minimalPgfplotsVersion = formatPgfplotsVersion(m2t.pgfplotsVersion);
 
     m2t.content.comment = sprintf('This file was created by %s.\n', m2t.name);
 
@@ -5933,7 +5933,7 @@ function m2t = needsPgfplotsVersion(m2t, minVersion)
     end
 end
 % ==============================================================================
-function str = formatPgfplotsVersion(m2t, version)
+function str = formatPgfplotsVersion(version)
     version = versionArray(version);
     if all(isfinite(version))
         str = sprintf('%d.',version);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5808,20 +5808,30 @@ function str  = opts_print(m2t, opts, sep)
     str = join(m2t, c, sep);
 end
 % ==============================================================================
-function [env,versionString] = getEnvironment()
+function [env, versionString] = getEnvironment()
 % Checks if we are in MATLAB or Octave.
-    alternatives = {'MATLAB','Octave'};
-    for iCase = 1:numel(alternatives)
-        env   = alternatives{iCase};
-        vData = ver(env);
-        if ~isempty(vData)
-            versionString = vData.Version;
-            return; % found the right environment
+    persistent cache
+    
+    alternatives = {'MATLAB', 'Octave'};
+    if isempty(cache)
+        for iCase = 1:numel(alternatives)
+            env   = alternatives{iCase};
+            vData = ver(env);
+            if ~isempty(vData) % found the right environment
+                versionString = vData.Version;
+                % store in cache
+                cache.env = env;
+                cache.versionString = versionString;
+                return;
+            end
         end
-    end
-    % otherwise:
-    env = '';
-    versionString = '';
+        % fall-back values
+        env = '';
+        versionString = '';
+    else
+        env = cache.env;
+        versionString = cache.versionString;
+    end    
 end
 % ==============================================================================
 function bool = isHG2(m2t)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1541,7 +1541,7 @@ function dataCellNew = splitByArraySize(m2t, dataCell)
             % otherwise the line between two data chunks would be broken.
             % Technically, this is only needed when the plot has a line
             % connecting the points, but the additional cost when there is no
-            % line doesn't hustify the added complexity.
+            % line doesn't justify the added complexity.
             if chunkEnd~=len
                 dataCellNew{end} = [dataCellNew{end};...
                                     data{1}(chunkEnd+1,:)];

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -405,7 +405,7 @@ function bool = isColorDefinitions(colors)
 end
 % ==============================================================================
 function fid = fileOpenForWrite(m2t, filename)
-    encoding = switchMatOct(m2t, {'native', m2t.cmdOpts.Results.encoding}, {});
+    encoding = switchMatOct({'native', m2t.cmdOpts.Results.encoding}, {});
 
     fid      = fopen(filename, 'w', encoding{:});
     if fid == -1
@@ -559,7 +559,7 @@ function [m2t, axesHandles] = findPlotAxes(m2t, fh)
     % Remove all legend handles, as they are treated separately.
     if ~isempty(axesHandles)
         % TODO fix for octave
-        tagKeyword = switchMatOct(m2t, 'Tag', 'tag');
+        tagKeyword = switchMatOct('Tag', 'tag');
         % Find all legend handles. This is MATLAB-only.
         m2t.legendHandles = findobj(fh, tagKeyword, 'legend');
         m2t.legendHandles = m2t.legendHandles(:)';
@@ -569,7 +569,7 @@ function [m2t, axesHandles] = findPlotAxes(m2t, fh)
 
     % Remove all colorbar handles, as they are treated separately.
     if ~isempty(axesHandles)
-        colorbarKeyword = switchMatOct(m2t, 'Colorbar', 'colorbar');
+        colorbarKeyword = switchMatOct('Colorbar', 'colorbar');
         % Find all colorbar handles. This is MATLAB-only.
         cbarHandles = findobj(fh, tagKeyword, colorbarKeyword);
         % Octave also finds text handles here; no idea why. Filter.
@@ -3319,7 +3319,7 @@ end
 % ==============================================================================
 function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
 % Get number of bars series and bar series id
-    prop         = switchMatOct(m2t, 'BarPeers', 'bargroup');
+    prop         = switchMatOct('BarPeers', 'bargroup');
     bargroup     = get(h, prop);
     numBarSeries = numel(bargroup);
     
@@ -5233,9 +5233,9 @@ function c = prettyPrint(m2t, strings, interpreter)
                 %       would not remedy the issue -- in that case 'string' would
                 %       contain backslashes introduced by brace escaping that are
                 %       not supposed to be printable characters.
-                repl = switchMatOct(m2t, '\\{', '\{');
+                repl = switchMatOct('\\{', '\{');
                 string = regexprep(string, '(?<!\\textbackslash){', repl);
-                repl = switchMatOct(m2t, '\\}', '\}');
+                repl = switchMatOct('\\}', '\}');
                 string = regexprep(string, '(?<!\\textbackslash{)}', repl);
                 string = strrep(string, '$', '\$');
                 string = strrep(string, '%', '\%');
@@ -5626,11 +5626,11 @@ function [string] = parseStringsAsMath(m2t, string)
         string = regexprep(string, '\\text\{(\s+)}', '$1');
 
         % '<<' probably means 'much smaller than', i.e. '\ll'
-        repl = switchMatOct(m2t, '$1\\ll{}$2', '$1\ll{}$2');
+        repl = switchMatOct('$1\\ll{}$2', '$1\ll{}$2');
         string = regexprep(string, '([^<])<<([^<])', repl);
 
         % '>>' probably means 'much greater than', i.e. '\gg'
-        repl = switchMatOct(m2t, '$1\\gg{}$2', '$1\gg{}$2');
+        repl = switchMatOct('$1\\gg{}$2', '$1\gg{}$2');
         string = regexprep(string, '([^>])>>([^>])', repl);
 
         % Single letters are most likely variables and thus should be in math mode
@@ -5887,7 +5887,7 @@ function arr = versionArray(env, str)
     arr = arr(:)';
 end
 % ==============================================================================
-function [retval] = switchMatOct(m2t, matlabValue, octaveValue)
+function [retval] = switchMatOct(matlabValue, octaveValue)
 % Returns a different value for MATLAB and Octave
     switch getEnvironment
         case 'MATLAB'

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -149,11 +149,9 @@ function matlab2tikz(varargin)
 %   found on http://www.mathworks.com/matlabcentral/fileexchange/12962 .
 
 %% Check if we are in MATLAB or Octave.
-[m2t.env, m2t.envVersion] = getEnvironment();
-
 minimalVersion = struct('MATLAB', struct('name','2014a', 'num',[8 3]), ...
                         'Octave', struct('name','3.8', 'num',[3 8]));
-checkDeprecatedEnvironment(m2t, minimalVersion);
+checkDeprecatedEnvironment(minimalVersion);
 
 m2t.cmdOpts = [];
 m2t.currentHandles = [];
@@ -330,7 +328,7 @@ if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
     m2t.website, ...
     m2t.version, ...
     m2t.cmdOpts.Results.showInfo, ...
-    m2t.env...
+    getEnvironment...
     );
     % Terminate conversion if update was successful (the user is notified
     % by the updater)
@@ -468,7 +466,6 @@ function m2t = saveToFile(m2t, fid, fileWasOpen)
     % actually print the stuff
     minimalPgfplotsVersion = formatPgfplotsVersion(m2t, m2t.pgfplotsVersion);
 
-    environment = sprintf('%s %s',m2t.env, m2t.envVersion);
     m2t.content.comment = sprintf('This file was created by %s.\n', m2t.name);
 
     if m2t.cmdOpts.Results.showInfo
@@ -713,7 +710,7 @@ interpreter  = '';
 hasLegend = false;
 
 % Check if current handle is referenced in a legend.
-switch m2t.env
+switch getEnvironment
     case 'MATLAB'
         % Make sure that m2t.legendHandles is a row vector.
         for legendHandle = m2t.legendHandles(:)'
@@ -933,7 +930,7 @@ end
 function legendhandle = getAssociatedLegend(m2t, handle)
 % Check if the axis is referenced by a legend (only necessary for Octave)
     legendhandle = [];
-    switch m2t.env
+    switch getEnvironment
         case 'Octave'
             % Make sure that m2t.legendHandles is a row vector.
             for lhandle = m2t.legendHandles(:)'
@@ -1061,7 +1058,7 @@ function m2t = drawLegendOptionsOfAxes(m2t, handle)
     % This could be done better with a heuristic of finding
     % the nearest legend to a plot, which would cope with legends outside
     % plot boundaries.
-    switch m2t.env
+    switch getEnvironment
         case 'MATLAB'
             legendHandle = legend(handle);
             if ~isempty(legendHandle)
@@ -3330,7 +3327,7 @@ function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
         % In HG2, BarPeers are sorted in reverse order wrt HG1
         bargroup = bargroup(end:-1:1);
     
-    elseif strcmpi(m2t.env,'MATLAB')
+    elseif strcmpi(getEnvironment, 'MATLAB')
         % In HG1, h is a double but bargroup a graphic object. Cast h to a
         % graphic object
         h = handle(h);
@@ -4384,7 +4381,7 @@ function [lStyle] = legendEntryAlignment(m2t, handle, lStyle)
 % determines the text and picture alignment inside a legend
     textalign = '';
     pictalign = '';
-    switch m2t.env
+    switch getEnvironment()
         case 'Octave'
             % Octave allows to change the alignment of legend text and
             % pictograms using legend('left') and legend('right')
@@ -5551,7 +5548,7 @@ function string = escapeTildes(m2t, string, origstr)
 % Escape plain "~" in MATLAB and replace escaped "\~" in Octave with a proper
 % escape sequence. An un-escaped "~" produces weird output in Octave, thus
 % give a warning in that case
-    switch m2t.env
+    switch getEnvironment
         case 'MATLAB'
             string = strrep(string, '~', '\textasciitilde{}'); % or '\~{}'
         case 'Octave'
@@ -5574,7 +5571,7 @@ end
 function string = escapeAmpersands(m2t, string, origstr)
 % Escape plain "&" in MATLAB and replace it and the following character with
 % a space in Octave unless the "&" is already escaped
-    switch m2t.env
+    switch getEnvironment
         case 'MATLAB'
             string = strrep(string, '&', '\&');
         case 'Octave'
@@ -5838,8 +5835,9 @@ function bool = isHG2(m2t)
 % Checks if graphics system is HG2 (true) or HG1 (false).
 % HG1 : MATLAB up to R2014a and currently all OCTAVE versions
 % HG2 : MATLAB starting from R2014b (version 8.4)
-    bool = strcmpi(m2t.env,'MATLAB') && ...
-           ~isVersionBelow(m2t.env, m2t.envVersion, [8,4]);
+    [env, envVersion] = getEnvironment();
+    bool = strcmpi(getEnvironment,'MATLAB') && ...
+           ~isVersionBelow(env, envVersion, [8,4]);
 end
 % ==============================================================================
 function bool = isVersionBelow(env, versionA, versionB)
@@ -5901,7 +5899,7 @@ function [retval] = switchMatOct(m2t, matlabValue, octaveValue)
     end
 end
 % ==============================================================================
-function checkDeprecatedEnvironment(m2t, minimalVersions)
+function checkDeprecatedEnvironment(minimalVersions)
     [env, envVersion] = getEnvironment();
     if isfield(minimalVersions, env)
         minVersion = minimalVersions.(env);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3222,7 +3222,7 @@ function [m2t, str] = drawBarseries(m2t, h)
         case 'grouped'  % grouped bar plots
             
             % Get number of bars series and bar series id
-            [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h);
+            [numBarSeries, barSeriesId] = getNumBarAndId(h);
 
             % Maximum group width relative to the minimum distance between two
             % x-values. See <MATLAB>/toolbox/matlab/specgraph/makebars.m
@@ -3317,7 +3317,7 @@ function [m2t, str] = drawBarseries(m2t, h)
                  opts_print(m2t, tabOpts, ','), table);
 end
 % ==============================================================================
-function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
+function [numBarSeries, barSeriesId] = getNumBarAndId(h)
 % Get number of bars series and bar series id
     prop         = switchMatOct('BarPeers', 'bargroup');
     bargroup     = get(h, prop);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5837,13 +5837,13 @@ function bool = isHG2()
 % HG2 : MATLAB starting from R2014b (version 8.4)
     [env, envVersion] = getEnvironment();
     bool = strcmpi(env,'MATLAB') && ...
-           ~isVersionBelow(env, envVersion, [8,4]);
+           ~isVersionBelow(envVersion, [8,4]);
 end
 % ==============================================================================
-function bool = isVersionBelow(env, versionA, versionB)
+function bool = isVersionBelow(versionA, versionB)
 % Checks if versionA is smaller than versionB
-    vA         = versionArray(env, versionA);
-    vB         = versionArray(env, versionB);
+    vA         = versionArray(versionA);
+    vB         = versionArray(versionB);
     n          = min(length(vA), length(vB));
     deltaAB    = vA(1:n) - vB(1:n);
     difference = find(deltaAB, 1, 'first');
@@ -5868,11 +5868,11 @@ function str = formatDim(value, unit)
     end
 end
 % ==============================================================================
-function arr = versionArray(env, str)
+function arr = versionArray(str)
 % Converts a version string to an array.
     if ischar(str)
         % Translate version string from '2.62.8.1' to [2; 62; 8; 1].
-        switch env
+        switch getEnvironment
             case 'MATLAB'
                 split = regexp(str, '\.', 'split'); % compatibility MATLAB < R2013a
             case  'Octave'
@@ -5905,7 +5905,7 @@ function checkDeprecatedEnvironment(minimalVersions)
         minVersion = minimalVersions.(env);
         envWithVersion = sprintf('%s %s', env, minVersion.name);
 
-        if isVersionBelow(env, envVersion, minVersion.num)
+        if isVersionBelow(envVersion, minVersion.num)
             ID = 'matlab2tikz:deprecatedEnvironment';
 
             warningMessage = ['\n', repmat('=',1,80), '\n\n', ...
@@ -5928,13 +5928,13 @@ function errorUnknownEnvironment()
 end
 % ==============================================================================
 function m2t = needsPgfplotsVersion(m2t, minVersion)
-    if isVersionBelow(m2t, m2t.pgfplotsVersion, minVersion)
+    if isVersionBelow(m2t.pgfplotsVersion, minVersion)
         m2t.pgfplotsVersion = minVersion;
     end
 end
 % ==============================================================================
 function str = formatPgfplotsVersion(m2t, version)
-    version = versionArray(m2t, version);
+    version = versionArray(version);
     if all(isfinite(version))
         str = sprintf('%d.',version);
         str = str(1:end-1); % remove the last period

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2389,7 +2389,7 @@ function m2t = drawAnnotations(m2t)
     end
 
     % Get annotation handles
-    if isHG2(m2t)
+    if isHG2
         annotPanes   = findobj(m2t.currentHandles.gcf,'Tag','scribeOverlay');
         annotHandles = findobj(get(annotPanes,'Children'),'Visible','on'); 
     else
@@ -3323,7 +3323,7 @@ function [numBarSeries, barSeriesId] = getNumBarAndId(m2t,h)
     bargroup     = get(h, prop);
     numBarSeries = numel(bargroup);
     
-    if isHG2(m2t)
+    if isHG2
         % In HG2, BarPeers are sorted in reverse order wrt HG1
         bargroup = bargroup(end:-1:1);
     
@@ -3902,7 +3902,7 @@ function axisOptions = getColorbarOptions(m2t, handle)
                                                 cbarOptions, cbarStyleOptions);
 
     % axis label and direction
-    if isHG2(m2t)
+    if isHG2
         % VERSION: Starting from R2014b there is only one field `label`.
         % The colorbar's position determines, if it should be a x- or y-label.
 
@@ -5831,7 +5831,7 @@ function [env, versionString] = getEnvironment()
     end    
 end
 % ==============================================================================
-function bool = isHG2(m2t)
+function bool = isHG2()
 % Checks if graphics system is HG2 (true) or HG1 (false).
 % HG1 : MATLAB up to R2014a and currently all OCTAVE versions
 % HG2 : MATLAB starting from R2014b (version 8.4)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5836,7 +5836,7 @@ function bool = isHG2()
 % HG1 : MATLAB up to R2014a and currently all OCTAVE versions
 % HG2 : MATLAB starting from R2014b (version 8.4)
     [env, envVersion] = getEnvironment();
-    bool = strcmpi(getEnvironment,'MATLAB') && ...
+    bool = strcmpi(env,'MATLAB') && ...
            ~isVersionBelow(env, envVersion, [8,4]);
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2112,7 +2112,7 @@ function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
             hY = (yData(end)-yData(1)) / (length(yData)-1);
         otherwise
             error('drawImage:arrayLengthMismatch', ...
-                'Array lengths not matching (%d = size(cdata,2) ~= length(yData) = %d).', n, length(yData));
+                'Array lengths not matching (%d = size(cData,2) ~= length(yData) = %d).', size(cData,2), length(yData));
     end
     Y = yData(1):hY:yData(end);
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5891,7 +5891,7 @@ end
 % ==============================================================================
 function [retval] = switchMatOct(m2t, matlabValue, octaveValue)
 % Returns a different value for MATLAB and Octave
-    switch m2t.env
+    switch getEnvironment()
         case 'MATLAB'
             retval = matlabValue;
         case 'Octave'
@@ -5902,11 +5902,12 @@ function [retval] = switchMatOct(m2t, matlabValue, octaveValue)
 end
 % ==============================================================================
 function checkDeprecatedEnvironment(m2t, minimalVersions)
-    if isfield(minimalVersions, m2t.env)
-        minVersion = minimalVersions.(m2t.env);
-        envWithVersion = sprintf('%s %s', m2t.env, minVersion.name);
+    [env, envVersion] = getEnvironment();
+    if isfield(minimalVersions, env)
+        minVersion = minimalVersions.(env);
+        envWithVersion = sprintf('%s %s', env, minVersion.name);
 
-        if isVersionBelow(m2t.env, m2t.envVersion, minVersion.num)
+        if isVersionBelow(env, envVersion, minVersion.num)
             ID = 'matlab2tikz:deprecatedEnvironment';
 
             warningMessage = ['\n', repmat('=',1,80), '\n\n', ...
@@ -5925,7 +5926,7 @@ end
 % ==============================================================================
 function errorUnknownEnvironment()
     error('matlab2tikz:unknownEnvironment',...
-          'Unknown environment. Need MATLAB(R) or Octave.')
+          'Unknown environment "%s". Need MATLAB(R) or Octave.', getEnvironment);
 end
 % ==============================================================================
 function m2t = needsPgfplotsVersion(m2t, minVersion)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4381,7 +4381,7 @@ function [lStyle] = legendEntryAlignment(m2t, handle, lStyle)
 % determines the text and picture alignment inside a legend
     textalign = '';
     pictalign = '';
-    switch getEnvironment()
+    switch getEnvironment
         case 'Octave'
             % Octave allows to change the alignment of legend text and
             % pictograms using legend('left') and legend('right')
@@ -5889,7 +5889,7 @@ end
 % ==============================================================================
 function [retval] = switchMatOct(m2t, matlabValue, octaveValue)
 % Returns a different value for MATLAB and Octave
-    switch getEnvironment()
+    switch getEnvironment
         case 'MATLAB'
             retval = matlabValue;
         case 'Octave'

--- a/test/private/execute_save_stage.m
+++ b/test/private/execute_save_stage.m
@@ -21,7 +21,8 @@ function [status] = execute_save_stage(status, ipp)
                 print(reference_pdf, '-dpdf', '-S415,311', '-r150');
                 pause(1.0)
             otherwise
-                error('Unknown environment. Need MATLAB(R) or GNU Octave.')
+                error('matlab2tikz:UnknownEnvironment', ...
+                     'Unknown environment. Need MATLAB(R) or GNU Octave.')
         end
     catch %#ok
         e = lasterror('reset'); %#ok

--- a/test/private/getEnvironment.m
+++ b/test/private/getEnvironment.m
@@ -1,18 +1,25 @@
-function [env,versionString] = getEnvironment()
-% Check if we are in MATLAB or Octave.
-% Calling ver with an argument: iterating over all entries is very slow
-    supportedEnvironments = {'MATLAB', 'Octave'};
-    for iCase = 1:numel(supportedEnvironments)
-        env   = supportedEnvironments{iCase};
-        vData = ver(env);
-        if ~isempty(vData)
-            versionString = vData.Version;
-            return; % found the right environment
+function [env, versionString] = getEnvironment()
+% Checks if we are in MATLAB or Octave.
+    persistent cache
+    
+    alternatives = {'MATLAB', 'Octave'};
+    if isempty(cache)
+        for iCase = 1:numel(alternatives)
+            env   = alternatives{iCase};
+            vData = ver(env);
+            if ~isempty(vData) % found the right environment
+                versionString = vData.Version;
+                % store in cache
+                cache.env = env;
+                cache.versionString = versionString;
+                return;
+            end
         end
-    end
-    % no suitable environment found
-    if ~ismember(env, supportedEnvironments)
-        error('testMatlab2tikz:UnknownEnvironment',...
-              'Unknown environment. Only MATLAB and Octave are supported.')
-    end
+        % fall-back values
+        env = '';
+        versionString = '';
+    else
+        env = cache.env;
+        versionString = cache.versionString;
+    end    
 end

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1441,7 +1441,7 @@ function [stat] = texrandom()
       % \fontname{Times} etc. isn't included
       % \fontsize{12} etc. isn't included
 
-  switch getEnvironment()
+  switch getEnvironment
       case 'MATLAB'
           % MATLAB expects tilde and ampersand to be un-escaped and backslashes
           % to be escaped

--- a/test/suites/private/getEnvironment.m
+++ b/test/suites/private/getEnvironment.m
@@ -1,15 +1,25 @@
-function [env,versionString] = getEnvironment()
+function [env, versionString] = getEnvironment()
 % Checks if we are in MATLAB or Octave.
-    alternatives = {'MATLAB','Octave'};
-    for iCase = 1:numel(alternatives)
-        env   = alternatives{iCase};
-        vData = ver(env);
-        if ~isempty(vData)
-            versionString = vData.Version;
-            return; % found the right environment
+    persistent cache
+    
+    alternatives = {'MATLAB', 'Octave'};
+    if isempty(cache)
+        for iCase = 1:numel(alternatives)
+            env   = alternatives{iCase};
+            vData = ver(env);
+            if ~isempty(vData) % found the right environment
+                versionString = vData.Version;
+                % store in cache
+                cache.env = env;
+                cache.versionString = versionString;
+                return;
+            end
         end
-    end
-    % otherwise:
-    env = '';
-    versionString = '';
+        % fall-back values
+        env = '';
+        versionString = '';
+    else
+        env = cache.env;
+        versionString = cache.versionString;
+    end    
 end

--- a/test/suites/private/isVersionBelow.m
+++ b/test/suites/private/isVersionBelow.m
@@ -1,7 +1,7 @@
-function isBelow = isVersionBelow(env, versionA, versionB)
+function isBelow = isVersionBelow(versionA, versionB)
 % Checks if versionA is smaller than versionB
-    vA         = versionArray(env, versionA);
-    vB         = versionArray(env, versionB);
+    vA         = versionArray(versionA);
+    vB         = versionArray(versionB);
     n          = min(length(vA), length(vB));
     deltaAB    = vA(1:n) - vB(1:n);
     difference = find(deltaAB, 1, 'first');
@@ -12,11 +12,11 @@ function isBelow = isVersionBelow(env, versionA, versionB)
     end
 end
 % ==============================================================================
-function arr = versionArray(env, str)
+function arr = versionArray(str)
 % Converts a version string to an array.
     if ischar(str)
         % Translate version string from '2.62.8.1' to [2; 62; 8; 1].
-        switch env
+        switch getEnvironment
             case 'MATLAB'
                 split = regexp(str, '\.', 'split'); % compatibility MATLAB < R2013a
             case  'Octave'
@@ -29,5 +29,10 @@ function arr = versionArray(env, str)
         arr = str;
     end
     arr = arr(:)';
+end
+% ==============================================================================
+function errorUnknownEnvironment()
+error('matlab2tikz:unknownEnvironment',...
+      'Unknown environment "%s". Need MATLAB(R) or Octave.', getEnvironment);
 end
 % ==============================================================================

--- a/test/suites/private/versionCompare.m
+++ b/test/suites/private/versionCompare.m
@@ -1,19 +1,18 @@
 function bool = versionCompare( vA, operator, vB )
 %VERSIONCOMPARE Performs a version comparison operation
-    ENV = getEnvironment();
     switch operator
         case '<'
-            bool = isVersionBelow(ENV, vA, vB);
+            bool = isVersionBelow(vA, vB);
         case '>'
-            bool = isVersionBelow(ENV, vB, vA);
+            bool = isVersionBelow(vB, vA);
         case {'<=', '=<'}
-            bool = ~isVersionBelow(ENV, vB, vA);
+            bool = ~isVersionBelow(vB, vA);
         case {'>=', '=>'}
-            bool = ~isVersionBelow(ENV, vA, vB);
+            bool = ~isVersionBelow(vA, vB);
         case {'=', '=='}
-            bool = ~isVersionBelow(ENV, vA, vB) && ~isVersionBelow(ENV, vB, vA);
+            bool = ~isVersionBelow(vA, vB) && ~isVersionBelow(vB, vA);
         case {'~=', '!='}
-            bool = isVersionBelow(ENV, vA, vB) || isVersionBelow(ENV, vB, vA);
+            bool = isVersionBelow(vA, vB) || isVersionBelow(vB, vA);
         otherwise
             error('versionCompare:UnknownOperator',...
                   '"%s" is not a known comparison operator', operator);

--- a/test/suites/testSurfshader.m
+++ b/test/suites/testSurfshader.m
@@ -56,8 +56,7 @@ end
 % =========================================================================
 function [stat] = surfShader4()
 stat.description = 'shader=faceted | Fc: RGB | Ec: interp';
-env = getEnvironment();
-if strcmpi(env, 'MATLAB') && isVersionBelow(env, 8, 4) %R2014a and older
+if isMATLAB('<', [8,4]); %R2014a and older
     warning('m2t:ACID:surfShader4',...
         'The MATLAB EPS export may behave strangely for this case');
 end
@@ -99,47 +98,5 @@ stat.description = 'mesh | Fc: none | Ec: RGB';
 
 [X,Y,Z]  = peaks(5);
 surf(X,Y,Z,'FaceColor','none','EdgeColor','green')
-end
-% =========================================================================
-function env = getEnvironment
-  if ~isempty(ver('MATLAB'))
-     env = 'MATLAB';
-  elseif ~isempty(ver('Octave'))
-     env = 'Octave';
-  else
-     env = [];
-  end
-end
-% =========================================================================
-function [below, noenv] = isVersionBelow ( env, threshMajor, threshMinor )
-  % get version string for `env' by iterating over all toolboxes
-  versionData = ver;
-  versionString = '';
-  for k = 1:max(size(versionData))
-      if strcmp( versionData(k).Name, env )
-          % found it: store and exit the loop
-          versionString = versionData(k).Version;
-          break
-      end
-  end
-
-  if isempty( versionString )
-      % couldn't find `env'
-      below = true;
-      noenv = true;
-      return
-  end
-
-  majorVer = str2double(regexprep( versionString, '^(\d+)\..*', '$1' ));
-  minorVer = str2double(regexprep( versionString, '^\d+\.(\d+\.?\d*)[^\d]*.*', '$1' ));
-
-  if (majorVer < threshMajor) || (majorVer == threshMajor && minorVer < threshMinor)
-      % version of `env' is below threshold
-      below = true;
-  else
-      % version of `env' is same as or above threshold
-      below = false;
-  end
-  noenv = false;
 end
 % =========================================================================


### PR DESCRIPTION
This fixes #563. Basically, I got fed up of passing `m2t` around to access the global variable `env`. From within `matlab2tikz`, I've replaced all instances that I could find.
On the way, I found a little bug that was not covered by any test case (since it only occurs in error situations). I fixed it anyway :smile_cat: 