### PR TITLE
FIX #594 - FaceAlpha and EdgeAlpha

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1825,12 +1825,20 @@ function [m2t, str] = drawPatch(m2t, handle)
         ptType = '';
         cycle  = conditionallyCyclePath(Vertices);
         if ~isNone(s.edgeColor)
-            [m2t, xEdgeColor]  = getColor(m2t, handle, s.edgeColor, 'patch');
-            drawOptions        = opts_add(drawOptions, 'draw', xEdgeColor);
+            [m2t, xEdgeColor]   = getColor(m2t, handle, s.edgeColor, 'patch');
+            drawOptions         = opts_add(drawOptions, 'draw', xEdgeColor);
         end
         if ~isNone(s.faceColor)
-            [m2t,xFaceColor]   = getColor(m2t, handle, s.faceColor, 'patch');
-            drawOptions        = opts_add(drawOptions,'fill',xFaceColor);
+            [m2t,xFaceColor]    = getColor(m2t, handle, s.faceColor, 'patch');
+            drawOptions         = opts_add(drawOptions,'fill',xFaceColor);
+        end
+        if opts_has(patchOptions, 'draw opacity')
+            drawOptions         = opts_add(drawOptions,'draw opacity', ...
+                                            sprintf(m2t.ff, s.edgeAlpha));
+        end
+        if opts_has(patchOptions, 'fill opacity')
+            drawOptions         = opts_add(drawOptions,'fill opacity', ...
+                                            sprintf(m2t.ff, s.faceAlpha));
         end
         
     % Multiple patches    
@@ -2906,13 +2914,18 @@ end
 % ==============================================================================
 function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
 
-            
     % Set opacity if FaceAlpha < 1 in MATLAB
     s.faceAlpha = get(handle, 'FaceAlpha');
     if isnumeric(s.faceAlpha) && s.faceAlpha ~= 1.0
-        opts = opts_add(opts,'opacity',sprintf(m2t.ff,s.faceAlpha));
+        opts = opts_add(opts,'fill opacity',sprintf(m2t.ff,s.faceAlpha));
     end
-    
+
+    % Set opacity if EdgeAlpha < 1 in MATLAB
+    s.edgeAlpha = get(handle, 'EdgeAlpha');
+    if isnumeric(s.edgeAlpha) && s.edgeAlpha ~= 1.0
+        opts = opts_add(opts,'draw opacity',sprintf(m2t.ff,s.edgeAlpha));
+    end
+
     % Edge 'none'
     if isNone(s.edgeColor)
         s.hasOneEdgeColor = true; % consider void as true

--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -1,4 +1,5 @@
 alphaImage : 7fa8e375bafbccebf528fa6664a063d7
+alphaTest : ec585c86d6c7231875aa4cd68b18ef34
 annotationAll : 3f34845acba1235af1f62b9edab9769d
 annotationSubplots : 5f26cd035c0224e873f9b6c669f86192
 annotationText : 980a64a699884fba7074f9c382261148

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -1,4 +1,5 @@
 alphaImage : 4eaa63f678cf072618765064bfb64c55
+alphaTest : c6b47801eedffc1543cc460c5e3131c3
 annotationAll : 38e1f845b613f5e1b616df2d8e7fdc72
 annotationSubplots : 7f2b6c865ef1db561faed58714babbc2
 annotationText : 7d84c8fe322ac47f304f44f2c94db3e1

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -1,4 +1,5 @@
 alphaImage : f6a2e2d1756f72cbad060d0a85116134
+alphaTest : 9d458c612443b2057184427c91bdd5ce
 areaPlot : 9b367779566f4bc7605a6f7b8483e34d
 axesColors : cc0a6def293580e4f51790dfb477d632
 axesLocation : 5ba110beaee8adc0f969effd8ab68e4b

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2546,7 +2546,12 @@ function [stat] = alphaTest()
   
   % line with different properties
   h = line([3 3.5], [1.5 3.5]);
-  set(h, 'Color', [1 1 1 0.3]);             % RGBA (with alpha channel)
+  set(h, 'Color', [1 1 1]);
+  if isMATLAB('>=', [8,4])
+      % TODO: later replace by 'isHG2()'
+      fprintf('Note: RGBA (with alpha channel) only in HG2.\n' );
+      set(h, 'Color', [1 1 1 0.3]);
+  end
   set(h, 'LineStyle', ':');
   set(h, 'LineWidth', 6);
   set(h, 'Marker', 'o');

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -2541,14 +2541,14 @@ function [stat] = alphaTest()
   set(h, 'LineWidth', 4);
   set(h, 'Marker', 'x');
   set(h, 'MarkerSize', 16);
-  set(h, 'MarkerEdgeColor', [1 1 0]);
+  set(h, 'MarkerEdgeColor', [1 0.5 0]);
   set(h, 'MarkerFaceColor', [1 0 0]);       % has no visual effect
   
   % line with different properties
   h = line([3 3.5], [1.5 3.5]);
-  set(h, 'Color', [1 1 1 0.4]);             % RGBA (with alpha channel)
+  set(h, 'Color', [1 1 1 0.3]);             % RGBA (with alpha channel)
   set(h, 'LineStyle', ':');
-  set(h, 'LineWidth', 4);
+  set(h, 'LineWidth', 6);
   set(h, 'Marker', 'o');
   set(h, 'MarkerSize', 14);
   set(h, 'MarkerEdgeColor', [1 1 0]);

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -131,8 +131,9 @@ function [status] = ACID(k)
                            @stackedBarsWithOther, ...
                            @colorbarLabelTitle  , ...
                            @textAlignment       , ...
-                           @overlappingPlots    ,...
-                           @histogramPlot
+                           @overlappingPlots    , ...
+                           @histogramPlot       , ...
+                           @alphaTest
                          };
 
 
@@ -2522,5 +2523,35 @@ function [stat] = histogramPlot()
   hold on
   h = histogram(y);
   set(h, 'orientation', 'horizontal');
+end
+% =========================================================================
+function [stat] = alphaTest()
+  stat.description = 'overlapping objects with transparency and other properties';
+  stat.issues      = 593;
+
+  contourf(peaks(5)); hold on;              % background
+
+  % rectangular patch with different properties
+  h = fill([2 2 4 4], [2 3 3 2], 'r');
+  set(h, 'FaceColor', 'r');
+  set(h, 'FaceAlpha', 0.2);
+  set(h, 'EdgeColor', 'g');
+  set(h, 'EdgeAlpha', 0.4);
+  set(h, 'LineStyle', ':');
+  set(h, 'LineWidth', 4);
+  set(h, 'Marker', 'x');
+  set(h, 'MarkerSize', 16);
+  set(h, 'MarkerEdgeColor', [1 1 0]);
+  set(h, 'MarkerFaceColor', [1 0 0]);       % has no visual effect
+  
+  % line with different properties
+  h = line([3 3.5], [1.5 3.5]);
+  set(h, 'Color', [1 1 1 0.4]);             % RGBA (with alpha channel)
+  set(h, 'LineStyle', ':');
+  set(h, 'LineWidth', 4);
+  set(h, 'Marker', 'o');
+  set(h, 'MarkerSize', 14);
+  set(h, 'MarkerEdgeColor', [1 1 0]);
+  set(h, 'MarkerFaceColor', [1 0 0]);
 end
 % =========================================================================


### PR DESCRIPTION
Consider `faceAlpha` and `edgeAlpha`

Do this, if a single patch is considered.
This fixes #593.

**Test code:**
```
contourf(peaks(5)); hold on;

h = fill([2 2 4 4], [2 3 3 2],'b');
set(h,'FaceColor', 'r');
set(h,'FaceAlpha', 0.2);
set(h,'EdgeColor', 'g');
set(h,'EdgeAlpha', 0.5);
set(h,'LineStyle', ':');
set(h,'LineWidth', 3);
set(h,'Marker', 'x');
set(h,'MarkerSize', 12);
```

**Output with patch:**
![image](https://cloud.githubusercontent.com/assets/4340267/6781798/9183ae1e-d170-11e4-8a1e-10ee7eaa7487.png)