### PR TITLE
fix testGraphical()

### DIFF
--- a/test/private/execute_save_stage.m
+++ b/test/private/execute_save_stage.m
@@ -18,8 +18,8 @@ function [status] = execute_save_stage(status, ipp)
 
             case 'Octave'
                 % In Octave, figures are properly cropped when using  print().
-                print(reference_pdf, '-dpdf', '-S415,311', '-r150');
-                pause(1.0)
+                print(reference_eps, '-depsc');
+
             otherwise
                 error('matlab2tikz:UnknownEnvironment', ...
                      'Unknown environment. Need MATLAB(R) or GNU Octave.')

--- a/test/private/testMatlab2tikz.m
+++ b/test/private/testMatlab2tikz.m
@@ -71,11 +71,9 @@ function status = testMatlab2tikz(varargin)
 
   % -----------------------------------------------------------------------
   if strcmpi(env, 'Octave')
-      if ~ipp.Results.figureVisible
-          % Use the gnuplot backend to work around an fltk bug, see
-          % <http://savannah.gnu.org/bugs/?43429>.
-          graphics_toolkit gnuplot
-      end
+      % Use the gnuplot backend to work around an fltk bug, see
+      % <http://savannah.gnu.org/bugs/?43429>.
+      graphics_toolkit gnuplot
 
       if ispc
           % Prevent three digit exponent on Windows Octave


### PR DESCRIPTION
For `testGraphical()` and octave:
* also output to eps; `make clean` would otherwise delete `reference` data
* remove unecessary `pause`
* always use `gnuplot` backend

Discussion in #649.

Remaining issue, but was present before: `ACID(21)`  might crash octave (even after fixed #664).