### PR TITLE
Another round of refactorings

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3396,17 +3396,15 @@ function [m2t, str] = drawStemOrStairSeries_(m2t, h, plotType)
     [m2t, plotColor] = getColor(m2t, h, color, 'patch');
 
     lineOptions = getLineOptions(m2t, lineStyle, lineWidth);
-    [m2t, markerOptions] = getMarkerOptions(m2t, h);
-    lineOptions = opts_to_legacy(lineOptions);  %FIXME: remove this 
-    markerOptions = opts_to_legacy(markerOptions); %FIXME: remove this 
+    [m2t, markerOptions] = getMarkerOptions(m2t, h); 
 
-    drawOptions = [plotType,                      ...
-        sprintf('color=%s', plotColor),...
-        lineOptions, ...
-        markerOptions];
+    drawOptions = opts_new();
+    drawOptions = opts_add(drawOptions, plotType);
+    drawOptions = opts_add(drawOptions, 'color', plotColor);
+    drawOptions = opts_merge(drawOptions, lineOptions, markerOptions);
 
     %% insert draw options
-    drawOpts =  join(m2t, drawOptions, ',');
+    drawOpts =  opts_print(m2t, drawOptions, ',');
 
     %% plot the thing
     xData = get(h, 'XData');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3109,7 +3109,6 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Plot the thing.
     [env, data, sColumn] = organizeScatterData(m2t, xData, yData, zData, sData);
-    nColumns = size(data, 2);
     
     if ~constMarkerkSize %
         drawOptions = opts_add(drawOptions, 'visualization depends on', ...
@@ -3120,22 +3119,10 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     end
     drawOpts = opts_print(m2t, drawOptions, ',');
 
-    metaPart = opts_new();
-    if length(cData) == 3
-        % If size(cData,1)==1, then all the colors are the same and have
-        % already been accounted for above.
-
-    elseif size(cData,2) == 3
-        %TODO Hm, can't deal with this?
-        %[m2t, col] = rgb2colorliteral(m2t, cData(k,:));
-        %str = strcat(str, sprintf(' [%s]\n', col));
-    else
-        metaPart = opts_add(metaPart,'meta index', sprintf('%d', size(data,2)));
-        data = [data, cData(:)];
-        nColumns = nColumns + 1;
-    end
+    [data, metaPart] = addCDataToScatterData(data, cData);
 
     % The actual printing.
+    nColumns = size(data, 2);
     [m2t, table, tabOpts] = makeTable(m2t, repmat({''},1,nColumns), data);
     tabOpts = opts_merge(tabOpts, metaPart);
 
@@ -3164,7 +3151,25 @@ function [env, data, sColumn] = organizeScatterData(m2t, xData, yData, zData, sD
         end
     end
 end
-% ===
+% ==============================================================================
+function [data, metaOptions] = addCDataToScatterData(data, cData)
+% adds the cData vector to the data table of a scatter plot
+    metaOptions = opts_new();
+    if length(cData) == 3
+        % If size(cData,1)==1, then all the colors are the same and have
+        % already been accounted for above.
+
+    elseif size(cData,2) == 3
+        %TODO Hm, can't deal with this?
+        %[m2t, col] = rgb2colorliteral(m2t, cData(k,:));
+        %str = strcat(str, sprintf(' [%s]\n', col));
+    else
+        metaOptions = opts_add(metaOptions, ...
+                               'meta index', sprintf('%d', size(data,2)));
+        data = [data, cData(:)];
+    end
+end
+% ==============================================================================
 function [m2t, xcolor, hasColor] = getColorOfMarkers(m2t, h, name, cData)
     color = get(h, name);
     hasColor = ~isNone(color);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1856,7 +1856,7 @@ function [m2t, str] = drawPatch(m2t, handle)
         [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
          columnNames] = setColorsOfPatches(m2t, handle, drawOptions, ...
            Vertices, Faces, verticesTableOptions, ptType, columnNames, ...
-           isFaceColorFlat);
+           isFaceColorFlat, s);
     end
     
     drawOptions = showInLegend(m2t.currentHandleHasLegend, drawOptions);
@@ -1879,7 +1879,7 @@ end
 % ==============================================================================
 function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
          columnNames] = setColorsOfPatches(m2t, handle, drawOptions, ...
-           Vertices, Faces, verticesTableOptions, ptType, columnNames, isFaceColorFlat)
+           Vertices, Faces, verticesTableOptions, ptType, columnNames, isFaceColorFlat, s)
 % this behemoth does the color setting for patches
 
     % TODO: this function can probably be split further, just look at all those

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3508,22 +3508,21 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
         return
     end
 
-    arrowOpts = cell(0);
+    arrowOpts = opts_new();
     if showArrowHead
-        arrowOpts = [arrowOpts, '->'];
+        arrowOpts = opts_add(arrowOpts, '->');
     else
-        arrowOpts = [arrowOpts, '-'];
+        arrowOpts = opts_add(arrowOpts, '-');
     end
 
     color = get(h, 'Color');
+    lineOpts = getLineOptions(m2t, lineStyle, lineWidth);
     [m2t, arrowcolor] = getColor(m2t, h, color, 'patch');
-    arrowOpts = [arrowOpts, ...
-        sprintf('color=%s', arrowcolor), ... % color
-        opts_to_legacy(getLineOptions(m2t, lineStyle, lineWidth)), ... % line options %FIXME: remove legacy
-        ];
+    arrowOpts = opts_add(arrowOpts, 'color', arrowcolor);
+    arrowOpts = opts_merge(arrowOpts, lineOpts);
 
     % define arrow style
-    arrowOptions = join(m2t, arrowOpts, ',');
+    arrowOptions = opts_print(m2t, arrowOpts, ',');
 
     % Append the arrow style to the TikZ options themselves.
     % TODO: Look into replacing this by something more 'local',

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1951,7 +1951,9 @@ end
 % ==============================================================================
 function [m2t, options] = assignColor(m2t, handle, options, property, color, noneValue)
 % assigns the MATLAB color of the object identified by "handle" to the LaTeX
-% property stored in the options array.
+% property stored in the options array. An optional "noneValue" can be provided
+% that is set when the color == 'none' (if it is omitted, the property will not
+% be set).
 % TODO: probably this should be integrated with getAndCheckDefault etc.
     if ~isNone(color)
         [m2t, xcolor] = getColor(m2t, handle, color, 'patch');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4440,16 +4440,8 @@ function [pTicks, pTickLabels] = ...
             ) ...
             );
     end
-
-    % What MATLAB does when there the number of ticks and tick labels do not
-    % coincide is somewhat unclear. To fix bug
-    %     https://github.com/matlab2tikz/matlab2tikz/issues/161,
-    % cut off the first entries in `ticks`.
-    m = length(ticks);
-    n = length(tickLabels);
-    if n < m
-        ticks = ticks(m-n+1:end);
-    end
+    
+    ticks = removeSuperfluousTicks(ticks, tickLabels);
 
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Check if tickLabels are really necessary (and not already covered by
@@ -4515,6 +4507,17 @@ function [pTicks, pTickLabels] = ...
         pTickLabels = join(m2t, tickLabels, ',');
     else
         pTickLabels = [];
+    end
+end
+% ==============================================================================
+function ticks = removeSuperfluousTicks(ticks, tickLabels)
+% What MATLAB does when the number of ticks and tick labels is not the same,
+% is somewhat unclear. Cut of the first entries to fix bug 
+%     https://github.com/matlab2tikz/matlab2tikz/issues/161,
+    m = length(ticks);
+    n = length(tickLabels);
+    if n < m
+        ticks = ticks(m-n+1:end);
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1836,8 +1836,7 @@ function [m2t, str] = drawPatch(m2t, handle)
         [m2t, drawOptions] = assignColor(m2t, handle, drawOptions, 'fill', ...
                                          s.faceColor);
         
-    % Multiple patches    
-    else
+    else % Multiple patches    
         
         % Patch table type
         ptType      = 'patch table';
@@ -4457,10 +4456,16 @@ function [pTicks, pTickLabels] = ...
     
     ticks = removeSuperfluousTicks(ticks, tickLabels);
 
-    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    isNeeded = areTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis);
+    
+    pTickLabels = formatPgfTickLabels(m2t, isNeeded, tickLabels, ...
+        isLogAxis, tickLabelMode);
+end
+% ==============================================================================
+function bool = areTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis)
     % Check if tickLabels are really necessary (and not already covered by
     % the tick values themselves).
-    plotLabelsNecessary = false;
+    bool = false;
 
     k = find(ticks ~= 0.0, 1); % get an index with non-zero tick value
     if isLogAxis || isempty(k) % only a 0-tick
@@ -4495,12 +4500,15 @@ function [pTicks, pTickLabels] = ...
             s = str2double(tickLabels{k});
         end
         if isnan(s)  ||  abs(ticks(k)-s*scalingFactor) > m2t.tol
-            plotLabelsNecessary = true;
-            break;
+            bool = true;
+            return; 
         end
     end
-    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
+end
+% ==============================================================================
+function pTickLabels = formatPgfTickLabels(m2t, plotLabelsNecessary, ...
+        tickLabels, isLogAxis, tickLabelMode)
+% formats the tick labels for pgfplots
     if plotLabelsNecessary
         % if the axis is logscaled, MATLAB does not store the labels,
         % but the exponents to 10

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1556,10 +1556,10 @@ end
 % ==============================================================================
 function lineOpts = getLineOptions(m2t, lineStyle, lineWidth)
 % Gathers the line options.
-    lineOpts = cell(0);
+    lineOpts = opts_new();
 
     if ~isNone(lineStyle) && (lineWidth > m2t.tol)
-        lineOpts{end+1} = sprintf('%s', translateLineStyle(lineStyle));
+        lineOpts = opts_add(lineOpts, translateLineStyle(lineStyle));
     end
 
     % Take over the line width in any case when in strict mode. If not, don't add
@@ -1570,8 +1570,10 @@ function lineOpts = getLineOptions(m2t, lineStyle, lineWidth)
     matlabDefaultLineWidth = 0.5;
     if m2t.cmdOpts.Results.strict ...
             || ~abs(lineWidth-matlabDefaultLineWidth) <= m2t.tol
-        lineOpts{end+1} = sprintf('line width=%.1fpt', lineWidth);
+        lineOpts = opts_add(lineOpts, 'line width', sprintf('%.1fpt', lineWidth));
     end
+    
+    lineOpts = opts_to_legacy(lineOpts); %FIXME: move into call sites
 end
 % ==============================================================================
 function [m2t, drawOptions] = getMarkerOptions(m2t, h)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1445,8 +1445,7 @@ function [m2t, str] = writePlotData(m2t, str, data, drawOptions)
             %if ~isempty(m2t.legendHandles) && (~m2t.currentHandleHasLegend || k < length(dataCell))
             if ~m2t.currentHandleHasLegend || k < length(dataCell)
                 % No legend entry found. Don't include plot in legend.
-                
-                hiddenDrawOptions = opts_add(drawOptions, 'forget plot');
+                hiddenDrawOptions = maybeShowInLegend(false, drawOptions);
                 opts = opts_print(m2t, hiddenDrawOptions, ',');
             else
                 opts = opts_print(m2t, drawOptions, ',');
@@ -1859,7 +1858,7 @@ function [m2t, str] = drawPatch(m2t, handle)
            isFaceColorFlat, s);
     end
     
-    drawOptions = showInLegend(m2t.currentHandleHasLegend, drawOptions);
+    drawOptions = maybeShowInLegend(m2t.currentHandleHasLegend, drawOptions);
     m2t = jumpAtUnboundCoords(m2t, Faces(:));
     
     % Add Faces table
@@ -1941,9 +1940,9 @@ function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
     end
 end
 % ==============================================================================
-function [drawOptions] = showInLegend(currentHandleHasLegend, drawOptions)
-% hides the current plot from the legend
-    if ~currentHandleHasLegend
+function [drawOptions] = maybeShowInLegend(showInLegend, drawOptions)
+% sets the appropriate options to show/hide the plot in the legend
+    if ~showInLegend
         % No legend entry found. Don't include plot in legend.
         drawOptions = opts_add(drawOptions, 'forget plot', '');
     end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1391,6 +1391,7 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     % Line and marker options
     lineOptions          = getLineOptions(m2t, lineStyle, lineWidth);
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
+    markerOptions = opts_to_legacy(markerOptions); %FIXME: remove this
     drawOptions = [{sprintf('color=%s', xcolor)}, lineOptions, markerOptions];
 
     % Check for "special" lines, e.g.:
@@ -1628,7 +1629,6 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
             drawOptions = opts_add(drawOptions, 'mark options', ['{' mo '}']);
         end
     end
-    drawOptions = opts_to_legacy(drawOptions); %FIXME: move this to the call sites
 end
 % ==============================================================================
 function [tikzMarkerSize, isDefault] = ...
@@ -1814,8 +1814,7 @@ function [m2t, str] = drawPatch(m2t, handle)
     
     % Marker options
     [m2t, markerOptions] = getMarkerOptions(m2t, handle);
-%     drawOptions          = opts_merge(drawOptions, markerOptions); % TODO: use opts_* API in getMarkerOptions
-    drawOptions = [drawOptions; [markerOptions(:), repmat({[]},numel(markerOptions),1)]];
+    drawOptions          = opts_merge(drawOptions, markerOptions);
     
     % Line options
     lineStyle   = get(handle, 'LineStyle');
@@ -3398,6 +3397,7 @@ function [m2t, str] = drawStemOrStairSeries_(m2t, h, plotType)
 
     lineOptions = getLineOptions(m2t, lineStyle, lineWidth);
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
+    markerOptions = opts_to_legacy(markerOptions); %FIXME: remove this 
 
     drawOptions = [plotType,                      ...
         sprintf('color=%s', plotColor),...

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1860,7 +1860,7 @@ function [m2t, str] = drawPatch(m2t, handle)
         end
         drawOptions = opts_add(drawOptions,s.plotType,''); % Eventually add mesh, but after patch!
 
-        drawOptions = getPatchShapeOpts(m2t, handle, drawOptions, patchOptions);
+        drawOptions = getPatchShape(m2t, handle, drawOptions, patchOptions);
 
         [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
          columnNames] = setColorsOfPatches(m2t, handle, drawOptions, ...
@@ -1978,7 +1978,7 @@ function [m2t, options] = setColor(m2t, handle, options, property, color, noneVa
     end
 end
 % ==============================================================================
-function drawOptions = getPatchShapeOpts(m2t, h, drawOptions, patchOptions)
+function drawOptions = getPatchShape(m2t, h, drawOptions, patchOptions)
 % Retrieves the shape options (i.e. number of vertices) of patch objects
 % Depending on the number of vertices, patches can be triangular, rectangular 
 % or polygonal

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1611,9 +1611,8 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         markerFaceColor = get(h, 'markerfaceColor');
         markerEdgeColor = get(h, 'markeredgeColor');
         
-        [tikzMarker, markOptions] = translateMarker(m2t, marker,         ...
-            opts_to_legacy(markOptions), ~isNone(markerFaceColor));
-        markOptions = opts_from_legacy(markOptions); %FIXME: move this into translateMarker
+        [tikzMarker, markOptions] = translateMarker(m2t, marker, ...
+                                        markOptions, ~isNone(markerFaceColor));
         
         [m2t, markOptions] = assignColor(m2t, h, markOptions, 'fill', markerFaceColor);
         
@@ -1742,15 +1741,15 @@ function [tikzMarker, markOptions] = ...
 
                 case 'v'
                     tikzMarker = 'triangle';
-                    markOptions{end+1} = 'rotate=180';
+                    markOptions = opts_add(markOptions, 'rotate', '180');
 
                 case '<'
                     tikzMarker = 'triangle';
-                    markOptions{end+1} = 'rotate=90';
+                    markOptions = opts_add(markOptions, 'rotate', '90');
 
                 case '>'
                     tikzMarker = 'triangle';
-                    markOptions{end+1} = 'rotate=270';
+                    markOptions = opts_add(markOptions, 'rotate', '270');
 
                 case {'p','pentagram'}
                     tikzMarker = 'star';
@@ -3008,7 +3007,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     markerEdgeColor = get(h, 'MarkerEdgeColor');
     hasFaceColor = ~isNone(markerFaceColor);
     hasEdgeColor = ~isNone(markerEdgeColor);
-    markOptions = cell(0);
+    markOptions = opts_new();
     [tikzMarker, markOptions] = translateMarker(m2t, matlabMarker, ...
         markOptions, hasFaceColor);
 
@@ -3027,7 +3026,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
         if constMarkerkSize
             drawOptions = { 'only marks', ...
                 ['mark=' tikzMarker], ...
-                ['mark options={', join(m2t, markOptions, ','), '}'],...
+                ['mark options={', opts_print(m2t, markOptions, ','), '}'],...
                 sprintf('mark size=%.4fpt', sData)};
             if hasFaceColor && hasEdgeColor
                 drawOptions{end+1} = { ['draw=' ecolor], ...
@@ -3037,7 +3036,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
             end
         else % if changing marker size but same color on all marks
             markerOptions = { ['mark=', tikzMarker], ...
-                ['mark options={', join(m2t, markOptions, ','), '}'] };
+                ['mark options={', opts_print(m2t, markOptions, ','), '}'] };
             if hasEdgeColor
                 markerOptions{end+1} = ['draw=' ecolor];
             else
@@ -3051,7 +3050,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
                 'only marks', ...
                 ['color=' xcolor], ...
                 ['mark=' tikzMarker], ...
-                ['mark options={', join(m2t, markOptions, ','), '}'] };
+                ['mark options={', opts_print(m2t, markOptions, ','), '}'] };
             if ~hasFaceColor
                 drawOptions{end+1} = { ['scatter/use mapped color=' xcolor] };
             else
@@ -3063,7 +3062,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
             % TODO Get this in order as soon as Pgfplots can do "scatter rgb".
     else
         markerOptions = { ['mark=', tikzMarker], ...
-            ['mark options={', join(m2t, markOptions, ','), '}'] };
+            ['mark options={', opts_print(m2t, markOptions, ','), '}'] };
         if hasEdgeColor && hasFaceColor
             [m2t, ecolor] = getColor(m2t, h, markerEdgeColor,'patch');
             markerOptions{end+1} = ['draw=' ecolor];

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1968,7 +1968,11 @@ function [m2t, options] = assignColor(m2t, handle, options, property, color, non
 end
 % ==============================================================================
 function drawOptions = getPatchShapeOpts(m2t, h, drawOptions, patchOptions)
-% retrieves the shape options (i.e. number of vertices) of patch objects
+% Retrieves the shape options (i.e. number of vertices) of patch objects
+% Depending on the number of vertices, patches can be triangular, rectangular 
+% or polygonal
+% See pgfplots 1.12 manual section 5.8.1 "Additional Patch Types" and the
+% patchplots library
     vertexCount = size(get(h, 'Faces'), 2);
 
     switch vertexCount
@@ -2010,8 +2014,11 @@ function [cycle] = conditionallyCyclePath(data)
 end
 % ==============================================================================
 function m2t = jumpAtUnboundCoords(m2t, data)
-% signals the axis that unbound coords should be a jump
+% signals the axis to allow discontinuities in the plot at unbounded 
+% coordinates (i.e. Inf and NaN). 
+% See also pgfplots 1.12 manual section 4.5.13 "Interrupted Plots".
     if any(~isfinite(data(:)))
+        m2t = needsPgfplotsVersion(m2t, [1 4]);
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, 'unbounded coords', 'jump');
     end
@@ -4478,13 +4485,13 @@ function [pTicks, pTickLabels] = ...
     
     ticks = removeSuperfluousTicks(ticks, tickLabels);
 
-    isNeeded = areTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis);
+    isNeeded = isTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis);
     
     pTickLabels = formatPgfTickLabels(m2t, isNeeded, tickLabels, ...
         isLogAxis, tickLabelMode);
 end
 % ==============================================================================
-function bool = areTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis)
+function bool = isTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis)
     % Check if tickLabels are really necessary (and not already covered by
     % the tick values themselves).
     bool = false;

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1915,11 +1915,7 @@ function [m2t, str] = drawPatch(m2t, handle)
         end
     end
     
-    if ~m2t.currentHandleHasLegend
-        % No legend entry found. Don't include plot in legend.
-        drawOptions = opts_add(drawOptions,'forget plot','');
-    end
-
+    drawOptions = showInLegend(m2t.currentHandleHasLegend, drawOptions);
     m2t = jumpAtUnboundCoords(m2t, Faces(:));
     
     % Add Faces table
@@ -1935,6 +1931,14 @@ function [m2t, str] = drawPatch(m2t, handle)
     
     str = sprintf('%s\n\\%s[%s]\ntable[%s] {%s}%s;\n',...
         str, plotCmd, drawOpts, opts_print(m2t, tabOpts, ', '), verticesTable, cycle);
+end
+% ==============================================================================
+function [drawOptions] = showInLegend(currentHandleHasLegend, drawOptions)
+% hides the current plot from the legend
+    if ~currentHandleHasLegend
+        % No legend entry found. Don't include plot in legend.
+        drawOptions = opts_add(drawOptions, 'forget plot', '');
+    end
 end
 % ==============================================================================
 function [m2t, options] = assignColor(m2t, handle, options, property, color, noneValue)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3097,27 +3097,9 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Plot the thing.
-    if ~m2t.axesContainers{end}.is3D
-        env = 'addplot';
-        if length(sData) == 1
-            nColumns = 2;
-            data = [xData(:), yData(:)];
-        else
-            nColumns = 3;
-            sColumn = 2;
-            data = [xData(:), yData(:), sData(:)];
-        end
-    else
-        env = 'addplot3';
-        if length(sData) == 1
-            nColumns = 3;
-            data = applyHgTransform(m2t, [xData(:),yData(:),zData(:)]);
-        else
-            nColumns = 4;
-            sColumn = 3;
-            data = applyHgTransform(m2t, [xData(:),yData(:),zData(:),sData(:)]);
-        end
-    end
+    [env, data, sColumn] = organizeScatterData(m2t, xData, yData, zData, sData);
+    nColumns = size(data, 2);
+    
     if ~constMarkerkSize %
         drawOptions = opts_add(drawOptions, 'visualization depends on', ...
             ['{\thisrowno{', num2str(sColumn), '} \as \perpointmarksize}']);
@@ -3150,6 +3132,28 @@ function [m2t, str] = drawScatterPlot(m2t, h)
         drawOpts, opts_print(m2t, tabOpts, ','), table);
 end
 % ==============================================================================
+function [env, data, sColumn] = organizeScatterData(m2t, xData, yData, zData, sData)
+% reorganizes the {X,Y,Z,S} data into a single matrix
+    sColumn = [];
+    if ~m2t.axesContainers{end}.is3D
+        env = 'addplot';
+        if length(sData) == 1
+            data = [xData(:), yData(:)];
+        else
+            sColumn = 2;
+            data = [xData(:), yData(:), sData(:)];
+        end
+    else
+        env = 'addplot3';
+        if length(sData) == 1
+            data = applyHgTransform(m2t, [xData(:),yData(:),zData(:)]);
+        else
+            sColumn = 3;
+            data = applyHgTransform(m2t, [xData(:),yData(:),zData(:),sData(:)]);
+        end
+    end
+end
+% ===
 function [m2t, xcolor, hasColor] = getColorOfMarkers(m2t, h, name, cData)
     color = get(h, name);
     hasColor = ~isNone(color);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5819,35 +5819,6 @@ function opts = opts_append_userdefined(opts, userDefined)
         end
     end
 end
-function c = opts_to_legacy(opts)
-% converts an option array to the legacy (1D) cell format
-% TODO: eventually inline this function back into opts_print
-    nOpts = size(opts,1);
-    c = cell(1,nOpts);
-    for k = 1:nOpts
-        if isempty(opts{k,2})
-            c{k} = sprintf('%s', opts{k,1});
-        else
-            c{k} = sprintf('%s=%s', opts{k,1}, opts{k,2});
-        end
-    end
-end
-function opts = opts_from_legacy(c)
-% converts a legacy option array to an actual option array
-% TODO: eventually remove this function
-    opts = opts_new();
-    for kOption = 1:numel(c)
-        entry = c{kOption};
-        iSplit = strfind(entry,'=');
-        if isempty(iSplit)
-            opts = opts_append(opts, entry);
-        else
-            key = entry(1:iSplit(1)-1);
-            value = entry(iSplit(1)+1:end);
-            opts = opts_append(opts, key, value);
-        end
-    end
-end
 function opts = opts_remove(opts, varargin)
 % remove some key-value pairs from an options array
     keysToDelete = varargin;
@@ -5865,7 +5836,15 @@ function opts = opts_merge(opts, varargin)
 end
 function str  = opts_print(m2t, opts, sep)
 % pretty print an options array
-    c = opts_to_legacy(opts);
+    nOpts = size(opts,1);
+    c = cell(1,nOpts);
+    for k = 1:nOpts
+        if isempty(opts{k,2})
+            c{k} = sprintf('%s', opts{k,1});
+        else
+            c{k} = sprintf('%s=%s', opts{k,1}, opts{k,2});
+        end
+    end
     str = join(m2t, c, sep);
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5795,6 +5795,7 @@ function c = opts_to_legacy(opts)
     end
 end
 function opts = opts_from_legacy(c)
+% converts a legacy option array to an actual option array
     opts = opts_new();
     for kOption = 1:numel(c)
         entry = c{kOption};

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3444,7 +3444,7 @@ function [m2t, str] = drawAreaSeries(m2t, h)
     if ~isfield(m2t, 'addedAreaOption') || isempty(m2t.addedAreaOption) || ~m2t.addedAreaOption
         % Add 'area style' to axes options.
         m2t.axesContainers{end}.options = ...
-            opts_add(m2t.axesContainers{end}.options, 'area style', []);
+            opts_add(m2t.axesContainers{end}.options, 'area style');
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, 'stack plots', 'y');
         m2t.addedAreaOption = true;
@@ -3452,7 +3452,7 @@ function [m2t, str] = drawAreaSeries(m2t, h)
 
     % Handle draw options.
     % define edge color
-    drawOptions = {};
+    drawOptions = opts_new();
     edgeColor = get(h, 'EdgeColor');
     [m2t, xEdgeColor] = getColor(m2t, h, edgeColor, 'patch');
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3469,13 +3469,13 @@ function [m2t, str] = drawAreaSeries(m2t, h)
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % gather the draw options
     lineStyle = get(h, 'LineStyle');
-    drawOptions{end+1} = sprintf('fill=%s', xFaceColor);
+    drawOptions = opts_add(drawOptions, 'fill', xFaceColor);
     if isNone(lineStyle)
-        drawOptions{end+1} = 'draw=none';
+        drawOptions = opts_add(drawOptions, 'draw', 'none');
     else
-        drawOptions{end+1} = sprintf('draw=%s', xEdgeColor);
+        drawOptions = opts_add(drawOptions, 'draw', xEdgeColor);
     end
-    drawOpts = join(m2t, drawOptions, ',');
+    drawOpts = opts_print(m2t, drawOptions, ',');
 
     % plot the thing
     xData = get(h, 'XData');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1391,15 +1391,16 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     % Line and marker options
     lineOptions          = getLineOptions(m2t, lineStyle, lineWidth);
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
-    lineOptions = opts_to_legacy(lineOptions); %FIXME: remove this
-    markerOptions = opts_to_legacy(markerOptions); %FIXME: remove this
-    drawOptions = [{sprintf('color=%s', xcolor)}, lineOptions, markerOptions];
+
+    drawOptions = opts_new();
+    drawOptions = opts_add(drawOptions, 'color', xcolor);
+    drawOptions = opts_merge(drawOptions, lineOptions, markerOptions);
 
     % Check for "special" lines, e.g.:
     if strcmp(get(h, 'Tag'), 'zplane_unitcircle')
         % Draw unit circle and axes.
         % TODO Don't hardcode "10".
-        opts = join(m2t, drawOptions, ',');
+        opts = opts_print(m2t, drawOptions, ',');
         str = [sprintf('\\draw[%s] (axis cs:0,0) circle[radius=1];\n', opts),...
             sprintf('\\draw[%s] (axis cs:-10,0)--(axis cs:10,0);\n', opts), ...
             sprintf('\\draw[%s] (axis cs:0,-10)--(axis cs:0,10);\n', opts)];
@@ -1430,7 +1431,7 @@ function [m2t, str] = writePlotData(m2t, str, data, drawOptions)
         % Don't try to be smart in parametric 3d plots: Just plot all the data.
         [m2t, table, tabOpts] = makeTable(m2t, {'','',''}, data);
         str = sprintf('%s\\addplot3 [%s]\n table[%s] {%s};\n ', ...
-                      str, join(m2t, drawOptions, ','), ...
+                      str, opts_print(m2t, drawOptions, ','), ...
                       opts_print(m2t, tabOpts,','), table);
     else
         % split the data into logical chunks
@@ -1444,9 +1445,11 @@ function [m2t, str] = writePlotData(m2t, str, data, drawOptions)
             %if ~isempty(m2t.legendHandles) && (~m2t.currentHandleHasLegend || k < length(dataCell))
             if ~m2t.currentHandleHasLegend || k < length(dataCell)
                 % No legend entry found. Don't include plot in legend.
-                opts = join(m2t, [drawOptions, {'forget plot'}], ',');
+                
+                hiddenDrawOptions = opts_add(drawOptions, 'forget plot');
+                opts = opts_print(m2t, hiddenDrawOptions, ',');
             else
-                opts = join(m2t, drawOptions, ',');
+                opts = opts_print(m2t, drawOptions, ',');
             end
 
             [m2t, Part] = plotLine2d(m2t, opts, dataCell{k});

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -673,7 +673,7 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, h)
 
             case 'rectangle'
                 [m2t, str] = drawRectangle(m2t, child);
-                
+
             case 'histogram'
                 [m2t, str] = drawHistogram(m2t, child);
 
@@ -812,7 +812,7 @@ function m2t = drawAxes(m2t, handle)
 
     % update gca
     m2t.currentHandles.gca = handle;
-    
+
     % Check if axis is 3d
     % In MATLAB, all plots are treated as 3D plots; it's just the view that
     % makes 2D plots appear like 2D.
@@ -824,7 +824,7 @@ function m2t = drawAxes(m2t, handle)
     m2t.gcaAssociatedLegend = getAssociatedLegend(m2t, handle);
 
     m2t = retrievePositionOfAxes(m2t, handle);
-    
+
     % Axis direction
     for axis = 'xyz'
         m2t.([axis 'AxisReversed']) = ...
@@ -855,9 +855,9 @@ function m2t = drawAxes(m2t, handle)
 
     m2t.axesContainers{end}.options = opts_merge(m2t.axesContainers{end}.options, ...
                                             xopts, yopts);
-    
+
     m2t = add3DOptionsOfAxes(m2t, handle);
-    
+
     if ~isVisible(handle)
         % Setting hide{x,y} axis also hides the axis labels in Pgfplots whereas
         % in MATLAB, they may still be visible. Well.
@@ -883,7 +883,7 @@ function m2t = drawAxes(m2t, handle)
         %    return
     end
     m2t.axesContainers{end}.name = 'axis';
-    
+
     m2t = drawBackgroundOfAxes(m2t, handle);
     m2t = drawTitleOfAxes(m2t, handle);
     m2t = drawBoxAndLineLocationsOfAxes(m2t, handle);
@@ -964,7 +964,7 @@ end
 function m2t = retrievePositionOfAxes(m2t, handle)
 % This retrieves the position of an axes and stores it into the m2t data
 % structure
-    
+
     pos = getAxesPosition(m2t, handle, m2t.cmdOpts.Results.width, ...
                           m2t.cmdOpts.Results.height, m2t.axesBoundingBox);
     % set the width
@@ -1027,7 +1027,7 @@ function [m2t, opts] = getTitleOrLabel_(m2t, handle, opts, labelKind, tikzKeywor
         tikzKeyword = lower(labelKind);
     end
     object = get(handle, labelKind);
-    
+
     str = get(object, 'String');
     if ~isempty(str)
         interpreter = get(object, 'Interpreter');
@@ -1052,7 +1052,7 @@ function m2t = drawBoxAndLineLocationsOfAxes(m2t, h)
     yLoc          = get(h, 'YAxisLocation');
     isXaxisBottom = strcmpi(xLoc,'bottom');
     isYaxisLeft   = strcmpi(yLoc,'left');
-    
+
     % Only flip the labels to the other side if not at the default
     % left/bottom positions
     if isBoxOn
@@ -1066,7 +1066,7 @@ function m2t = drawBoxAndLineLocationsOfAxes(m2t, h)
             opts_add(m2t.axesContainers{end}.options, ...
             'yticklabel pos','right');
         end
-        
+
     % Position axes lines (strips the box)
     else
         m2t.axesContainers{end}.options = ...
@@ -1082,7 +1082,7 @@ function m2t = drawBoxAndLineLocationsOfAxes(m2t, h)
                 opts_add(m2t.axesContainers{end}.options, ...
                 'axis z line*', 'left');
         end
-    end       
+    end
 end
 % ==============================================================================
 function m2t = drawLegendOptionsOfAxes(m2t, handle)
@@ -1178,7 +1178,7 @@ end
 % ==============================================================================
 function [m2t, options] = getAxisOptions(m2t, handle, axis)
     assertValidAxisSpecifier(axis);
-    
+
     options = opts_new();
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % axis colors
@@ -1272,7 +1272,7 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
     keywordMinorTick = [upper(axis), 'MinorTick'];
     hasMinorTicks = strcmpi(getOrDefault(handle, keywordMinorTick, 'off'), 'on');
     tickDirection = getOrDefault(handle, 'TickDir', 'in');
-    
+
     options = setAxisTicks(m2t, options, axis, pgfTicks, pgfTickLabels, ...
         hasMinorTicks, tickDirection);
 end
@@ -1489,7 +1489,7 @@ function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar
         labelName = sprintf('addplot:%s%d', name, m2t.automaticLabelIndex);
         labelCode = sprintf('\\label{%s}\n', labelName);
         m2t.automaticLabelIndex = m2t.automaticLabelIndex + 1;
-        
+
         userWarning(m2t, 'Automatically added label ''%s'' for line plot.', labelName);
         generatedCodeSoFar = [generatedCodeSoFar, labelCode];
     end
@@ -1529,7 +1529,7 @@ function dataCellNew = splitByArraySize(m2t, dataCell)
 % As a work-around, the plot is split into several smaller plots, and this
 % function does the job.
     dataCellNew = cell(0);
-    
+
     %TODO: pre-allocate the cell array such that it doesn't grow during the loop
     %TODO: scale `maxChunkLength` with the number of columns in the data array
 
@@ -1542,7 +1542,7 @@ function dataCellNew = splitByArraySize(m2t, dataCell)
             % Copy over the data to the new containers.
             dataCellNew{end+1} = data{1}(chunkStart:chunkEnd,:);
 
-            % Add an extra (overlap) point to the data stream; 
+            % Add an extra (overlap) point to the data stream;
             % otherwise the line between two data chunks would be broken.
             % Technically, this is only needed when the plot has a line
             % connecting the points, but the additional cost when there is no
@@ -1614,12 +1614,12 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         % get the marker color right
         markerFaceColor = get(h, 'markerfaceColor');
         markerEdgeColor = get(h, 'markeredgeColor');
-        
+
         [tikzMarker, markOptions] = translateMarker(m2t, marker, ...
                                         markOptions, ~isNone(markerFaceColor));
-        
+
         [m2t, markOptions] = setColor(m2t, h, markOptions, 'fill', markerFaceColor);
-        
+
         if ~strcmpi(markerEdgeColor,'auto')
             [m2t, markOptions] = setColor(m2t, h, markOptions, 'draw', markerEdgeColor);
         end
@@ -1783,12 +1783,12 @@ function [m2t, str] = drawPatch(m2t, handle)
     % This is for a quirky workaround for stacked bar plots.
     m2t.axesContainers{end}.nonbarPlotsPresent = true;
 
-    % Each row of the faces matrix represents a distinct patch 
+    % Each row of the faces matrix represents a distinct patch
     % NOTE: pgfplot uses zero-based indexing into vertices and interpolates
     % counter-clockwise
     Faces    = get(handle,'Faces')-1;
     Vertices = get(handle,'Vertices');
-    
+
     % 3D vs 2D
     is3D = m2t.axesContainers{end}.is3D;
     if is3D
@@ -1800,25 +1800,25 @@ function [m2t, str] = drawPatch(m2t, handle)
         plotCmd     = 'addplot';
         Vertices    = Vertices(:,1:2);
     end
-        
+
     % Process fill, edge colors and shader
     [m2t,patchOptions, s] = shaderOpts(m2t,handle,'patch');
-    
+
     % Return empty axes if no face or edge colors
     if isNone(s.plotType)
         return
     end
-    
+
     % -----------------------------------------------------------------------
     % gather the draw options
     % Make sure that legends are shown in area mode.
     drawOptions = opts_add(opts_new,'area legend','');
     verticesTableOptions = opts_new();
-    
+
     % Marker options
     [m2t, markerOptions] = getMarkerOptions(m2t, handle);
     drawOptions          = opts_merge(drawOptions, markerOptions);
-    
+
     % Line options
     lineStyle   = get(handle, 'LineStyle');
     lineWidth   = get(handle, 'LineWidth');
@@ -1893,24 +1893,24 @@ function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
 
     % TODO: this function can probably be split further, just look at all those
     % parameters being passed.
-    
+
     fvCData   = get(handle,'FaceVertexCData');
     rowsCData = size(fvCData,1);
-    
+
     % We have CData for either all faces or vertices
     if rowsCData > 1
-        
+
         % Add the color map
         m2t.axesContainers{end}.options = ...
             opts_add(m2t.axesContainers{end}.options, ...
             matlab2pgfplotsColormap(m2t, m2t.currentHandles.colormap), []);
-        
+
         % Determine if mapping is direct or scaled
         CDataMapping = get(handle,'CDataMapping');
         if strcmpi(CDataMapping, 'direct')
             drawOptions = opts_add(drawOptions, 'colormap access','direct');
         end
-        
+
         % Switch to face CData if not using interpolated shader
         isVerticesCData = rowsCData == size(Vertices,1);
         if isFaceColorFlat && isVerticesCData
@@ -1919,18 +1919,18 @@ function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
             rowsCData       = size(fvCData,1);
             isVerticesCData = false;
         end
-        
+
         % Point meta as true color CData, i.e. RGB in [0,1]
         if size(fvCData,2) == 3
             % Create additional custom colormap
             m2t.axesContainers{end}.options(end+1,:) = ...
                 {matlab2pgfplotsColormap(m2t, fvCData, 'patchmap'), []};
             drawOptions = opts_append(drawOptions, 'colormap name','patchmap');
-            
+
             % Index into custom colormap
             fvCData = (0:rowsCData-1)';
         end
-        
+
         % Add pointmeta data to vertices or faces
         if isVerticesCData
             columnNames{end+1}   = 'c';
@@ -1940,11 +1940,11 @@ function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
             ptType = 'patch table with point meta';
             Faces  = [Faces fvCData];
         end
-        
+
     else
         % Scalar FaceVertexCData, i.e. one color mapping for all patches,
         % used e.g. by Octave in drawing barseries
-        
+
         [m2t,xFaceColor] = getColor(m2t, handle, s.faceColor, 'patch');
         drawOptions      = opts_add(drawOptions, 'fill', xFaceColor);
     end
@@ -1967,7 +1967,7 @@ function [m2t, options] = setColor(m2t, handle, options, property, color, noneVa
     if ~isNone(color)
         [m2t, xcolor] = getColor(m2t, handle, color, 'patch');
         if ~isempty(xcolor)
-            % this may happen when color == 'flat' and CData is Nx3, e.g. in 
+            % this may happen when color == 'flat' and CData is Nx3, e.g. in
             % scatter plot or in patches
             options = opts_add(options, property, xcolor);
         end
@@ -1980,7 +1980,7 @@ end
 % ==============================================================================
 function drawOptions = getPatchShape(m2t, h, drawOptions, patchOptions)
 % Retrieves the shape options (i.e. number of vertices) of patch objects
-% Depending on the number of vertices, patches can be triangular, rectangular 
+% Depending on the number of vertices, patches can be triangular, rectangular
 % or polygonal
 % See pgfplots 1.12 manual section 5.8.1 "Additional Patch Types" and the
 % patchplots library
@@ -2025,8 +2025,8 @@ function [cycle] = conditionallyCyclePath(data)
 end
 % ==============================================================================
 function m2t = jumpAtUnboundCoords(m2t, data)
-% signals the axis to allow discontinuities in the plot at unbounded 
-% coordinates (i.e. Inf and NaN). 
+% signals the axis to allow discontinuities in the plot at unbounded
+% coordinates (i.e. Inf and NaN).
 % See also pgfplots 1.12 manual section 4.5.13 "Interrupted Plots".
     if any(~isfinite(data(:)))
         m2t = needsPgfplotsVersion(m2t, [1 4]);
@@ -2080,7 +2080,7 @@ function [m2t, str] = imageAsPNG(m2t, handle, xData, yData, cData)
         alphaData = alphaData(ones(size(colorData(:,:,1))));
     end
     [colorData, alphaData] = flipImageIfAxesReversed(m2t, colorData, alphaData);
-    
+
     % Write an indexed or a truecolor image
     hasAlpha = true;
     if isfloat(alphaData) && all(alphaData(:) == 1)
@@ -2136,14 +2136,14 @@ end
 function [m2t, str] = imageAsTikZ(m2t, handle, xData, yData, cData)
 % writes an image as raw TikZ commands (STRONGLY DISCOURAGED)
     str = '';
-    
+
     % set up cData
     if ndims(cData) == 3
         cData = cData(end:-1:1,:,:);
     else
         cData = cData(end:-1:1,:);
     end
-    
+
 
     % Generate uniformly distributed X, Y, although xData and yData may be
     % non-uniform.
@@ -2222,7 +2222,7 @@ function alpha = normalizedAlphaValues(m2t, alpha, handle)
             error('matlab2tikz:UnknownAlphaMapping', ...
                   'Unknown alpha mapping "%s"', alphaMapping);
     end
-    
+
     if isfloat(alpha) %important, alpha data can have integer type which should not be scaled
         alpha = min(1,max(alpha,0)); % clip at range [0, 1]
     end
@@ -2234,7 +2234,7 @@ function [m2t, str] = drawContour(m2t, h)
   % Retrieve ContourMatrix
   contours = get(h,'ContourMatrix')';
   [istart, nrows] = findStartOfContourData(contours);
-    
+
   % Scale negative contours one level down (for proper coloring)
   Levels    = contours(istart,1);
   LevelList = get(h,'LevelList');
@@ -2244,36 +2244,36 @@ function [m2t, str] = drawContour(m2t, h)
       idx       = idx & ineg;
       contours(istart(idx)) = LevelList(pos(idx)-1);
   end
-    
+
   % Draw a contour group (MATLAB R2014b and newer only)
   isFilled = strcmpi(get(h,'Fill'),'on');
   if isFilled
       [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows);
-      
+
   else
       % Add colormap
       cmap = m2t.currentHandles.colormap;
       m2t.axesContainers{end}.options = ...
           opts_add(m2t.axesContainers{end}.options, ...
           matlab2pgfplotsColormap(m2t, cmap));
-      
+
       % Contour table in Matlab format
       plotoptions = opts_new();
       plotoptions = opts_add(plotoptions,'contour prepared');
       plotoptions = opts_add(plotoptions,'contour prepared format','matlab');
-      
+
       % Labels
       if strcmpi(get(h,'ShowText'),'off')
           plotoptions = opts_add(plotoptions,'contour/labels','false');
       end
-      
+
       % Make contour table
       [m2t, table, tabOpts] = makeTable(m2t, {'',''}, contours);
-      
+
       str = sprintf('\\addplot[%s] table[%s] {%%\n%s};\n', ...
           opts_print(m2t, plotoptions, ', '),...
           opts_print(m2t, tabOpts, ','), table);
-      
+
   end
 end
 % ==============================================================================
@@ -2437,38 +2437,38 @@ function [m2t, str] = drawHggroup(m2t, h)
 end
 % ==============================================================================
 function m2t = drawAnnotations(m2t)
-% Draws annotation in Matlab (Octave not supported). 
+% Draws annotation in Matlab (Octave not supported).
 
 % In HG1 annotations are children of an invisible axis called scribeOverlay.
 % In HG2 annotations are children of annotationPane object which does not
 % have any axis properties. Hence, we cannot simply handle it with a
-% drawAxes() call. 
+% drawAxes() call.
 
     % Octave
-    if strcmpi(getEnvironment,'Octave') 
+    if strcmpi(getEnvironment,'Octave')
         return
     end
 
     % Get annotation handles
     if isHG2
         annotPanes   = findobj(m2t.currentHandles.gcf,'Tag','scribeOverlay');
-        annotHandles = findobj(get(annotPanes,'Children'),'Visible','on'); 
+        annotHandles = findobj(get(annotPanes,'Children'),'Visible','on');
     else
         annotHandles = findobj(m2t.scribeLayer,'-depth',1,'Visible','on');
     end
-    
+
     % There are no anotations
     if isempty(annotHandles)
         return
     end
-    
+
     % Create fake simplified axes overlay (no children)
     warning('off', 'matlab2tikz:NoChildren')
     scribeLayer = axes('Units','Normalized','Position',[0,0,1,1],'Visible','off');
     m2t         = drawAxes(m2t, scribeLayer);
     warning('on', 'matlab2tikz:NoChildren')
-    
-    % Plot in reverse to preserve z-ordering and assign the converted 
+
+    % Plot in reverse to preserve z-ordering and assign the converted
     % annotations to the converted fake overlay
     for ii = numel(annotHandles):-1:1
         m2t = drawAnnotationsHelper(m2t,annotHandles(ii));
@@ -2495,17 +2495,17 @@ function m2t = drawAnnotationsHelper(m2t,h)
         % Ellipse
         case {'scribe.scribeellipse','matlab.graphics.shape.Ellipse'}
             [m2t, str] = drawEllipse(m2t, h);
-        
-        % Arrows 
+
+        % Arrows
         case {'scribe.arrow', 'scribe.doublearrow'}%,...
               %'matlab.graphics.shape.Arrow', 'matlab.graphics.shape.DoubleEndArrow'}
             % Annotation: single and double Arrow, line
-            % TODO: 
+            % TODO:
             % - write a drawArrow(). Handle all info info directly
             %   without using handleAllChildren() since HG2 does not have
-            %   children (so no shortcut). 
-            % - It would be good if drawArrow() was callable on a 
-            %   matlab.graphics.shape.TextArrow object to draw the arrow 
+            %   children (so no shortcut).
+            % - It would be good if drawArrow() was callable on a
+            %   matlab.graphics.shape.TextArrow object to draw the arrow
             %   part.
             [m2t, str] = handleAllChildren(m2t, h);
 
@@ -2516,8 +2516,8 @@ function m2t = drawAnnotationsHelper(m2t,h)
         % Tetx arrow
         case {'scribe.textarrow'}%,'matlab.graphics.shape.TextArrow'}
             % TODO: rewrite drawTextarrow. Handle all info info directly
-            %       without using handleAllChildren() since HG2 does not 
-            %       have children (so no shortcut) as used for 
+            %       without using handleAllChildren() since HG2 does not
+            %       have children (so no shortcut) as used for
             %       scribe.textarrow.
             [m2t, str] = drawTextarrow(m2t, h);
 
@@ -2547,7 +2547,7 @@ function [m2t,str] = drawSurface(m2t, h)
 
     [dx, dy, dz, numrows] = getXYZDataFromSurface(h);
     m2t = jumpAtUnboundCoords(m2t, [dx(:); dy(:); dz(:)]);
-    
+
     opts = addZBufferOptions(m2t, h, opts);
 
     % Check if 3D
@@ -2561,7 +2561,7 @@ function [m2t,str] = drawSurface(m2t, h)
         plotCmd     = 'addplot';
         data        = [dx(:), dy(:)];
     end
-    
+
     % There are several possibilities of how colors are specified for surface
     % plots:
     %    * explicitly by RGB-values,
@@ -2572,21 +2572,21 @@ function [m2t,str] = drawSurface(m2t, h)
     % Check if we need extra CData.
     CData = get(h, 'CData');
     if length(size(CData)) == 3 && size(CData, 3) == 3
-        
+
         % Create additional custom colormap
         nrows = size(data,1);
         CData = reshape(CData, nrows,3);
         m2t.axesContainers{end}.options(end+1,:) = ...
             {matlab2pgfplotsColormap(m2t, CData, 'patchmap'), []};
-        
+
         % Index into custom colormap
         color = (0:nrows-1)';
-        
+
         tabOpts = opts_add(tabOpts, 'colormap name','surfmap');
     else
         opts = opts_add(opts,matlab2pgfplotsColormap(m2t, m2t.currentHandles.colormap),'');
         % If NaNs are present in the color specifications, don't use them for
-        % Pgfplots; they may be interpreted as strings there. 
+        % Pgfplots; they may be interpreted as strings there.
         % Note:
         % Pgfplots actually does a better job than MATLAB in determining what
         % colors to use for the patches. The circular test case on
@@ -2608,7 +2608,7 @@ function [m2t,str] = drawSurface(m2t, h)
     % lines in the data list below. This makes it possible to reduce the
     % data writing to one single sprintf() call.
     opts = opts_add(opts,'mesh/rows',sprintf('%d', numrows));
-    
+
     % Print the addplot options
     str = sprintf('\n\\%s[%%\n%s,\n%s]', plotCmd, s.plotType, opts_print(m2t, opts, ','));
 
@@ -2629,12 +2629,12 @@ function [m2t,str] = drawSurface(m2t, h)
 end
 % ==============================================================================
 function opts = addZBufferOptions(m2t, h, opts)
-    % Enforce 'z buffer=sort' if shader is flat and is a 3D plot. It is to 
-    % avoid overlapping e.g. sphere plots and to properly mimic Matlab's 
+    % Enforce 'z buffer=sort' if shader is flat and is a 3D plot. It is to
+    % avoid overlapping e.g. sphere plots and to properly mimic Matlab's
     % coloring of faces.
     % NOTE:
-    % - 'z buffer=sort' is computationally more expensive for LaTeX, we 
-    %   could try to avoid it in some default situations, e.g. when dx and 
+    % - 'z buffer=sort' is computationally more expensive for LaTeX, we
+    %   could try to avoid it in some default situations, e.g. when dx and
     %   dy are rank-1-matrices.
     % - hist3D plots should not be z-sorted or the highest bars will cover
     %   the shortest one even if positioned in the back
@@ -2710,7 +2710,7 @@ function [m2t, str] = drawText(m2t, handle)
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % translate them to pgf style
     style = opts_new();
-    
+
     bgColor = get(handle,'BackgroundColor');
     [m2t, style] = setColor(m2t, handle, style, 'fill', bgColor);
 
@@ -2726,7 +2726,7 @@ function [m2t, str] = drawText(m2t, handle)
 
     EdgeColor = get(handle, 'EdgeColor');
     [m2t, style] = setColor(m2t, handle, style, 'draw', EdgeColor);
-    
+
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % plot the thing
     [m2t, posString] = getPositionOfText(m2t, handle);
@@ -2777,13 +2777,13 @@ function [m2t,posString] = getPositionOfText(m2t, h)
     pos   = get(h, 'Position');
     units = get(h, 'Units');
     is3D  = m2t.axesContainers{end}.is3D;
-    
+
     % Deduce if text or textbox
     type = get(h,'type');
     if isempty(type) || strcmpi(type,'hggroup')
         type = get(h,'ShapeType'); % Undocumented property valid from 2008a
     end
-    
+
     switch type
         case 'text'
             if is3D
@@ -2799,11 +2799,11 @@ function [m2t,posString] = getPositionOfText(m2t, h)
             %   - Alignment of the resized box
             pos  = pos(1:2);
             npos = 2;
-        
+
         otherwise
             error('matlab2tikz:drawText', 'Unrecognized text type: %s.', type);
-    end    
-    
+    end
+
     % Format according to units
     switch units
         case 'normalized'
@@ -2812,13 +2812,13 @@ function [m2t,posString] = getPositionOfText(m2t, h)
         case 'data'
             type    = 'axis cs:';
             fmtUnit = '';
-        % Let Matlab do the conversion of any unit into cm 
+        % Let Matlab do the conversion of any unit into cm
         otherwise
             type    = '';
             fmtUnit = 'cm';
             if ~strcmpi(units, 'centimeters')
                 % Save old pos, set units to cm, query pos, reset
-                % NOTE: cannot use copyobj since it is buggy in R2014a, see 
+                % NOTE: cannot use copyobj since it is buggy in R2014a, see
                 %       http://www.mathworks.com/support/bugreports/368385
                 oldPos = get(h, 'Position');
                 set(h,'Units','centimeters')
@@ -2831,20 +2831,20 @@ function [m2t,posString] = getPositionOfText(m2t, h)
     for ii = 1:npos
         posString{ii} = formatDim(pos(ii), fmtUnit);
     end
-    
-    posString = sprintf('(%s%s)',type,join(m2t,posString,','));    
+
+    posString = sprintf('(%s%s)',type,join(m2t,posString,','));
     m2t = disableClippingInCurrentAxes(m2t, pos);
-    
+
 end
 % ==============================================================================
 function m2t = disableClippingInCurrentAxes(m2t, pos)
 % Disables clipping in the current axes if the `pos` vector lies outside
-% the limits of the axes. 
+% the limits of the axes.
     xlim  = getOrDefault(m2t.currentHandles.gca, 'XLim',[-Inf +Inf]);
     ylim  = getOrDefault(m2t.currentHandles.gca, 'YLim',[-Inf +Inf]);
     zlim  = getOrDefault(m2t.currentHandles.gca, 'ZLim',[-Inf +Inf]);
     is3D  = m2t.axesContainers{end}.is3D;
-    
+
     xOutOfRange =          pos(1) < xlim(1) || pos(1) > xlim(2);
     yOutOfRange =          pos(2) < ylim(1) || pos(2) > ylim(2);
     zOutOfRange = is3D && (pos(3) < zlim(1) || pos(3) > zlim(2));
@@ -2929,7 +2929,7 @@ function [m2t,opts,s] = shaderOpts(m2t, handle, selectedType)
     % Get relevant Face and Edge color properties
     s.faceColor = get(handle, 'FaceColor');
     s.edgeColor = get(handle, 'EdgeColor');
-    
+
     if isNone(s.faceColor) && isNone(s.edgeColor)
         s.plotType        = 'none';
         s.hasOneEdgeColor = true;
@@ -2938,7 +2938,7 @@ function [m2t,opts,s] = shaderOpts(m2t, handle, selectedType)
         s.hasOneFaceColor = true;
         [m2t, opts, s]    = shaderOptsMesh(m2t, handle, opts, s);
     else
-        s.plotType     = selectedType; 	
+        s.plotType     = selectedType;
         [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s);
     end
 end
@@ -2948,7 +2948,7 @@ function [m2t, opts, s] = shaderOptsMesh(m2t, handle, opts, s)
     % Edge 'interp'
     if strcmpi(s.edgeColor, 'interp')
         opts = opts_add(opts,'shader','flat');
-    
+
     % Edge RGB
     else
         s.hasOneEdgeColor = true;
@@ -2983,7 +2983,7 @@ function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
             [m2t,xFaceColor]  = getColor(m2t, handle, s.faceColor, 'patch');
             opts              = opts_add(opts,'fill',xFaceColor);
         end
-        
+
     % Edge 'interp'
     elseif strcmpi(s.edgeColor, 'interp')
         if strcmpi(s.faceColor, 'interp')
@@ -2995,7 +2995,7 @@ function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
             [m2t,xFaceColor]  = getColor(m2t, handle, s.faceColor, 'patch');
             opts              = opts_add(opts,'fill',xFaceColor);
          end
-        
+
     % Edge 'flat'
     elseif strcmpi(s.edgeColor, 'flat')
         if strcmpi(s.faceColor, 'flat')
@@ -3008,7 +3008,7 @@ function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
             [m2t,xFaceColor]  = getColor(m2t, handle, s.faceColor, 'patch');
             opts              = opts_add(opts,'fill',xFaceColor);
         end
-        
+
     % Edge RGB
     else
         s.hasOneEdgeColor = true;
@@ -3134,7 +3134,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Plot the thing.
     [env, data, sColumn] = organizeScatterData(m2t, xData, yData, zData, sData);
-    
+
     if ~constMarkerkSize %
         drawOptions = opts_add(drawOptions, 'visualization depends on', ...
             ['{\thisrowno{', num2str(sColumn), '} \as \perpointmarksize}']);
@@ -3206,34 +3206,34 @@ function [m2t, xcolor, hasColor] = getColorOfMarkers(m2t, h, name, cData)
 end
 % ==============================================================================
 function [m2t, str] = drawHistogram(m2t, h)
-    
+
     if ~isVisible(h)
         str = '';
         return;
     end
 
-    % Init options 
+    % Init options
     opts = opts_new();
-    
+
     % Face
     faceColor = get(h,'FaceColor');
     [m2t, opts] = setColor(m2t, h, opts, 'fill', faceColor, 'none');
-    
+
     % FaceAlpha
     faceAlpha = get(h, 'FaceAlpha');
     if ~isNone(faceColor) && isnumeric(faceAlpha) && faceAlpha ~= 1.0
         opts = opts_add(opts,'fill opacity', sprintf(m2t.ff,faceAlpha));
     end
-    
+
     % Edge
     edgeColor = get(h, 'EdgeColor');
     [m2t, opts] = setColor(m2t, h, opts, 'draw', edgeColor, 'none');
-    
+
     % Data
     binEdges = get(h, 'BinEdges');
     binValue = get(h, 'Values');
     data     = [binEdges(:), [binValue(:); binValue(end)]];
-    
+
     % Bar type (depends on orientation)
     isVertical = strcmpi(get(h,'Orientation'),'vertical');
     if isVertical
@@ -3242,13 +3242,13 @@ function [m2t, str] = drawHistogram(m2t, h)
         opts = opts_add(opts, 'xbar interval');
         data = fliplr(data);
     end
-    
+
     % Make table
     [m2t, table, tableOptions] = makeTable(m2t, {'x','y'},data);
-    
+
     % Add 'area legend' (x/ybar interval legend do not seem to work)
     opts = opts_add(opts, 'area legend');
-    
+
     % Print out
     drawOpts = opts_print(m2t, opts, ',');
     tabOpts = opts_print(m2t, tableOptions, ',');
@@ -3364,7 +3364,7 @@ function [m2t, drawOptions] = setBarLayoutOfBarSeries(m2t, h, barType, drawOptio
 
             % Bar type
             drawOptions = opts_add(drawOptions, barType);
-            
+
             % Bar width
             drawOptions = opts_add(drawOptions, 'bar width', ...
                                  formatDim(barWidth, ''));
@@ -3405,21 +3405,21 @@ function [numBarSeries, barSeriesId] = getNumBarAndId(h)
     prop         = switchMatOct('BarPeers', 'bargroup');
     bargroup     = get(h, prop);
     numBarSeries = numel(bargroup);
-    
+
     if isHG2
         % In HG2, BarPeers are sorted in reverse order wrt HG1
         bargroup = bargroup(end:-1:1);
-    
+
     elseif strcmpi(getEnvironment, 'MATLAB')
         % In HG1, h is a double but bargroup a graphic object. Cast h to a
         % graphic object
         h = handle(h);
-    
+
     else
-        % In Octave, the bargroup is a replicated cell array. Pick first 
+        % In Octave, the bargroup is a replicated cell array. Pick first
         bargroup = bargroup{1};
     end
-    
+
     % Get bar series Id
     [dummy, barSeriesId] = ismember(h, bargroup);
 end
@@ -3459,7 +3459,7 @@ function [m2t, str] = drawStemOrStairSeries_(m2t, h, plotType)
     [m2t, plotColor] = getColor(m2t, h, color, 'patch');
 
     lineOptions = getLineOptions(m2t, lineStyle, lineWidth);
-    [m2t, markerOptions] = getMarkerOptions(m2t, h); 
+    [m2t, markerOptions] = getMarkerOptions(m2t, h);
 
     drawOptions = opts_new();
     drawOptions = opts_add(drawOptions, plotType);
@@ -3759,7 +3759,7 @@ function [m2t, str] = drawEllipse(m2t, handle)
     color = get(handle, 'Color');
     [m2t, xcolor] = getColor(m2t, handle, color, 'patch');
     lineOptions = getLineOptions(m2t, lineStyle, lineWidth);
-    
+
     filling = get(handle, 'FaceColor');
 
     %% Has a filling?
@@ -4132,11 +4132,11 @@ function [m2t, xcolor] = getColor(m2t, handle, color, mode)
             case 'patch'
                 [m2t, xcolor] = patchcolor2xcolor(m2t, color, handle);
             case 'image'
-                
+
                 m = size(color,1);
                 n = size(color,2);
                 xcolor = cell(m, n);
-                
+
                 if ndims(color) == 3
                     for i = 1:m
                         for j = 1:n
@@ -4190,7 +4190,7 @@ function [m2t, xcolor] = patchcolor2xcolor(m2t, color, patchhandle)
                 try
                     color = get(patchhandle, 'Color');
                 catch
-                    % From R2014b use an undocumented property if Color is 
+                    % From R2014b use an undocumented property if Color is
                     % not present
                     color = get(patchhandle, 'AutoColor');
                 end
@@ -4498,11 +4498,11 @@ function [pTicks, pTickLabels] = ...
             ) ...
             );
     end
-    
+
     ticks = removeSuperfluousTicks(ticks, tickLabels);
 
     isNeeded = isTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis);
-    
+
     pTickLabels = formatPgfTickLabels(m2t, isNeeded, tickLabels, ...
         isLogAxis, tickLabelMode);
 end
@@ -4546,7 +4546,7 @@ function bool = isTickLabelsNecessary(m2t, ticks, tickLabels, isLogAxis)
         end
         if isnan(s)  ||  abs(ticks(k)-s*scalingFactor) > m2t.tol
             bool = true;
-            return; 
+            return;
         end
     end
 end
@@ -4579,7 +4579,7 @@ end
 % ==============================================================================
 function ticks = removeSuperfluousTicks(ticks, tickLabels)
 % What MATLAB does when the number of ticks and tick labels is not the same,
-% is somewhat unclear. Cut of the first entries to fix bug 
+% is somewhat unclear. Cut of the first entries to fix bug
 %     https://github.com/matlab2tikz/matlab2tikz/issues/161,
     m = length(ticks);
     n = length(tickLabels);
@@ -5118,8 +5118,8 @@ function [m2t, axesBoundingBox] = getRelevantAxes(m2t, axesHandles)
 % computed. This can be used to avoid undesired borders.
 % This function is the remaining code of alignSubPlots() in the alternative
 % positioning system.
-    
-    % List only visible axes 
+
+    % List only visible axes
     N   = numel(axesHandles);
     idx = false(N,1);
     for ii = 1:N
@@ -5870,7 +5870,7 @@ end
 function [env, versionString] = getEnvironment()
 % Checks if we are in MATLAB or Octave.
     persistent cache
-    
+
     alternatives = {'MATLAB', 'Octave'};
     if isempty(cache)
         for iCase = 1:numel(alternatives)
@@ -5890,7 +5890,7 @@ function [env, versionString] = getEnvironment()
     else
         env = cache.env;
         versionString = cache.versionString;
-    end    
+    end
 end
 % ==============================================================================
 function bool = isHG2()

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5814,6 +5814,7 @@ function opts = opts_append_userdefined(opts, userDefined)
 end
 function c = opts_to_legacy(opts)
 % converts an option array to the legacy (1D) cell format
+% TODO: eventually inline this function back into opts_print
     nOpts = size(opts,1);
     c = cell(1,nOpts);
     for k = 1:nOpts
@@ -5826,6 +5827,7 @@ function c = opts_to_legacy(opts)
 end
 function opts = opts_from_legacy(c)
 % converts a legacy option array to an actual option array
+% TODO: eventually remove this function
     opts = opts_new();
     for kOption = 1:numel(c)
         entry = c{kOption};

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1619,10 +1619,10 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         [tikzMarker, markOptions] = translateMarker(m2t, marker, ...
                                         markOptions, ~isNone(markerFaceColor));
         
-        [m2t, markOptions] = assignColor(m2t, h, markOptions, 'fill', markerFaceColor);
+        [m2t, markOptions] = setColor(m2t, h, markOptions, 'fill', markerFaceColor);
         
         if ~strcmpi(markerEdgeColor,'auto')
-            [m2t, markOptions] = assignColor(m2t, h, markOptions, 'draw', markerEdgeColor);
+            [m2t, markOptions] = setColor(m2t, h, markOptions, 'draw', markerEdgeColor);
         end
 
         % add it all to drawOptions
@@ -1831,9 +1831,9 @@ function [m2t, str] = drawPatch(m2t, handle)
     if size(Faces,1) == 1 && s.hasOneEdgeColor && isFaceColorFlat
         ptType = '';
         cycle  = conditionallyCyclePath(Vertices);
-        [m2t, drawOptions] = assignColor(m2t, handle, drawOptions, 'draw', ...
+        [m2t, drawOptions] = setColor(m2t, handle, drawOptions, 'draw', ...
                                          s.edgeColor);
-        [m2t, drawOptions] = assignColor(m2t, handle, drawOptions, 'fill', ...
+        [m2t, drawOptions] = setColor(m2t, handle, drawOptions, 'fill', ...
                                          s.faceColor);
         
     else % Multiple patches    
@@ -1949,7 +1949,7 @@ function [drawOptions] = showInLegend(currentHandleHasLegend, drawOptions)
     end
 end
 % ==============================================================================
-function [m2t, options] = assignColor(m2t, handle, options, property, color, noneValue)
+function [m2t, options] = setColor(m2t, handle, options, property, color, noneValue)
 % assigns the MATLAB color of the object identified by "handle" to the LaTeX
 % property stored in the options array. An optional "noneValue" can be provided
 % that is set when the color == 'none' (if it is omitted, the property will not
@@ -1958,6 +1958,8 @@ function [m2t, options] = assignColor(m2t, handle, options, property, color, non
     if ~isNone(color)
         [m2t, xcolor] = getColor(m2t, handle, color, 'patch');
         if ~isempty(xcolor)
+            % this may happen when color == 'flat' and CData is Nx3, e.g. in 
+            % scatter plot or in patches
             options = opts_add(options, property, xcolor);
         end
     else
@@ -2701,7 +2703,7 @@ function [m2t, str] = drawText(m2t, handle)
     style = opts_new();
     
     bgColor = get(handle,'BackgroundColor');
-    [m2t, style] = assignColor(m2t, handle, style, 'fill', bgColor);
+    [m2t, style] = setColor(m2t, handle, style, 'fill', bgColor);
 
     style = getXYAlignmentOfText(handle, style);
 
@@ -2714,7 +2716,7 @@ function [m2t, str] = drawText(m2t, handle)
     style = opts_add(style, 'text', tcolor);
 
     EdgeColor = get(handle, 'EdgeColor');
-    [m2t, style] = assignColor(m2t, handle, style, 'draw', EdgeColor);
+    [m2t, style] = setColor(m2t, handle, style, 'draw', EdgeColor);
     
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % plot the thing
@@ -2894,7 +2896,7 @@ function [m2t, drawOptions] = getRectangleEdgeOptions(m2t, h, drawOptions)
     if isNone(lineStyle) || isNone(edgeColor)
         drawOptions = opts_add(drawOptions, 'draw', 'none');
     else
-        [m2t, drawOptions] = assignColor(m2t, h, drawOptions, 'draw', edgeColor);
+        [m2t, drawOptions] = setColor(m2t, h, drawOptions, 'draw', edgeColor);
     end
 end
 % ==============================================================================
@@ -3201,7 +3203,7 @@ function [m2t, str] = drawHistogram(m2t, h)
     
     % Face
     faceColor = get(h,'FaceColor');
-    [m2t, opts] = assignColor(m2t, h, opts, 'fill', faceColor, 'none');
+    [m2t, opts] = setColor(m2t, h, opts, 'fill', faceColor, 'none');
     
     % FaceAlpha
     faceAlpha = get(h, 'FaceAlpha');
@@ -3211,7 +3213,7 @@ function [m2t, str] = drawHistogram(m2t, h)
     
     % Edge
     edgeColor = get(h, 'EdgeColor');
-    [m2t, opts] = assignColor(m2t, h, opts, 'draw', edgeColor, 'none');
+    [m2t, opts] = setColor(m2t, h, opts, 'draw', edgeColor, 'none');
     
     % Data
     binEdges = get(h, 'BinEdges');
@@ -3277,7 +3279,7 @@ function [m2t, str] = drawBarseries(m2t, h)
     if isNone(lineStyle)
         drawOptions = opts_add(drawOptions, 'draw', 'none');
     else
-        [m2t, drawOptions] = assignColor(m2t, h, drawOptions, 'draw', ...
+        [m2t, drawOptions] = setColor(m2t, h, drawOptions, 'draw', ...
             edgeColor, 'none');
     end
 
@@ -3418,7 +3420,7 @@ function [m2t, drawOptions] = getFaceColorOfBar(m2t, h, drawOptions)
         obj = h;
     end
     faceColor = get(obj, 'FaceColor');
-    [m2t, drawOptions] = assignColor(m2t, h, drawOptions, 'fill', faceColor);
+    [m2t, drawOptions] = setColor(m2t, h, drawOptions, 'fill', faceColor);
 end
 % ==============================================================================
 function [m2t, str] = drawStemSeries(m2t, h)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -377,7 +377,7 @@ end
 % ==============================================================================
 function l = filenameValidation(x, p)
 % is the filename argument NOT another keyword?
-    l = ischar(x) && ~any(strcmp(x,p.Parameters));
+    l = ischar(x) && ~any(strcmp(x,p.Parameters)); %FIXME: See #471
 end
 % ==============================================================================
 function l = filehandleValidation(x)
@@ -828,7 +828,7 @@ function m2t = drawAxes(m2t, handle)
     % Axis direction
     for axis = 'xyz'
         m2t.([axis 'AxisReversed']) = ...
-            strcmp(get(handle,[upper(axis),'Dir']), 'reverse');
+            strcmpi(get(handle,[upper(axis),'Dir']), 'reverse');
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Add color scaling
@@ -907,7 +907,7 @@ function m2t = drawGridOfAxes(m2t, handle)
         % and effectively take Pgfplots' default.
         defaultMatlabGridLineStyle = ':';
         if m2t.cmdOpts.Results.strict ...
-                || ~strcmp(matlabGridLineStyle,defaultMatlabGridLineStyle)
+                || ~strcmpi(matlabGridLineStyle,defaultMatlabGridLineStyle)
             gls = translateLineStyle(matlabGridLineStyle);
             axisGridOpts = {'grid style', sprintf('{%s}', gls)};
             m2t.axesContainers{end}.options = cat(1, ...
@@ -1047,7 +1047,7 @@ end
 % ==============================================================================
 function m2t = drawBoxAndLineLocationsOfAxes(m2t, h)
 % draw the box and axis line location of an axes object
-    isBoxOn       = strcmp(get(h, 'box'), 'on');
+    isBoxOn       = strcmpi(get(h, 'box'), 'on');
     xLoc          = get(h, 'XAxisLocation');
     yLoc          = get(h, 'YAxisLocation');
     isXaxisBottom = strcmpi(xLoc,'bottom');
@@ -1114,7 +1114,7 @@ function m2t = drawLegendOptionsOfAxes(m2t, handle)
             % So let's make sure "siblings" is a row vector by reshaping it:
             siblings = reshape(siblings, 1, []);
             for sibling = siblings
-                if sibling && strcmp(get(sibling,'Type'), 'axes') && strcmp(get(sibling,'Tag'), 'legend')
+                if sibling && strcmpi(get(sibling,'Type'), 'axes') && strcmpi(get(sibling,'Tag'), 'legend')
                     legDims = pos2dims(get(sibling, 'Position')); %#ok
 
                     % TODO The following logic does not work for 3D plots.
@@ -1186,7 +1186,7 @@ function [m2t, options] = getAxisOptions(m2t, handle, axis)
                                               [upper(axis),'Color'], [ 0 0 0 ]);
     if ~isDfltColor || m2t.cmdOpts.Results.strict
         [m2t, col] = getColor(m2t, handle, color, 'patch');
-        if strcmp(get(handle, 'box'), 'on')
+        if strcmpi(get(handle, 'box'), 'on')
             % If the axes are arranged as a box, make sure that the individual
             % axes are drawn as four separate paths. This makes the alignment
             % at the box corners somewhat less nice, but allows for different
@@ -1204,14 +1204,14 @@ function [m2t, options] = getAxisOptions(m2t, handle, axis)
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % handle the orientation
-    isAxisReversed = strcmp(get(handle,[upper(axis),'Dir']), 'reverse');
+    isAxisReversed = strcmpi(get(handle,[upper(axis),'Dir']), 'reverse');
     m2t.([axis 'AxisReversed']) = isAxisReversed;
     if isAxisReversed
         options = opts_add(options, [axis, ' dir'], 'reverse');
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     axisScale = getOrDefault(handle, [upper(axis) 'Scale'], 'lin');
-    if strcmp(axisScale, 'log');
+    if strcmpi(axisScale, 'log');
         options = opts_add(options, [axis,'mode'], 'log');
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1225,10 +1225,10 @@ function [m2t, options] = getAxisOptions(m2t, handle, axis)
     [m2t, options] = getAxisLabel(m2t, handle, axis, options);
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % get grids
-    if strcmp(getOrDefault(handle, [upper(axis),'Grid'], 'off'), 'on');
+    if strcmpi(getOrDefault(handle, [upper(axis),'Grid'], 'off'), 'on');
         options = opts_add(options, [axis, 'majorgrids'], []);
     end
-    if strcmp(getOrDefault(handle, [upper(axis),'MinorGrid'], 'off'), 'on');
+    if strcmpi(getOrDefault(handle, [upper(axis),'MinorGrid'], 'off'), 'on');
         options = opts_add(options, [axis, 'minorgrids'], []);
     end
 end
@@ -1246,12 +1246,12 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
         % If no ticks are present, we need to enforce this in any case.
         pgfTicks = '\empty';
     else
-        if strcmp(tickMode, 'auto') && ~m2t.cmdOpts.Results.strict
+        if strcmpi(tickMode, 'auto') && ~m2t.cmdOpts.Results.strict
             % If the ticks are set automatically, and strict conversion is
             % not required, then let Pgfplots take care of the ticks.
             % In most cases, this looks a lot better anyway.
             pgfTicks = [];
-        else % strcmp(tickMode,'manual') || m2t.cmdOpts.Results.strict
+        else % strcmpi(tickMode,'manual') || m2t.cmdOpts.Results.strict
             pgfTicks = join(m2t, cellstr(num2str(ticks(:))), ', ');
         end
     end
@@ -1260,17 +1260,17 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
     tickLabelMode = get(handle, keywordTickLabelMode);
     keywordTickLabel = [upper(axis), 'TickLabel'];
     tickLabels = cellstr(get(handle, keywordTickLabel));
-    if strcmp(tickLabelMode, 'auto') && ~m2t.cmdOpts.Results.strict
+    if strcmpi(tickLabelMode, 'auto') && ~m2t.cmdOpts.Results.strict
         pgfTickLabels = [];
-    else % strcmp(tickLabelMode,'manual') || m2t.cmdOpts.Results.strict
+    else % strcmpi(tickLabelMode,'manual') || m2t.cmdOpts.Results.strict
         keywordScale = [upper(axis), 'Scale'];
-        isAxisLog = strcmp(getOrDefault(handle,keywordScale, 'lin'), 'log');
+        isAxisLog = strcmpi(getOrDefault(handle,keywordScale, 'lin'), 'log');
         [pgfTicks, pgfTickLabels] = ...
             matlabTicks2pgfplotsTicks(m2t, ticks, tickLabels, isAxisLog, tickLabelMode);
     end
 
     keywordMinorTick = [upper(axis), 'MinorTick'];
-    hasMinorTicks = strcmp(getOrDefault(handle, keywordMinorTick, 'off'), 'on');
+    hasMinorTicks = strcmpi(getOrDefault(handle, keywordMinorTick, 'off'), 'on');
     tickDirection = getOrDefault(handle, 'TickDir', 'in');
     
     options = setAxisTicks(m2t, options, axis, pgfTicks, pgfTickLabels, ...
@@ -1397,7 +1397,7 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     drawOptions = opts_merge(drawOptions, lineOptions, markerOptions);
 
     % Check for "special" lines, e.g.:
-    if strcmp(get(h, 'Tag'), 'zplane_unitcircle')
+    if strcmpi(get(h, 'Tag'), 'zplane_unitcircle')
         % Draw unit circle and axes.
         % TODO Don't hardcode "10".
         opts = opts_print(m2t, drawOptions, ',');
@@ -1603,7 +1603,7 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         markOptions = opts_new();
         % make sure that the markers get painted in solid (and not dashed)
         % if the 'lineStyle' is not solid (otherwise there is no problem)
-        if ~strcmp(lineStyle, 'solid')
+        if ~strcmpi(lineStyle, 'solid')
             markOptions = opts_add(markOptions, 'solid');
         end
 
@@ -1621,7 +1621,7 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         
         [m2t, markOptions] = assignColor(m2t, h, markOptions, 'fill', markerFaceColor);
         
-        if ~strcmp(markerEdgeColor,'auto')
+        if ~strcmpi(markerEdgeColor,'auto')
             [m2t, markOptions] = assignColor(m2t, h, markOptions, 'draw', markerEdgeColor);
         end
 
@@ -1898,7 +1898,7 @@ function [m2t, drawOptions, Vertices, Faces, verticesTableOptions, ptType, ...
         
         % Determine if mapping is direct or scaled
         CDataMapping = get(handle,'CDataMapping');
-        if strcmp(CDataMapping, 'direct')
+        if strcmpi(CDataMapping, 'direct')
             drawOptions = opts_add(drawOptions, 'colormap access','direct');
         end
         
@@ -2425,7 +2425,7 @@ function m2t = drawAnnotations(m2t)
 % drawAxes() call. 
 
     % Octave
-    if strcmp(getEnvironment,'Octave') 
+    if strcmpi(getEnvironment,'Octave') 
         return
     end
 
@@ -2660,8 +2660,8 @@ function [m2t, str] = drawVisibleText(m2t, handle)
     % descriptions therein.  Also, Matlab treats text objects with a NaN in the
     % position as invisible.
     if any(isnan(get(handle, 'Position')) | isnan(get(handle, 'Rotation'))) ...
-            || strcmp(get(handle, 'Visible'), 'off') ...
-            || (strcmp(get(handle, 'HandleVisibility'), 'off') && ...
+            || strcmpi(get(handle, 'Visible'), 'off') ...
+            || (strcmpi(get(handle, 'HandleVisibility'), 'off') && ...
                 ~m2t.cmdOpts.Results.showHiddenStrings)
 
         str = '';
@@ -2760,7 +2760,7 @@ function [m2t,posString] = getPositionOfText(m2t, h)
     
     % Deduce if text or textbox
     type = get(h,'type');
-    if isempty(type) || strcmp(type,'hggroup')
+    if isempty(type) || strcmpi(type,'hggroup')
         type = get(h,'ShapeType'); % Undocumented property valid from 2008a
     end
     
@@ -2841,7 +2841,7 @@ function [m2t, str] = drawRectangle(m2t, h)
     % there may be some text objects floating around a Matlab figure which
     % are handled by other subfunctions (labels etc.) or don't need to be
     % handled at all
-    if ~isVisible(h) || strcmp(get(h, 'HandleVisibility'), 'off')
+    if ~isVisible(h) || strcmpi(get(h, 'HandleVisibility'), 'off')
         return;
     end
 
@@ -2869,9 +2869,9 @@ end
 function [m2t, drawOptions] = getRectangleFaceOptions(m2t, h, drawOptions)
 % draws the face (i.e. fill) of a Rectangle
     faceColor    = get(h, 'FaceColor');
-    isAnnotation = strcmp(get(h,'type'),'rectangleshape') || ...
-                   strcmp(getOrDefault(h,'ShapeType',''),'rectangle');
-    isFlatColor  = strcmp(faceColor, 'flat');
+    isAnnotation = strcmpi(get(h,'type'),'rectangleshape') || ...
+                   strcmpi(getOrDefault(h,'ShapeType',''),'rectangle');
+    isFlatColor  = strcmpi(faceColor, 'flat');
     if ~(isNone(faceColor) || (isAnnotation && isFlatColor))
         [m2t, xFaceColor] = getColor(m2t, h, faceColor, 'patch');
         drawOptions = opts_add(drawOptions, 'fill', xFaceColor);
@@ -3173,7 +3173,7 @@ end
 function [m2t, xcolor, hasColor] = getColorOfMarkers(m2t, h, name, cData)
     color = get(h, name);
     hasColor = ~isNone(color);
-    if hasColor && ~strcmp(color,'flat');
+    if hasColor && ~strcmpi(color,'flat');
         [m2t, xcolor] = getColor(m2t, h, color, 'patch');
     else
         [m2t, xcolor] = getColor(m2t, h, cData, 'patch');
@@ -3210,7 +3210,7 @@ function [m2t, str] = drawHistogram(m2t, h)
     data     = [binEdges(:), [binValue(:); binValue(end)]];
     
     % Bar type (depends on orientation)
-    isVertical = strcmp(get(h,'Orientation'),'vertical');
+    isVertical = strcmpi(get(h,'Orientation'),'vertical');
     if isVertical
         opts = opts_add(opts, 'ybar interval');
     else
@@ -5078,7 +5078,7 @@ end
 % ==============================================================================
 function bool = isVisible(handles)
 % Determines whether an object is actually visible or not.
-    bool = strcmp(get(handles,'Visible'), 'on');
+    bool = strcmpi(get(handles,'Visible'), 'on');
     % There's another handle property, 'HandleVisibility', which may or may not
     % determine the visibility of the object. Empirically, it seems to be 'off'
     % whenever we're dealing with an object that's not user-created, such as
@@ -5191,7 +5191,7 @@ function printAll(m2t, env, fid)
 
     % End the tikzpicture environment with an empty comment and no newline
     % so no additional space is generated after the tikzpicture in TeX.
-    if strcmp(env.name, 'tikzpicture')
+    if strcmp(env.name, 'tikzpicture') % LaTeX is case sensitive
         fprintf(fid, '\\end{%s}%%', env.name);
     else
         fprintf(fid, '\\end{%s}\n', env.name);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -924,6 +924,7 @@ function m2t = drawGridOfAxes(m2t, handle)
                 opts_add(m2t.axesContainers{end}.options, ...
                 'axis on top', []);
         end
+        % FIXME: axis background, axis grid, main, axis ticks, axis lines, axis tick labels, axis descriptions, axis foreground
     end
 end
 % ==============================================================================

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -1,4 +1,4 @@
-alphaImage : 4eaa63f678cf072618765064bfb64c55
+alphaImage : 858f46142ced4be4b9e8a3b6e68f68ab
 annotationAll : 38e1f845b613f5e1b616df2d8e7fdc72
 annotationSubplots : 7f2b6c865ef1db561faed58714babbc2
 annotationText : 7d84c8fe322ac47f304f44f2c94db3e1

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2473,6 +2473,9 @@ end
 % =========================================================================
 function [stat] = overlappingPlots()
     stat.description = 'Overlapping plots with zoomed data and varying background.';
+    stat.unreliable = isMATLAB('>=', [8,4]);
+    % FIXME this test is unreliable because the x/y lims of `ax2` are not set
+    % explicitly. We should not set them explicitly, rather implement #591
     stat.issues = 6;
 
     % create pseudo random data and convert it from matrix to vector

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2547,7 +2547,7 @@ function [stat] = alphaTest()
   set(h, 'MarkerSize', 16);
   set(h, 'MarkerEdgeColor', [1 0.5 0]);
   set(h, 'MarkerFaceColor', [1 0 0]);       % has no visual effect
-  
+
   % line with different properties
   h = line([3 3.5], [1.5 3.5]);
   set(h, 'Color', [1 1 1]);


### PR DESCRIPTION
I've spent my Sunday refactoring some parts, mainly to address #391, but also some other things that have been bothering me for a while. Note that since everything should be a refactoring, no additional functionality has been included.

* I've added a `FIXME` tag in ee9a811 where we can change the Z-order of the axes/grids/... (I have been dragging that commit along for a bit too long now, I thought it was time to incorporate it)
* All functions should now use the `opts_*` internal API for option arrays.
* As a side result, I've also added some functions to convert to/from option array and plain cell arrays with `{'key=value', 'key', ...}` syntax (i.e. legacy format for options).
* Complexity has been reduced from 97 to 27 as in the overview below:

       Function       |Complexity 
----------------------|-----------
`shaderOptsSurfPatch` |    14     
  `drawScatterPlot`   |    13     
      **Total**       |    27     

![complexity](https://cloud.githubusercontent.com/assets/177360/6771653/cafb2a82-d0e4-11e4-836d-4dcabcdc3618.png)

> **Little factoid**: the complexity peak at `2` in the figure above is due to a common pattern I've been using in some functions, i.e.
> ```matlab
> function [...] = X(...)
>    if flag
>       % do X
>    end
> end
> ```

Everything works in our R2014b ACID test, hopefully Travis agrees for Octave. There are, however, some parts, that I'm not entirely happy with (especially  5947e03), but it is a step in the right direction.

I might work a bit further on this PR over the next week, but feel free to share your comments (or even merge this PR) in the meanwhile. 