### PR TITLE
Fix herrorbar octave

### DIFF
--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -14,7 +14,7 @@ double_axes : 9cbfe4265d7a4ed12ca17580c11ac171
 double_axes2 : 3a81de3827ae481ca051f0a1508b8b1c
 errorBars : 51fdde5ec181938a9de6262560491a43
 errorBars2 : c781f9350cada6b1698829321694c84b
-herrorbarPlot : 0901e645e5b9df5ca2b944a246016300
+herrorbarPlot : 9c16ae9eec25226b1a80e7e89a983f55
 imageOrientation_PNG : 8182b4b0a2fa56c9c5b6b42ad326ab06
 imageOrientation_inline : 5eacd8c1430bacb917dd9c106acb22e0
 imagescplot : c95430098d3f1e88cf1fdf4a12622441

--- a/test/suites/private/herrorbar.m
+++ b/test/suites/private/herrorbar.m
@@ -143,9 +143,10 @@ yb(9:9:end,:) = NaN;
 [ls,col,mark,msg] = colstyle(symbol); if ~isempty(msg), error(msg); end
 symbol = [ls mark col]; % Use marker only on data part
 esymbol = ['-' col]; % Make sure bars are solid
-
-h = plot(xb,yb,esymbol); hold on
-h = [h;plot(x,y,symbol)];
+if ~isempty(strfind(symbol,'none')), symbol = 'none'; end
+if ~isempty(strfind(esymbol,'none')), esymbol = 'none'; end
+h = plot(xb,yb,'LineStyle',esymbol); hold on
+h = [h;plot(x,y,'LineStyle',symbol)];
 
 if ~hold_state, hold off; end
 


### PR DESCRIPTION
Fixes `plot failed` for `ACID(74)` on octave (as observed on Travis).
This is an issue in the used `herrorbar.m` [FEX](http://www.mathworks.com/matlabcentral/fileexchange/3963-herrorbar).

Verified visually, updated hash of octave. Matlab is not affected.