### PR TITLE
Add Visvalingam simplification to cleanfigure

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -482,15 +482,7 @@ function a = featureArea(x,y)
         a(heap(1)) = maxArea;
     end
 
-
     % Heap utility functions
-    function swap(a,b)
-        %a and b in the heap, keeping pos up to date
-        pos(heap(a)) = b;
-        pos(heap(b)) = a;
-        heap([a b]) = heap([b a]);
-    end
-
     function down(root)
         % Move element at "root" down the heap, assuming the heap property
         % is satisfied for the rest of the tree
@@ -511,7 +503,8 @@ function a = featureArea(x,y)
                 break
             else
                 % otherwise, swap the root and its minimum child and continue
-                swap(root,minimum);
+                pos(heap([root,minimum])) = [minimum,root];
+                heap([root,minimum]) = heap([minimum,root]);
                 root = minimum;
             end
         end
@@ -523,7 +516,8 @@ function a = featureArea(x,y)
             parent = bitshift(n,-1);
             if a(heap(child)) < a(heap(parent))
                 % If this element is less than its parent, swap them
-                swap(parent,child)
+                pos(heap([parent,child])) = [child,parent];
+                heap([parent,child]) = heap([child,parent]);
                 child = parent;
             else
                 %Otherwise the heap property is restored
@@ -538,7 +532,8 @@ function a = featureArea(x,y)
         e = heap(i);
 
         %Swap the first and the last
-        swap(i,len);
+        pos(heap([i,len])) = [len,i];
+        heap([i,len]) = heap([len,i]);
 
         %Remove the last element from the heap
         len = len-1;

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -411,11 +411,14 @@ function a = featureArea(x,y)
 
   % 'heap' stores the points in an array heap, referenced by their index
   % First and last points are assumed fixed and not added to the heap
-  % 'pos' stores the current position of each point in the heap array
-  % will be needed to lookup position of updated points
   heap = (2:n-1)';
   len = numel(heap);
-  pos = (1:len)';
+
+  % 'pos' stores the current position of each point in the heap array
+  % will be needed to lookup position of updated points. 
+  %
+  % pos(i) = 0 denotes not in the heap
+  pos = [0;(1:len)';0];
 
 
   area = @(i,j,k) abs((y(j) - y(k)).*x(i) + (y(k)-y(i)).*x(j) + ...
@@ -458,13 +461,13 @@ function a = featureArea(x,y)
     %Update area of neighbouring points if they're not the ends points
     if llst(left,1) > 0
       a(left) = area(llst(left,1),left,llst(left,2));
-      pop(pos(left-1));
+      pop(pos(left));
       push();
     end
 
     if llst(right,2) > 0
       a(right) = area(llst(right,1),right,llst(right,2));
-      pop(pos(right-1));
+      pop(pos(right));
       push();
     end
   end
@@ -494,13 +497,11 @@ function a = featureArea(x,y)
         % otherwise, swap the root and its minimum child
       else
         %swap in the pos array
-        pos(heap(root)-1) = swap;
-        pos(heap(swap)-1) = root;
+        pos(heap(root)) = swap;
+        pos(heap(swap)) = root;
 
         %swap in the heap array
-        t = heap(root);
-        heap(root) = heap(swap);
-        heap(swap) = t;
+        heap([root swap]) = heap([swap root])
 
         root = swap;
       end
@@ -511,12 +512,11 @@ function a = featureArea(x,y)
     while child > 1
       parent = bitshift(n,-1);
       if a(heap(child)) < a(heap(parent))
-        pos(heap(parent)-1) = child;
-        pos(heap(child)-1) = parent;
 
-        t = heap(parent);
-        heap(parent) = heap(child);
-        heap(child) = t;
+        pos(heap(parent)) = child;
+        pos(heap(child)) = parent;
+
+        heap([parent child]) = heap([child parent])
 
         child = parent;
       else
@@ -527,8 +527,8 @@ function a = featureArea(x,y)
 
   function e = pop(i)
     %Swap the first and the last
-    pos(heap(i)-1) = len;
-    pos(heap(len)-1) = i;
+    pos(heap(i)) = len;
+    pos(heap(len)) = i;
 
     e = heap(i);
     heap(i) = heap(len);

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -520,7 +520,6 @@ function a = featureArea(x,y)
     % remove smallest element from heap
     e = pop(1);
 
-   
     left = llst(e,1);
     right = llst(e,2);
     % remove element from linked list
@@ -550,16 +549,14 @@ function a = featureArea(x,y)
   % is satisfied for the rest of the tree
   function down(root)
     while 2*root  <= len %while the root has a child
-      lchild = 2*root; 
+      lchild = 2*root;
       rchild = lchild+1;
       % Find the minimum of the root and its children
       swap = root;
-      if a(heap(lchild)) < a(heap(swap)) ...
-          || (a(heap(lchild)) == a(heap(swap)) && rand(1)>0.5)
+      if a(heap(lchild)) < a(heap(swap))
         swap = lchild;
       end
-      if rchild <= len && (a(heap(rchild)) < a(heap(swap)) ...
-          || (a(heap(rchild)) == a(heap(swap)) && rand(1)>0.5))
+      if rchild <= len && (a(heap(rchild)) < a(heap(swap)))
         swap = rchild;
       end
 
@@ -586,8 +583,7 @@ function a = featureArea(x,y)
   function up(child)
     while child > 1
       parent = bitshift(n,-1);
-      if a(heap(child)) < a(heap(parent)) ...
-              || (a(heap(child)) == a(heap(parent)) && rand(1)>0.5)
+      if a(heap(child)) < a(heap(parent))
         pos(heap(parent)-1) = child;
         pos(heap(child)-1) = parent;
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -390,6 +390,7 @@ function simplifyLine(meta, handle, targetResolution)
         % simplification path
         mask = [true,diff(round(vx/xrange*nPixelsX/4))~=0];
         mask = [true,diff(round(vy/yrange*nPixelsY/4))~=0] | mask;
+        mask = find(mask);
         vx = vx(mask);
         vy = vy(mask);
 
@@ -444,6 +445,8 @@ function a = featureArea(x,y)
     % pos(i) = 0 denotes that the elements are not in the heap.
     pos = [0;(1:len)';0];
 
+    %Area of the triangle with verticies at index i,j and k in the line.
+    %From Shoelace formula
     area = @(i,j,k) abs((y(j) - y(k)).*x(i) + (y(k)-y(i)).*x(j) + ...
         (y(i)-y(j)).*x(k))/2;
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -112,8 +112,6 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
           % Move some points closer to the box to avoid TeX:DimensionTooLarge
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);
-          % Don't be too precise.
-          % coarsenLine(meta, h, minimumPointsDistance);
           simplifyLine(meta, h, targetResolution);
       elseif strcmpi(type, 'stair')
           pruneOutsideBox(meta, h);
@@ -297,75 +295,6 @@ function out = segmentsIntersect(X1, X2, X3, X4)
   lambda = crossLines(X1, X2, X3, X4);
   out = all(lambda > 0.0) && all(lambda < 1.0);
   return
-end
-% =========================================================================
-function coarsenLine(meta, handle, minimumPointsDistance)
-  % Reduce the number of data points in the line handle.
-  % Given a minimum distance at which two nodes are considered different,
-  % this can help with plots that contain a large amount of data points not
-  % all of which need to be plotted.
-  %
-  if ( abs(minimumPointsDistance) < 1.0e-15 )
-      % bail out early
-      return
-  end
-
-  % Extract the data from the current line handle.
-  xData = get(handle, 'XData');
-  yData = get(handle, 'YData');
-  zData = get(handle, 'ZData');
-  if ~isempty(zData)
-    % Don't do funny stuff when zData is present.
-    return;
-  end
-
-  data = [xData(:), yData(:)];
-
-  if isempty(data)
-      return;
-  end
-
-  % Generate a mask which is true for the first point, and all
-  % subsequent points which have a greater norm2-distance from
-  % the previous point than 'threshold'.
-  n = size(data, 1);
-
-  % Get info about log scaling.
-  isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
-  isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
-
-  mask = false(n, 1);
-
-  XRef = data(1,:);
-  mask(1) = true;
-  for kk = 2:n
-      % Compute the visible distance of those points,
-      % incorporating possible log-scaling of the axes.
-      visDiff = XRef - data(kk,:);
-      if isXlog
-          % visDiff(1) = log10(XRef(1)) - log10(data(kk,1));
-          visDiff(1) = log10(visDiff(1));
-      end
-      if isYlog
-          visDiff(2) = log10(visDiff(2));
-      end
-      % Check if it's larger than the threshold and
-      % update the reference point in that case.
-      if norm(visDiff) > minimumPointsDistance
-          XRef = data(kk,:);
-          mask(kk) = true;
-      end
-  end
-  mask(end) = true;
-
-  % Make sure to keep NaNs.
-  mask = mask | any(isnan(data)')';
-
-  % Set the new (masked) data.
-  set(handle, 'XData', data(mask, 1));
-  set(handle, 'YData', data(mask, 2));
-
-  return;
 end
 % =========================================================================
 function simplifyLine(meta, handle, targetResolution)

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -369,9 +369,14 @@ function coarsenLine(meta, handle, minimumPointsDistance)
 end
 % =========================================================================
 function simplifyLine(meta, handle, targetResolution)
-  % Reduce the number of data points in the line handle.
-  % this can help with plots that contain a large amount of data points not
-  % all of which need to be plotted.
+  % Reduce the number of data points in the line handle by removing
+  % points which add features with area smaller than 1/4 of a pixel at the
+  % target resolution. 
+  %
+  % targetResolution is in format 'WxH@Res', eg. '15x9@600' for a 15cm by 9cm
+  % figure at 600 ppcm.
+  % 
+  % Use targetResolution = 'off' to disable line simplification
 
   % Extract the data from the current line handle.
   xData = get(handle, 'XData');
@@ -384,6 +389,17 @@ function simplifyLine(meta, handle, targetResolution)
   end
   if isempty(xData) || isempty(yData)
       return;
+  end
+  if numel(xData) <= 2
+      return;
+  end
+  if strcmp(targetResolution,'off')
+      return
+  end
+  [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');
+  
+  if nparms < 3
+      parms(3) = 600;
   end
 
   % Get info about log scaling.
@@ -399,17 +415,8 @@ function simplifyLine(meta, handle, targetResolution)
 	  vyData = log10(yData);
   end
   
-  % Automatically guess a tol based on the area of the figure and the expected
-  % area of the output
-  if strcmp(targetResolution,'off')
-      return
-  end
-  [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');
-  
-  if nparms < 3
-      parms(3) = 600;
-  end
-  
+  % Automatically guess a tol based on the area of the figure and 
+  % the area and resolution of the output
   a = axis(meta.gca);
   if ~isXlog
       xrange = (a(2)-a(1));
@@ -421,17 +428,38 @@ function simplifyLine(meta, handle, targetResolution)
   else
       yrange = (log10(a(4))-log10(a(3)));
   end
-
   tol = xrange*yrange/(4*prod(parms));
   
-  area = featureArea(vxData,vyData);
 
-  mask = area>tol;
-  mask = mask | any(isnan(xData)')' | any(isnan(yData)')';
+  %Split up lines which are seperated by NaNs
+  nans = isnan(vxData) | isnan(vyData);
+  idx = sort([1,find(nans)-1,find(nans)+1,numel(vxData)]);
+  linesx = {};
+  linesy = {};
+  for i = 1:2:numel(idx)
+      %Simplify based on *visual* data
+      vx = vxData(idx(i):idx(i+1));
+      vy = vyData(idx(i):idx(i+1));
+      area = featureArea(vx,vy);
+      
+      %append actual data to the list
+      x = xData(idx(i):idx(i+1));
+      y = yData(idx(i):idx(i+1));
+      linesx{end+1} = x(area>tol);
+      linesy{end+1} = y(area>tol);
+      
+	  %Add nans back in on internal splits
+      if i+1 < numel(idx)
+          linesx{end+1} = nan;
+          linesy{end+1} = nan;
+      end
+  end
+  xData = horzcat(linesx{:});
+  yData = horzcat(linesy{:});
 
   % Set the new (masked) data.
-  set(handle, 'XData', xData(mask));
-  set(handle, 'YData', yData(mask));
+  set(handle, 'XData', xData);
+  set(handle, 'YData', yData);
 
   return;
 end

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -367,8 +367,8 @@ function simplifyLine(meta, handle, targetResolution)
         yrange = (log10(a(4))-log10(a(3)));
     end
     tol = xrange*yrange/(4*prod(targetResolution));
-    nPixelsX = targetResolution(1)*targetResolution(3);
-    nPixelsY = targetResolution(2)*targetResolution(3);
+    nPixelsX = targetResolution(1)*sqrt(targetResolution(3));
+    nPixelsY = targetResolution(2)*sqrt(targetResolution(3));
 
 
     %Split up lines which are seperated by NaNs

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -298,250 +298,249 @@ function out = segmentsIntersect(X1, X2, X3, X4)
 end
 % =========================================================================
 function simplifyLine(meta, handle, targetResolution)
-  % Reduce the number of data points in the line handle by removing
-  % points which add features with area smaller than 1/4 of a pixel at the
-  % target resolution.
-  %
-  % targetResolution is in format 'WxH@Res', eg. '15x9@600' for a 15cm by 9cm
-  % figure at 600 ppcm.
-  %
-  % Use targetResolution = 'off' to disable line simplification
+    % Reduce the number of data points in the line handle by removing
+    % points which add features with area smaller than 1/4 of a pixel at the
+    % target resolution.
+    %
+    % targetResolution is in format 'WxH@Res', eg. '15x9@600' for a 15cm by 9cm
+    % figure at 600 ppcm.
+    %
+    % Use targetResolution = 'off' to disable line simplification
 
-  % Extract the data from the current line handle.
-  xData = get(handle, 'XData');
-  yData = get(handle, 'YData');
-  zData = get(handle, 'ZData');
+    % Extract the data from the current line handle.
+    xData = get(handle, 'XData');
+    yData = get(handle, 'YData');
+    zData = get(handle, 'ZData');
 
-  if ~isempty(zData)
-    % Don't simplify 3d plots
-    return;
-  end
-  if isempty(xData) || isempty(yData)
-    return;
-  end
-  if numel(xData) <= 2
-    return;
-  end
-  if strcmpi(targetResolution,'off')
-    return
-  end
-  [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');
-
-  if nparms < 3
-    parms(3) = 600;
-  end
-
-  % Get info about log scaling.
-  isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
-  vxData = xData;
-  if isXlog
-    vxData = log10(xData);
-  end
-
-  isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
-  vyData = yData;
-  if isYlog
-    vyData = log10(yData);
-  end
-
-  % Automatically guess a tol based on the area of the figure and 
-  % the area and resolution of the output
-  a = axis(meta.gca);
-  if ~isXlog
-    xrange = (a(2)-a(1));
-  else
-    xrange = (log10(a(2))-log10(a(1)));
-  end
-  if ~isYlog
-    yrange = (a(4)-a(3));
-  else
-    yrange = (log10(a(4))-log10(a(3)));
-  end
-  tol = xrange*yrange/(4*prod(parms));
-
-
-  %Split up lines which are seperated by NaNs
-  nans = isnan(vxData) | isnan(vyData);
-  idx = sort([1,find(nans)-1,find(nans)+1,numel(vxData)]);
-  linesx = {};
-  linesy = {};
-  for i = 1:2:numel(idx)
-    %Simplify based on *visual* data
-    vx = vxData(idx(i):idx(i+1));
-    vy = vyData(idx(i):idx(i+1));
-    area = featureArea(vx,vy);
-
-    %append actual data to the list
-    x = xData(idx(i):idx(i+1));
-    y = yData(idx(i):idx(i+1));
-    linesx{end+1} = x(area>tol);
-    linesy{end+1} = y(area>tol);
-
-    %Add nans back in on internal splits
-    if i+1 < numel(idx)
-      linesx{end+1} = nan;
-      linesy{end+1} = nan;
+    if ~isempty(zData)
+        % Don't simplify 3d plots
+        return;
     end
-  end
-  xData = horzcat(linesx{:});
-  yData = horzcat(linesy{:});
+    if isempty(xData) || isempty(yData)
+        return;
+    end
+    if numel(xData) <= 2
+        return;
+    end
+    if strcmpi(targetResolution,'off')
+        return
+    end
+    [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');
 
-  % Set the new (masked) data.
-  set(handle, 'XData', xData);
-  set(handle, 'YData', yData);
+    if nparms < 3
+        parms(3) = 600;
+    end
 
-  return;
+    % Get info about log scaling.
+    isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
+    vxData = xData;
+    if isXlog
+        vxData = log10(xData);
+    end
+
+    isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
+    vyData = yData;
+    if isYlog
+        vyData = log10(yData);
+    end
+
+    % Automatically guess a tol based on the area of the figure and
+    % the area and resolution of the output
+    a = axis(meta.gca);
+    if ~isXlog
+        xrange = (a(2)-a(1));
+    else
+        xrange = (log10(a(2))-log10(a(1)));
+    end
+    if ~isYlog
+        yrange = (a(4)-a(3));
+    else
+        yrange = (log10(a(4))-log10(a(3)));
+    end
+    tol = xrange*yrange/(4*prod(parms));
+
+
+    %Split up lines which are seperated by NaNs
+    nans = isnan(vxData) | isnan(vyData);
+    idx = sort([1,find(nans)-1,find(nans)+1,numel(vxData)]);
+    linesx = {};
+    linesy = {};
+    for i = 1:2:numel(idx)
+        %Simplify based on *visual* data
+        vx = vxData(idx(i):idx(i+1));
+        vy = vyData(idx(i):idx(i+1));
+        area = featureArea(vx,vy);
+
+        %append actual data to the list
+        x = xData(idx(i):idx(i+1));
+        y = yData(idx(i):idx(i+1));
+        linesx{end+1} = x(area>tol);
+        linesy{end+1} = y(area>tol);
+
+        %Add nans back in on internal splits
+        if i+1 < numel(idx)
+            linesx{end+1} = nan;
+            linesy{end+1} = nan;
+        end
+    end
+    xData = horzcat(linesx{:});
+    yData = horzcat(linesy{:});
+
+    % Set the new (masked) data.
+    set(handle, 'XData', xData);
+    set(handle, 'YData', yData);
+
+    return;
 end
 % =========================================================================
 function a = featureArea(x,y)
-  % Performs Visvalingam's algorithm:
-  % Given the path defined by x,y, the function returns list of the
-  % maximum area associated with each point in the list. Path then can be
-  % simplified via x = x(a>tol)
-  %
-  % Runtime is O(n log(n))
-  %
-  % Used by 'simplifyLine'.
+    % Performs Visvalingam's algorithm:
+    % Given the path defined by x,y, the function returns list of the
+    % maximum area associated with each point in the list. Path then can be
+    % simplified via x = x(a>tol)
+    %
+    % Runtime is O(n log(n))
+    %
+    % Used by 'simplifyLine'.
 
-  n = numel(x);
+    n = numel(x);
 
-  % Index of next and previous elements in the linked list which defines
-  % the path
-  llst = [(0:n-1)',[(2:n)';0]];
+    % Index of next and previous elements in the linked list which defines
+    % the path
+    linkedList = [(0:n-1)',[(2:n)';0]];
 
-  % 'heap' stores the points in an array heap, referenced by their index
-  % First and last points are assumed fixed and not added to the heap
-  heap = (2:n-1)';
-  len = numel(heap);
+    % 'heap' stores the points in an array heap, referenced by their index
+    % First and last points are assumed fixed and not added to the heap
+    heap = (2:n-1)';
+    len = numel(heap);
 
-  % 'pos' stores the current position of each point in the heap array
-  % will be needed to lookup position of updated points. 
-  %
-  % pos(i) = 0 denotes not in the heap
-  pos = [0;(1:len)';0];
+    % 'pos' stores the current position of each point in the heap array
+    % will be needed to lookup position of updated points. 
+    %
+    % pos(i) = 0 denotes not in the heap
+    pos = [0;(1:len)';0];
 
+    area = @(i,j,k) abs((y(j) - y(k)).*x(i) + (y(k)-y(i)).*x(j) + ...
+        (y(i)-y(j)).*x(k))/2;
 
-  area = @(i,j,k) abs((y(j) - y(k)).*x(i) + (y(k)-y(i)).*x(j) + ...
-                                                    (y(i)-y(j)).*x(k))/2;
+    % Endpoints are assigned infinte area so they can't be removed
+    a = [Inf;area((1:n-2)', (2:n-1)', (3:n)')';Inf];
 
-  % Endpoints are assigned infinte area so they can't be removed
-  a = [Inf;area((1:n-2)', (2:n-1)', (3:n)')';Inf];
+    % Keep track of the maximum area removed so far to ensure
+    % a given element will only be excluded after earlier elements
+    maxArea = 0;
 
-  % Keep track of the maximum area removed so far to ensure 
-  % a given element will only be excluded after earlier elements
-  maxArea = 0;
-
-  %Heapify the 'heap' array based on the area, using Floyd's alg
-  root = bitshift(len,-1); %starting with the first parent node
-  while root >= 1
-    down(root);
-    root = root-1;
-  end
-
-  %Now remove the element with the minimum area off the heap
-  while len > 1
-     if a(heap(1)) > maxArea
-       maxArea = a(heap(1));
-     else
-       % ensure current element will only be excluded when earlier elements
-       % are also excluded
-       a(heap(1)) = maxArea;
-     end
-
-    % remove smallest element from heap
-    e = pop(1);
-
-    left = llst(e,1);
-    right = llst(e,2);
-    % remove element from linked list
-    llst(left,2) = llst(e,2);
-    llst(right,1) = llst(e,1);
-
-
-    %Update area of neighbouring points if they're not the ends points
-    if llst(left,1) > 0
-      a(left) = area(llst(left,1),left,llst(left,2));
-      pop(pos(left));
-      push();
+    %Heapify the 'heap' array based on the area, using Floyd's alg
+    root = bitshift(len,-1); %starting with the first parent node
+    while root >= 1
+        down(root);
+        root = root-1;
     end
 
-    if llst(right,2) > 0
-      a(right) = area(llst(right,1),right,llst(right,2));
-      pop(pos(right));
-      push();
+    %Now remove the element with the minimum area off the heap
+    while len > 1
+        if a(heap(1)) > maxArea
+            maxArea = a(heap(1));
+        else
+            % ensure current element will only be excluded when earlier elements
+            % are also excluded
+            a(heap(1)) = maxArea;
+        end
+
+        % remove smallest element from heap
+        e = pop(1);
+
+        left = linkedList(e,1);
+        right = linkedList(e,2);
+        % remove element from linked list
+        linkedList(left,2) = linkedList(e,2);
+        linkedList(right,1) = linkedList(e,1);
+
+
+        %Update area of neighbouring points if they're not the ends points
+        if linkedList(left,1) > 0
+            a(left) = area(linkedList(left,1),left,linkedList(left,2));
+            pop(pos(left));
+            push();
+        end
+
+        if linkedList(right,2) > 0
+            a(right) = area(linkedList(right,1),right,linkedList(right,2));
+            pop(pos(right));
+            push();
+        end
     end
-  end
 
-  if numel(heap) >0 &&  a(heap(1)) < maxArea
-    a(heap(1)) = maxArea;
-  end
-
-  % Move element at "root" down the heap, assuming the heap property
-  % is satisfied for the rest of the tree
-  function down(root)
-    while 2*root  <= len %while the root has a child
-      lchild = 2*root;
-      rchild = lchild+1;
-      % Find the minimum of the root and its children
-      swap = root;
-      if a(heap(lchild)) < a(heap(swap))
-        swap = lchild;
-      end
-      if rchild <= len && (a(heap(rchild)) < a(heap(swap)))
-        swap = rchild;
-      end
-
-      % if the root is the minimum, then we're done
-      if swap == root
-        break
-        % otherwise, swap the root and its minimum child
-      else
-        %swap in the pos array
-        pos(heap(root)) = swap;
-        pos(heap(swap)) = root;
-
-        %swap in the heap array
-        heap([root swap]) = heap([swap root])
-
-        root = swap;
-      end
+    if numel(heap) >0 &&  a(heap(1)) < maxArea
+        a(heap(1)) = maxArea;
     end
-  end
 
-  function up(child)
-    while child > 1
-      parent = bitshift(n,-1);
-      if a(heap(child)) < a(heap(parent))
+    % Move element at "root" down the heap, assuming the heap property
+    % is satisfied for the rest of the tree
+    function down(root)
+        while 2*root  <= len %while the root has a child
+            lchild = 2*root;
+            rchild = lchild+1;
+            % Find the minimum of the root and its children
+            swap = root;
+            if a(heap(lchild)) < a(heap(swap))
+                swap = lchild;
+            end
+            if rchild <= len && (a(heap(rchild)) < a(heap(swap)))
+                swap = rchild;
+            end
 
-        pos(heap(parent)) = child;
-        pos(heap(child)) = parent;
+            % if the root is the minimum, then we're done
+            if swap == root
+                break
+                % otherwise, swap the root and its minimum child
+            else
+                %swap in the pos array
+                pos(heap(root)) = swap;
+                pos(heap(swap)) = root;
 
-        heap([parent child]) = heap([child parent])
+                %swap in the heap array
+                heap([root swap]) = heap([swap root])
 
-        child = parent;
-      else
-        break
-      end
+                root = swap;
+            end
+        end
     end
-  end
 
-  function e = pop(i)
-    %Swap the first and the last
-    pos(heap(i)) = len;
-    pos(heap(len)) = i;
+    function up(child)
+        while child > 1
+            parent = bitshift(n,-1);
+            if a(heap(child)) < a(heap(parent))
 
-    e = heap(i);
-    heap(i) = heap(len);
-    heap(len) = e;
+                pos(heap(parent)) = child;
+                pos(heap(child)) = parent;
 
-    len = len-1;
-    down(i);
-  end
+                heap([parent child]) = heap([child parent])
 
-  function push()
-    len = len+1;
-    up(len);
-  end
+                child = parent;
+            else
+                break
+            end
+        end
+    end
+
+    function e = pop(i)
+        %Swap the first and the last
+        pos(heap(i)) = len;
+        pos(heap(len)) = i;
+
+        e = heap(i);
+        heap(i) = heap(len);
+        heap(len) = e;
+
+        len = len-1;
+        down(i);
+    end
+
+    function push()
+        len = len+1;
+        up(len);
+    end
 end
 % =========================================================================
 function movePointsCloser(meta, handle)

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -546,7 +546,7 @@ function a = featureArea(x,y)
     a(heap(1)) = maxArea;
   end
 
-  % Movse element at "root" down the heap, assuming the heap property
+  % Move element at "root" down the heap, assuming the heap property
   % is satisfied for the rest of the tree
   function down(root)
     while 2*root  <= len %while the root has a child

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -394,15 +394,20 @@ function simplifyLine(meta, handle, targetResolution)
         vx = vx(mask);
         vy = vy(mask);
 
-        area = featureArea(vx,vy);
-
-        %append actual data to the list
+        %actual data to append to the list
         x = xData(pstart(i):pend(i));
         y = yData(pstart(i):pend(i));
         x = x(mask);
         y = y(mask);
-        linesx{end+1} = x(area>tol);
-        linesy{end+1} = y(area>tol);
+
+        if numel(vx) > 2
+            area = featureArea(vx,vy);
+            linesx{end+1} = x(area>tol);
+            linesy{end+1} = y(area>tol);
+        else
+            linesx{end+1} = x;
+            linesy{end+1} = y;
+        end
 
         %Add nans back in at internal splits
         if i < numel(pstart)

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -117,11 +117,11 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
       %display(sprintf([repmat(' ',1,indent), '  handle this']))
 
       if strcmp(type, 'line')
+          simplifyLine(meta, h, targetResolution);
           pruneOutsideBox(meta, h);
           % Move some points closer to the box to avoid TeX:DimensionTooLarge
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);
-          simplifyLine(meta, h, targetResolution);
       elseif strcmpi(type, 'stair')
           pruneOutsideBox(meta, h);
       elseif strcmp(type, 'text')

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -9,8 +9,8 @@ function cleanfigure(varargin)
 %   CLEANFIGURE('targetResolution',[W,H,Res],...)  
 %   Reduce the number of data points in the line handle by removing points which
 %   add features with area smaller than 1/4 of a pixel at the target resolution.
-%   W is the target width of the figure, H is the target height, and Res is the
-%   target resolution.
+%   W and H are the target width and height of the figure (eg in cm) and Res is
+%   the target resolution (eg in pixels per cm^2)
 %      Use targetResolution = Inf, or targetResolution(3) = Inf to disable line
 %   simplification.
 %  (default [15 9 600])
@@ -57,7 +57,7 @@ function cleanfigure(varargin)
   % Set up command line options.
   m2t.cmdOpts = m2tInputParser;
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'handle', gcf, @ishandle);
-  m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'targetResolution', [15 9 600], @(a) isvector(a) && numel(a) == 3);
+  m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'targetResolution', [15 9 600], @(a)numel(a) == 3);
 
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'minimumPointsDistance', 1.0e-10, @isnumeric);
   m2t.cmdOpts = m2t.cmdOpts.deprecateParam(m2t.cmdOpts, 'minimumPointsDistance', 'targetResolution');
@@ -388,8 +388,8 @@ function simplifyLine(meta, handle, targetResolution)
 
         % Discretize data to 16th of a pixel before doing true
         % simplification path
-        mask = [true,diff(round(vx/xrange*nPixelsX/4))~=0];
-        mask = [true,diff(round(vy/yrange*nPixelsY/4))~=0] | mask;
+        mask = [true,diff(round(vx/xrange*nPixelsX*4))~=0];
+        mask = [true,diff(round(vy/yrange*nPixelsY*4))~=0] | mask;
         mask = find(mask);
         vx = vx(mask);
         vy = vy(mask);

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -393,7 +393,7 @@ function simplifyLine(meta, handle, targetResolution)
   if numel(xData) <= 2
       return;
   end
-  if strcmp(targetResolution,'off')
+  if strcmpi(targetResolution,'off')
       return
   end
   [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -113,7 +113,8 @@ function indent = recursiveCleanup(meta, h, minimumPointsDistance, indent)
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);
           % Don't be too precise.
-          coarsenLine(meta, h, minimumPointsDistance);
+          % coarsenLine(meta, h, minimumPointsDistance);
+          simplifyLine(meta, h);
       elseif strcmpi(type, 'stair')
           pruneOutsideBox(meta, h);
       elseif strcmp(type, 'text')
@@ -365,6 +366,219 @@ function coarsenLine(meta, handle, minimumPointsDistance)
   set(handle, 'YData', data(mask, 2));
 
   return;
+end
+% =========================================================================
+function simplifyLine(meta, handle, varargin)
+  % Reduce the number of data points in the line handle.
+  % this can help with plots that contain a large amount of data points not
+  % all of which need to be plotted.
+
+  % Extract the data from the current line handle.
+  xData = get(handle, 'XData');
+  yData = get(handle, 'YData');
+  zData = get(handle, 'ZData');
+
+  if ~isempty(zData)
+    % Don't do funny stuff when zData is present.
+    return;
+  end
+  if isempty(xData) || isempty(yData)
+      return;
+  end
+
+  % Get info about log scaling.
+  isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
+  vxData = xData;
+  if isXlog
+	  vxData = log10(xData);
+  end
+
+  isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
+  vyData = yData;
+  if isYlog
+	  vyData = log10(yData);
+  end
+
+  area = featureArea(vxData,vyData);
+
+  if nargin < 3
+	  % Automatically guess a tol based on the area of the figure and the expected
+	  % area of the output
+	  a = axis(meta.gca);
+	  if ~isXlog
+		  xrange = (a(2)-a(1));
+	  else
+		  xrange = (log10(a(2))-log10(a(1)));
+	  end
+	  if ~isYlog
+		  yrange = (a(4)-a(3));
+	  else
+		  yrange = (log10(a(4))-log10(a(3)));
+	  end
+	  
+	  tol = xrange*yrange/(15*9*600);
+  else
+	  tol = varargin(1);
+  end
+
+  mask = area>tol;
+  mask = mask | any(isnan(xData)')' | any(isnan(yData)')';
+
+  % Set the new (masked) data.
+  set(handle, 'XData', xData(mask));
+  set(handle, 'YData', yData(mask));
+
+  return;
+end
+% =========================================================================
+function a = featureArea(x,y)
+  % Given the path defined by x,y, the function returns list of the
+  % maximum area associated with each point in the list. Path then can be
+  % simplified via x = x(a>tol)
+
+  n = numel(x);
+  
+  %Index of next and previous elements in the linked list which defines the path
+  llst = [(0:n-1)',[(2:n)';0]];
+  
+  % 'heap' stores the points in an array heap, referenced by their index
+  % First and last points are assumed fixed and not added to the heap
+  % 'pos' stores the current position of each point in the heap array
+  % will be needed to lookup position of updated points
+  heap = (2:n-1)';
+  len = numel(heap);
+  pos = (1:len)';
+
+
+  area = @(i,j,k) abs((y(j) - y(k)).*x(i) + (y(k)-y(i)).*x(j) + (y(i)-y(j)).*x(k))/2;
+
+  %precompute the areas
+  a = [Inf;area((1:n-2)', (2:n-1)', (3:n)')';Inf];
+  %return
+
+  %store the maximum area removed so far
+  maxArea = 0;
+
+  %Heapify the 'heap' array based on the area, using Floyd's alg
+  root = bitshift(len,-1); %starting with the first parent node
+  while root >= 1
+    down(root);
+    root = root-1;
+  end
+  
+
+  %Now remove the element with the minimum area off the heap
+  while len > 1
+
+    % if a(heap(1)) > maxArea
+    %   maxArea = a(heap(1));
+    % else
+    %   % ensure current element will only be excluded when earlier elements
+    %   % are also excluded
+    %   a(heap(1)) = maxArea;
+    % end
+
+    % remove smallest element from heap
+    e = pop(1);
+
+    % remove element from linked list
+    left = llst(e,1);
+    right = llst(e,2);
+    llst(left,2) = llst(e,2);
+    llst(right,1) = llst(e,1);
+
+
+    %Update area of neighbouring points to the removed, if they're not the ends
+    if llst(left,1) > 0
+      a(left) = area(llst(left,1),left,llst(left,2));
+      pop(pos(left-1));
+      push();
+    end
+
+    if llst(right,2) > 0
+      a(right) = area(llst(right,1),right,llst(right,2));
+      pop(pos(right-1));
+      push();
+    end
+  end
+
+  if numel(heap) >0 &&  a(heap(1)) < maxArea
+    a(heap(1)) = maxArea;
+  end
+
+  % Move element at "root" down the heap, assuming the heap property
+  % is satisfied for the rest of the tree
+  function down(root)
+    while 2*root  <= len %while the root has a child
+      lchild = 2*root; 
+      rchild = lchild+1;
+      % Find the minimum of the root and its children
+      swap = root;
+      if a(heap(lchild)) < a(heap(swap)) ...
+          || (a(heap(lchild)) == a(heap(swap)) && rand(1)>0.5)
+        swap = lchild;
+      end
+      if rchild <= len && (a(heap(rchild)) < a(heap(swap)) ...
+          || (a(heap(rchild)) == a(heap(swap)) && rand(1)>0.5))
+        swap = rchild;
+      end
+
+      % if the root is the minimum, then we're done
+      if swap == root
+        break
+        % otherwise, swap the root and its minimum child
+      else
+        %swap in the pos array
+        pos(heap(root)-1) = swap;
+        pos(heap(swap)-1) = root;
+
+        %swap in the heap array
+        t = heap(root);
+        heap(root) = heap(swap);
+        heap(swap) = t;
+
+
+        root = swap;
+      end
+    end
+  end
+
+  function up(child)
+    while child > 1
+      parent = bitshift(n,-1);
+      if a(heap(child)) < a(heap(parent)) ...
+              || (a(heap(child)) == a(heap(parent)) && rand(1)>0.5)
+        pos(heap(parent)-1) = child;
+        pos(heap(child)-1) = parent;
+
+        t = heap(parent);
+        heap(parent) = heap(child);
+        heap(child) = t;
+
+        child = parent;
+      else
+        break
+      end
+    end
+  end
+
+  function e = pop(i)
+    %Swap the first and the last
+    pos(heap(i)-1) = len;
+    pos(heap(len)-1) = i;
+
+    e = heap(i);
+    heap(i) = heap(len);
+    heap(len) = e;
+
+    len = len-1;
+    down(i);
+  end
+
+  function push()
+      len = len+1;
+      up(len);
+  end
 end
 % =========================================================================
 function movePointsCloser(meta, handle)

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -371,11 +371,11 @@ end
 function simplifyLine(meta, handle, targetResolution)
   % Reduce the number of data points in the line handle by removing
   % points which add features with area smaller than 1/4 of a pixel at the
-  % target resolution. 
+  % target resolution.
   %
   % targetResolution is in format 'WxH@Res', eg. '15x9@600' for a 15cm by 9cm
   % figure at 600 ppcm.
-  % 
+  %
   % Use targetResolution = 'off' to disable line simplification
 
   % Extract the data from the current line handle.
@@ -388,48 +388,48 @@ function simplifyLine(meta, handle, targetResolution)
     return;
   end
   if isempty(xData) || isempty(yData)
-      return;
+    return;
   end
   if numel(xData) <= 2
-      return;
+    return;
   end
   if strcmpi(targetResolution,'off')
-      return
+    return
   end
   [parms,nparms] = sscanf(targetResolution,'%fx%f@%f');
-  
+
   if nparms < 3
-      parms(3) = 600;
+    parms(3) = 600;
   end
 
   % Get info about log scaling.
   isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
   vxData = xData;
   if isXlog
-	  vxData = log10(xData);
+    vxData = log10(xData);
   end
 
   isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
   vyData = yData;
   if isYlog
-	  vyData = log10(yData);
+    vyData = log10(yData);
   end
-  
+
   % Automatically guess a tol based on the area of the figure and 
   % the area and resolution of the output
   a = axis(meta.gca);
   if ~isXlog
-      xrange = (a(2)-a(1));
+    xrange = (a(2)-a(1));
   else
-      xrange = (log10(a(2))-log10(a(1)));
+    xrange = (log10(a(2))-log10(a(1)));
   end
   if ~isYlog
-      yrange = (a(4)-a(3));
+    yrange = (a(4)-a(3));
   else
-      yrange = (log10(a(4))-log10(a(3)));
+    yrange = (log10(a(4))-log10(a(3)));
   end
   tol = xrange*yrange/(4*prod(parms));
-  
+
 
   %Split up lines which are seperated by NaNs
   nans = isnan(vxData) | isnan(vyData);
@@ -437,22 +437,22 @@ function simplifyLine(meta, handle, targetResolution)
   linesx = {};
   linesy = {};
   for i = 1:2:numel(idx)
-      %Simplify based on *visual* data
-      vx = vxData(idx(i):idx(i+1));
-      vy = vyData(idx(i):idx(i+1));
-      area = featureArea(vx,vy);
-      
-      %append actual data to the list
-      x = xData(idx(i):idx(i+1));
-      y = yData(idx(i):idx(i+1));
-      linesx{end+1} = x(area>tol);
-      linesy{end+1} = y(area>tol);
-      
-	  %Add nans back in on internal splits
-      if i+1 < numel(idx)
-          linesx{end+1} = nan;
-          linesy{end+1} = nan;
-      end
+    %Simplify based on *visual* data
+    vx = vxData(idx(i):idx(i+1));
+    vy = vyData(idx(i):idx(i+1));
+    area = featureArea(vx,vy);
+
+    %append actual data to the list
+    x = xData(idx(i):idx(i+1));
+    y = yData(idx(i):idx(i+1));
+    linesx{end+1} = x(area>tol);
+    linesy{end+1} = y(area>tol);
+
+    %Add nans back in on internal splits
+    if i+1 < numel(idx)
+      linesx{end+1} = nan;
+      linesy{end+1} = nan;
+    end
   end
   xData = horzcat(linesx{:});
   yData = horzcat(linesy{:});
@@ -472,14 +472,14 @@ function a = featureArea(x,y)
   %
   % Runtime is O(n log(n))
   %
-  % Used by 'simplifyLine'. 
+  % Used by 'simplifyLine'.
 
   n = numel(x);
-  
+
   % Index of next and previous elements in the linked list which defines
   % the path
   llst = [(0:n-1)',[(2:n)';0]];
-  
+
   % 'heap' stores the points in an array heap, referenced by their index
   % First and last points are assumed fixed and not added to the heap
   % 'pos' stores the current position of each point in the heap array
@@ -505,7 +505,6 @@ function a = featureArea(x,y)
     down(root);
     root = root-1;
   end
-  
 
   %Now remove the element with the minimum area off the heap
   while len > 1
@@ -574,7 +573,6 @@ function a = featureArea(x,y)
         heap(root) = heap(swap);
         heap(swap) = t;
 
-
         root = swap;
       end
     end
@@ -612,8 +610,8 @@ function a = featureArea(x,y)
   end
 
   function push()
-      len = len+1;
-      up(len);
+    len = len+1;
+    up(len);
   end
 end
 % =========================================================================

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -364,24 +364,28 @@ function simplifyLine(meta, handle, targetResolution)
 
 
     %Split up lines which are seperated by NaNs
-    nans = isnan(vxData) | isnan(vyData);
-    idx = sort([1,find(nans)-1,find(nans)+1,numel(vxData)]);
+    inan   = isnan(vxData) | isnan(vyData);
+    df     = diff([false, ~inan, false]);
+    pstart = find(df == 1);
+    pend   = find(df == -1)-1;
+
     linesx = {};
     linesy = {};
-    for i = 1:2:numel(idx)
+
+    for i = 1:numel(pstart)
         %Simplify based on *visual* data
-        vx = vxData(idx(i):idx(i+1));
-        vy = vyData(idx(i):idx(i+1));
+        vx = vxData(pstart(i):pend(i));
+        vy = vyData(pstart(i):pend(i));
         area = featureArea(vx,vy);
 
         %append actual data to the list
-        x = xData(idx(i):idx(i+1));
-        y = yData(idx(i):idx(i+1));
+        x = xData(pstart(i):pend(i));
+        y = yData(pstart(i):pend(i));
         linesx{end+1} = x(area>tol);
         linesy{end+1} = y(area>tol);
 
-        %Add nans back in on internal splits
-        if i+1 < numel(idx)
+        %Add nans back in at internal splits
+        if i < numel(pstart)
             linesx{end+1} = nan;
             linesy{end+1} = nan;
         end


### PR DESCRIPTION
This patch replaces the `minimumPointsDistance` feature with a `targetResolution` option. The cleanfigure script then performs path simplification with Visvalingam's algorithm using a tolerance based on `targetResolution`. 

Essentially, cleanfigure now removes points which do not add any detail at the specified target resolution.