### PR TITLE
do not store hashTable as persistent

### DIFF
--- a/test/private/execute_hash_stage.m
+++ b/test/private/execute_hash_stage.m
@@ -22,17 +22,9 @@ function [status] = execute_hash_stage(status, ipp)
 end
 % ==============================================================================
 function hash = getReferenceHash(status, ipp)
-    % retrieves a reference hash from a persistent hash table
+    % retrieves a reference hash from a hash table
 
-    persistent hashTable
-    % By storing the hash table in a persistent variable, the amount of disk
-    % operations is minimized (i.e. reading the file, parsing it and storing its
-    % data in a MATLAB struct), as this is only done once a new test suite is
-    % executed. To clear this persistent storage, run `clear getReferenceHash`.
-
-    if isempty(hashTable) || ~isequal(hashTable.suite, ipp.Results.testsuite)
-        hashTable = loadHashTable(ipp.Results.testsuite);
-    end
+    hashTable = loadHashTable(ipp.Results.testsuite);
     if isfield(hashTable.contents, status.function)
         hash = hashTable.contents.(status.function);
     else

--- a/test/private/execute_hash_stage.m
+++ b/test/private/execute_hash_stage.m
@@ -23,6 +23,7 @@ end
 % ==============================================================================
 function hash = getReferenceHash(status, ipp)
     % retrieves a reference hash from a hash table
+    % WARNING: do not make `hashTable` persistent, since this is slower
 
     hashTable = loadHashTable(ipp.Results.testsuite);
     if isfield(hashTable.contents, status.function)

--- a/test/private/testMatlab2tikz.m
+++ b/test/private/testMatlab2tikz.m
@@ -52,9 +52,6 @@ function status = testMatlab2tikz(varargin)
 % POSSIBILITY OF SUCH DAMAGE.
 %
 % =========================================================================
-           
-  % Reinitialize hashes, as described in `getReferenceHash()`
-  clear getReferenceHash
 
   % In which environment are we?
   env = getEnvironment();


### PR DESCRIPTION
* oddly this results in a strong speedup of testsuite execution
* this eases the developers life, since now updated hashes in the file are always noticed
* `clear getReferenceHash` only worked in Matlab
* `clear functions` has unwanted side effects (`getEnvironment` could not be found anymore)

see https://github.com/matlab2tikz/matlab2tikz/commit/05520b8850b0e1a1a9d42f476d8ef5e06a7a04a6#commitcomment-10642865