### PR TITLE
fix pColorPlot (ACID(81))

### DIFF
--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -54,7 +54,7 @@ multipleAxes : 62ea3df8f3595e1ae3b900745f898fc1
 multiplePatches : 3fdceeb9e1aed6c4130988558ef6c863
 myBoxplot : a2b5f11f657e1fc92785355d678460db
 overlappingPlots : 18cf2acfd5edfd9466576a3a660bc3b6
-pColorPlot : 3af66108669a5d3cc6424e3e4159e6e6
+pColorPlot : cf970804d3e47193c92fb251ccf2355d
 parameterCurve3d : 6021198f4a70f990720e302739b2df80
 parameterSurf : a9b32b0319c0ec1fabdbeb0ff1be165b
 peaks_contour : bc176f0f75404e8cd45fb90e50550bae

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -54,7 +54,7 @@ multipleAxes : 62ea3df8f3595e1ae3b900745f898fc1
 multiplePatches : c30cfb0be1f8231e9cb88258e3cdc540
 myBoxplot : 54568259920da17d058ff0580831eb57
 overlappingPlots : 11e38420732e5b031e01bf1e874fb0ee
-pColorPlot : b1559431d24fe36f281b62d1fd75d107
+pColorPlot : 3c92ed387513b6492999c08b983c52a3
 parameterCurve3d : 2df6f224f80d5880511bbba7a4467e4a
 parameterSurf : 8ddaacbb7b6b87beda5db9f7874d254d
 peaks_contour : e0174fb6308d54f584cbb661ce7d8e7a

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -39,7 +39,7 @@ multiline_labels : 653c4d8adc49231847ba3e89ba0b31e6
 multipleAxes : a8c3f25ef10aa52214db072173d46b4e
 multiplePatches : 4a0e6a29dcc0e57066dba16ae3d12fd3
 overlappingPlots : a94c4dcdc8caa545a14fa5815d72f643
-pColorPlot : 0901e645e5b9df5ca2b944a246016300
+pColorPlot : 46d44f808adb8f0ea884392da92c1ac8
 parameterCurve3d : 5e2e2f78d50874964e8b7af774d5968c
 peaks_contour : d2d43f0ece7ebb383becce9945805ef9
 peaks_contourf : 101598c24a2ea711d7e1dbbf13cbbb78

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1948,6 +1948,7 @@ function [stat] = pColorPlot()
   stat.description = 'pcolor() plot.';
   stat.unreliable = isOctave || isMATLAB('<', [8,4]); % FIXME: investigate
 
+  ylim([-1 1]); xlim([-1 1]); hold on; % prevent error on octave
   n = 6;
   r = (0:n)'/n;
   theta = pi*(-n:n)/n;
@@ -1956,6 +1957,7 @@ function [stat] = pColorPlot()
   C = r*cos(2*theta);
   pcolor(X,Y,C)
   axis equal tight
+
 end
 % =========================================================================
 function [stat] = multiplePatches()

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1946,7 +1946,7 @@ end
 % =========================================================================
 function [stat] = pColorPlot()
   stat.description = 'pcolor() plot.';
-  stat.unreliable = isOctave || isMATLAB('<', [8,4]); % FIXME: investigate
+  stat.unreliable = isMATLAB('<', [8,4]); % FIXME: investigate
 
   ylim([-1 1]); xlim([-1 1]); hold on; % prevent error on octave
   n = 6;


### PR DESCRIPTION
ACID(81) now doesn't return `plot error` on octave. Workaround used is to explicitly set the axis limits. Thus hashes of MATLAB were also affected.

* [x] Please somebody report the tex output of HG1 (e.g. R2014a).
* [x] Verify that marking test reliable on octave is correct.