### PR TITLE
Added 'mesh/ordering=y varies' option in drawSurface

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2234,6 +2234,9 @@ function [m2t,env] = drawSurface(m2t, handle)
     % data writing to one single sprintf() call.
     opts{end+1} = sprintf('mesh/rows=%d', numrows);
 
+    % Add mesh/ordering=y varies for specifying the ordering of the data
+    opts{end+1} = 'mesh/ordering=y varies';
+    
     opts = join(m2t, opts, ',\n');
     str = [str, sprintf(['\n\\addplot3[%%\n%s,\n', opts ,']'], plotType)];
 


### PR DESCRIPTION
When plotting a surface, both the mesh/rows and mesh/ordering have to be specified.
http://tex.stackexchange.com/questions/198639/how-can-i-import-matrix-data-2d-function-from-matlab-into-pgfplots

If not, in some cases the resulting surface is incorrect. See the following example:
![pre_fix](https://cloud.githubusercontent.com/assets/2853795/7316205/ad64660c-ea7d-11e4-9b32-d56b2e65b414.png)
And now with the fix
![post_fix](https://cloud.githubusercontent.com/assets/2853795/7316213/c0b0c408-ea7d-11e4-862b-e7e047a96680.png)
