### PR TITLE
Fix `bodeplots` test (42)

### DIFF
--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -3,13 +3,13 @@ alphaTest : 3188c4306f1059094eb3b88f7c32dc17
 annotationAll : b44f6fe4c76300bb1a99fdbc77a6b287
 annotationSubplots : 4c3aa9a41108bc712dc46815976cefcc
 annotationText : 6e6cb9b22d404f72e71b266f054d33ac
-annotationTextUnits : b0d3c7bc84608154d1e71f85a532714d
+annotationTextUnits : 5b0ad40bef6ca940f07648465c58894c
 areaPlot : 988877a36cdb4a55afecf8b816dd634a
 axesColors : 62b8d24ae88ad1df29ed94ff50818f36
 axesLocation : e665762e22cc0cb64d3d23b5f1fcbd66
 bars : 7864982d62127f7cc2af076d0cde3395
 besselImage : ba676f198258acab7b2a29acf8696cf3
-bodeplots : 3b54f7499d401a098189fa6371710795
+bodeplots : ecdb9cfda5f04a8ab0f6b4aeb5ea5443
 clownImage : 1b5d18fa51afaafe1912b41bc3883d42
 colorbarLabelTitle : 0a97c646f136466e84a9f6213a5012a9
 colorbarLogplot : 81e8346c37f4bd5d72a6a4a3e772b617
@@ -33,7 +33,7 @@ imageOrientation_inline : 95b55b00b4a78ce2048a14d0d5c62a4c
 imagescplot : a594a023a15fb1c138c31674e18b3683
 imagescplot2 : 4e0233c5501d7ceb40d3292fd70bbc66
 latexInterpreter : ec686ebe3ad0c580069cbcf074d8416c
-latexmath2 : bc51844c5e542a82b9929440c09a3f4d
+latexmath2 : 36a52147cdc9699802003b2914cc48cf
 legendplot : 34e0bbc9920037784540b3389e4c3a7c
 legendplotBoxoff : 3d96df6372346407ffce28a2ea76e4eb
 legendsubplots : aa821b26c5907ffa9a4f3d652a288157
@@ -49,7 +49,7 @@ markerSizes2 : 96e29fde18b4b5d72f1182bda1cc626f
 meshPlot : 8add69082c7a518e3a679ffa914d5887
 mixedBarLine : 7fd3492ff6942a79977940e4ca463778
 moreLegends : 6d33153548c28341e8cb8ddc73c64f7c
-multiline_labels : 4e5b7ddd8cb37926e57403dfc2601a16
+multiline_labels : 89de7c812f91c1fa78a7fec08d502608
 multipleAxes : 62ea3df8f3595e1ae3b900745f898fc1
 multiplePatches : 3fdceeb9e1aed6c4130988558ef6c863
 myBoxplot : 2b850d55681937c2c38a7a4c0a5ef2af
@@ -67,7 +67,7 @@ quiveroverlap : 1bbbae36858575a3d37b830ea3fcf78c
 quiverplot : eed3b7d5dc17458d0b4d2bbdb2647fa9
 randomWithLines : 0a6d635c0d124f241039bc7b450b2953
 rectanglePlot : c48a3d22dac900605e1700f15a353b8f
-rlocusPlot : ed48ac9fa7dc0e423eadfcd4e53e2887
+rlocusPlot : 970105e228cc0b89906788ddc7ff7844
 roseplot : 59cd0d60b108e52dbe79503c4aa6650f
 scatter3Plot : 75935adb9bc4d37b59f335ac1748f2f5
 scatterPlot : 4c2b1cd7cd9640e128d9455cc8153bc2

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -9,7 +9,7 @@ axesColors : b30a83133a3d4785ac79e85457306601
 axesLocation : 3ae9cd9edf8b3ff2d46f594cbe1e9a86
 bars : e4c8ea6e0d90c330728f4909a382f11f
 besselImage : 8c7ea17c04f1dee3adfaea8a4b7345d9
-bodeplots : ab3ab64215ec9f65f029b9cbfe34fdc1
+bodeplots : 00f713aeefde59ade94c74b869a32e95
 clownImage : c27cd454ae291b401c7d9fc7fd1efb84
 colorbarLabelTitle : 6684cd23c11336f00c76c2a1147a4e05
 compassplot : 832026d56bd49c899f01267deb999606

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -976,6 +976,13 @@ function [stat] = bodeplots()
   grid on
 
   legend('Perfect LCL',' Real LCL','Location','SW')
+  % Work around a peculiarity in R2014a and older: when the figure is invisible,
+  % the XData/YData of all plots is NaN. It gets set to the proper values when
+  % the figure is actually displayed. To do so, we temporarily toggle this
+  % option. This triggers the call-back (and might flicker the figure).
+  isVisible = get(gcf,'visible');
+  set(gcf,'visible','on')
+  set(gcf,'visible',isVisible);
 end
 % =========================================================================
 function [stat] = rlocusPlot()


### PR DESCRIPTION
By toggling the 'visible` property, the callback gets triggered
and hence we work around bug #638.
This fixes #638.