### PR TITLE
Reinitialize hashes as indicated in `getReferenceHash()`

### DIFF
--- a/test/private/execute_hash_stage.m
+++ b/test/private/execute_hash_stage.m
@@ -28,7 +28,7 @@ function hash = getReferenceHash(status, ipp)
     % By storing the hash table in a persistent variable, the amount of disk
     % operations is minimized (i.e. reading the file, parsing it and storing its
     % data in a MATLAB struct), as this is only done once a new test suite is
-    % executed. To clear this persistent storage, run |clear functions|.
+    % executed. To clear this persistent storage, run `clear getReferenceHash`.
 
     if isempty(hashTable) || ~isequal(hashTable.suite, ipp.Results.testsuite)
         hashTable = loadHashTable(ipp.Results.testsuite);

--- a/test/private/testMatlab2tikz.m
+++ b/test/private/testMatlab2tikz.m
@@ -52,6 +52,9 @@ function status = testMatlab2tikz(varargin)
 % POSSIBILITY OF SUCH DAMAGE.
 %
 % =========================================================================
+           
+  % Reinitialize hashes, as described in `getReferenceHash()`
+  clear getReferenceHash
 
   % In which environment are we?
   env = getEnvironment();


### PR DESCRIPTION
see https://github.com/egeerardyn/matlab2tikz/commit/583251956adf3804577c27865dd90e15ee8043f8
I had the same problem, so went ahead and fixed this.
Personally I think that https://github.com/matlab2tikz/matlab2tikz/issues/575 is unrelated, but want to add the reference, in case this should be reviewed during the restructuring.