### PR TITLE
Improve updater

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -158,14 +158,14 @@ m2t.currentHandles = [];
 
 m2t.transform = []; % For hgtransform groups
 m2t.pgfplotsVersion = [1,3];
-m2t.name = 'matlab2tikz';
-m2t.version = '1.0.0';
-m2t.author = 'Nico Schlömer';
-m2t.authorEmail = 'nico.schloemer@gmail.com';
-m2t.years = '2008--2015';
-m2t.website = 'http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz';
+m2t.about.name = 'matlab2tikz';
+m2t.about.version = '1.0.0';
+m2t.about.author = 'Nico Schlömer';
+m2t.about.authorEmail = 'nico.schloemer@gmail.com';
+m2t.about.years = '2008--2015';
+m2t.about.website = 'http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz';
 VCID = VersionControlIdentifier();
-m2t.versionFull = strtrim(sprintf('v%s %s', m2t.version, VCID));
+m2t.about.versionFull = strtrim(sprintf('v%s %s', m2t.about.version, VCID));
 
 m2t.tol = 1.0e-15; % numerical tolerance (e.g. used to test equality of doubles)
 m2t.imageAsPngNo = 0;
@@ -321,14 +321,12 @@ end
 userInfo(m2t, ['(To disable info messages, pass [''showInfo'', false] to matlab2tikz.)\n', ...
     '(For all other options, type ''help matlab2tikz''.)\n']);
 
-userInfo(m2t, '\nThis is %s %s.\n', m2t.name, m2t.versionFull)
+userInfo(m2t, '\nThis is %s %s.\n', m2t.about.name, m2t.about.versionFull)
 
 %% Check for a new matlab2tikz version outside version control
 if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
   isUpdateInstalled = m2tUpdater(...
-    m2t.name, ...
-    m2t.website, ...
-    m2t.version, ...
+    m2t.about, ...
     m2t.cmdOpts.Results.showInfo, ...
     getEnvironment...
     );
@@ -346,7 +344,7 @@ versionInfo = ['The latest updates can be retrieved from\n' ,...
                '   https://github.com/matlab2tikz/matlab2tikz,\n'       ,...
                '   https://github.com/matlab2tikz/matlab2tikz/wiki,\n'  ,...
                '   https://github.com/matlab2tikz/matlab2tikz/issues.\n'];
-userInfo(m2t, versionInfo, m2t.website, m2t.name);
+userInfo(m2t, versionInfo, m2t.about.website, m2t.about.name);
 
 %% Save the figure as TikZ to file
 saveToFile(m2t, fid, fileWasOpen);
@@ -468,7 +466,7 @@ function m2t = saveToFile(m2t, fid, fileWasOpen)
     % actually print the stuff
     minimalPgfplotsVersion = formatPgfplotsVersion(m2t.pgfplotsVersion);
 
-    m2t.content.comment = sprintf('This file was created by %s.\n', m2t.name);
+    m2t.content.comment = sprintf('This file was created by %s.\n', m2t.about.name);
 
     if m2t.cmdOpts.Results.showInfo
         % disable this info if showInfo=false
@@ -477,7 +475,7 @@ function m2t = saveToFile(m2t, fid, fileWasOpen)
             'The latest updates can be retrieved from\n', ...
             '  %s\n', ...
             'where you can also make suggestions and rate %s.\n'], ...
-            m2t.website, m2t.name ) ...
+            m2t.about.website, m2t.about.name ) ...
             ];
     end
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -323,18 +323,6 @@ userInfo(m2t, ['(To disable info messages, pass [''showInfo'', false] to matlab2
 
 userInfo(m2t, '\nThis is %s %s.\n', m2t.about.name, m2t.about.versionFull)
 
-%% Check for a new matlab2tikz version outside version control
-if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
-  isUpdateInstalled = m2tUpdater(...
-    m2t.about, ...
-    m2t.cmdOpts.Results.showInfo, ...
-    getEnvironment...
-    );
-    % Terminate conversion if update was successful (the user is notified
-    % by the updater)
-    if isUpdateInstalled, return, end
-end
-
 %% print some version info to the screen
 versionInfo = ['The latest updates can be retrieved from\n' ,...
                ' %s\n' ,...
@@ -348,6 +336,12 @@ userInfo(m2t, versionInfo, m2t.about.website, m2t.about.name);
 
 %% Save the figure as TikZ to file
 saveToFile(m2t, fid, fileWasOpen);
+
+%% Check for a new matlab2tikz version outside version control
+if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
+    m2tUpdater(m2t.about, m2t.cmdOpts.Results.showInfo, getEnvironment);
+end
+
 end
 % ==============================================================================
 function [m2t, fid, fileWasOpen] = openFileForOutput(m2t)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -110,7 +110,7 @@ function matlab2tikz(varargin)
 %   taking a peek at what the figure will look like. (default: false)
 %
 %   MATLAB2TIKZ('checkForUpdates',BOOL,...) determines whether to automatically
-%   check for updates of matlab2tikz. (default: true)
+%   check for updates of matlab2tikz. (default: true (if not using git))
 %
 %   Example
 %      x = -pi:pi/10:pi;
@@ -205,7 +205,7 @@ ipp = ipp.addParamValue(ipp, 'strict', false, @islogical);
 ipp = ipp.addParamValue(ipp, 'strictFontSize', false, @islogical);
 ipp = ipp.addParamValue(ipp, 'showInfo', true, @islogical);
 ipp = ipp.addParamValue(ipp, 'showWarnings', true, @islogical);
-ipp = ipp.addParamValue(ipp, 'checkForUpdates', true, @islogical);
+ipp = ipp.addParamValue(ipp, 'checkForUpdates', isempty(VCID), @islogical);
 
 ipp = ipp.addParamValue(ipp, 'encoding' , '', @ischar);
 ipp = ipp.addParamValue(ipp, 'standalone', false, @islogical);
@@ -338,7 +338,7 @@ userInfo(m2t, versionInfo, m2t.about.website, m2t.about.name);
 saveToFile(m2t, fid, fileWasOpen);
 
 %% Check for a new matlab2tikz version outside version control
-if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
+if m2t.cmdOpts.Results.checkForUpdates
     m2tUpdater(m2t.about, m2t.cmdOpts.Results.showInfo);
 end
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -6001,17 +6001,6 @@ function bool = isHG2()
            ~isVersionBelow(envVersion, [8,4]);
 end
 % ==============================================================================
-function bool = isVersionBelow(versionA, versionB)
-% Checks if versionA is smaller than versionB
-    vA         = versionArray(versionA);
-    vB         = versionArray(versionB);
-    n          = min(length(vA), length(vB));
-    deltaAB    = vA(1:n) - vB(1:n);
-    difference = find(deltaAB, 1, 'first');
-    % Empty difference then same version
-    bool       = ~isempty(difference) && deltaAB(difference) < 0;
-end
-% ==============================================================================
 function str = formatAspectRatio(m2t, values)
 % format the aspect ratio. Behind the scenes, formatDim is used
     strs = arrayfun(@formatDim, values, 'UniformOutput', false);
@@ -6037,25 +6026,6 @@ function str = formatDim(value, unit)
         str = regexprep(str, '\.$', ''); % remove trailing period
         str = [str unit];
     end
-end
-% ==============================================================================
-function arr = versionArray(str)
-% Converts a version string to an array.
-    if ischar(str)
-        % Translate version string from '2.62.8.1' to [2; 62; 8; 1].
-        switch getEnvironment
-            case 'MATLAB'
-                split = regexp(str, '\.', 'split'); % compatibility MATLAB < R2013a
-            case  'Octave'
-                split = strsplit(str, '.');
-            otherwise
-                errorUnknownEnvironment();
-        end
-        arr = str2num(char(split)); %#ok
-    else
-        arr = str;
-    end
-    arr = arr(:)';
 end
 % ==============================================================================
 function [retval] = switchMatOct(matlabValue, octaveValue)
@@ -6091,11 +6061,6 @@ function checkDeprecatedEnvironment(minimalVersions)
     else
         errorUnknownEnvironment();
     end
-end
-% ==============================================================================
-function errorUnknownEnvironment()
-    error('matlab2tikz:unknownEnvironment',...
-          'Unknown environment "%s". Need MATLAB(R) or Octave.', getEnvironment);
 end
 % ==============================================================================
 function m2t = needsPgfplotsVersion(m2t, minVersion)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -339,7 +339,7 @@ saveToFile(m2t, fid, fileWasOpen);
 
 %% Check for a new matlab2tikz version outside version control
 if m2t.cmdOpts.Results.checkForUpdates && isempty(VCID)
-    m2tUpdater(m2t.about, m2t.cmdOpts.Results.showInfo, getEnvironment);
+    m2tUpdater(m2t.about, m2t.cmdOpts.Results.showInfo);
 end
 
 end
@@ -5990,32 +5990,6 @@ function str  = opts_print(m2t, opts, sep)
         end
     end
     str = join(m2t, c, sep);
-end
-% ==============================================================================
-function [env, versionString] = getEnvironment()
-% Checks if we are in MATLAB or Octave.
-    persistent cache
-
-    alternatives = {'MATLAB', 'Octave'};
-    if isempty(cache)
-        for iCase = 1:numel(alternatives)
-            env   = alternatives{iCase};
-            vData = ver(env);
-            if ~isempty(vData) % found the right environment
-                versionString = vData.Version;
-                % store in cache
-                cache.env = env;
-                cache.versionString = versionString;
-                return;
-            end
-        end
-        % fall-back values
-        env = '';
-        versionString = '';
-    else
-        env = cache.env;
-        versionString = cache.versionString;
-    end
 end
 % ==============================================================================
 function bool = isHG2()

--- a/src/private/errorUnknownEnvironment.m
+++ b/src/private/errorUnknownEnvironment.m
@@ -1,0 +1,5 @@
+function errorUnknownEnvironment()
+% Throw an error to indicate an unknwon environment (i.e. notMATLAB/Octave/...).
+    error('matlab2tikz:unknownEnvironment',...
+          'Unknown environment "%s". Need MATLAB(R) or Octave.', getEnvironment);
+end

--- a/src/private/errorUnknownEnvironment.m
+++ b/src/private/errorUnknownEnvironment.m
@@ -1,5 +1,5 @@
 function errorUnknownEnvironment()
-% Throw an error to indicate an unknwon environment (i.e. notMATLAB/Octave/...).
+% Throw an error to indicate an unknwon environment (i.e. not MATLAB/Octave).
     error('matlab2tikz:unknownEnvironment',...
           'Unknown environment "%s". Need MATLAB(R) or Octave.', getEnvironment);
 end

--- a/src/private/getEnvironment.m
+++ b/src/private/getEnvironment.m
@@ -1,0 +1,25 @@
+function [env, versionString] = getEnvironment()
+% Checks if we are in MATLAB or Octave.
+    persistent cache
+
+    alternatives = {'MATLAB', 'Octave'};
+    if isempty(cache)
+        for iCase = 1:numel(alternatives)
+            env   = alternatives{iCase};
+            vData = ver(env);
+            if ~isempty(vData) % found the right environment
+                versionString = vData.Version;
+                % store in cache
+                cache.env = env;
+                cache.versionString = versionString;
+                return;
+            end
+        end
+        % fall-back values
+        env = '';
+        versionString = '';
+    else
+        env = cache.env;
+        versionString = cache.versionString;
+    end
+end

--- a/src/private/isVersionBelow.m
+++ b/src/private/isVersionBelow.m
@@ -1,0 +1,13 @@
+function isBelow = isVersionBelow(versionA, versionB)
+% Checks if versionA is smaller than versionB
+    vA         = versionArray(versionA);
+    vB         = versionArray(versionB);
+    n          = min(length(vA), length(vB));
+    deltaAB    = vA(1:n) - vB(1:n);
+    difference = find(deltaAB, 1, 'first');
+    if isempty(difference)
+        isBelow = false; % equal versions
+    else
+        isBelow = (deltaAB(difference) < 0);
+    end
+end

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -33,8 +33,8 @@ function m2tUpdater(about, verbose)
 
   mostRecentVersion = determineLatestRelease(version);
   if askToUpgrade(mostRecentVersion, version, verbose)
-    tryToUpgrade(name, fileExchangeUrl, verbose);
-    userInfo(verbose, '');
+      tryToUpgrade(name, fileExchangeUrl, verbose);
+      userInfo(verbose, '');
   end
 end
 % ==============================================================================
@@ -170,23 +170,22 @@ function mostRecentVersion = determineLatestRelease(version)
 end
 % ==============================================================================
 function isBelow = isVersionBelow(versionA, versionB)
-  % Checks if version string or vector versionA is smaller than
-  % version string or vector versionB.
-  env = getEnvironment;
-  vA = versionArray(versionA);
-  vB = versionArray(versionB);
+% Checks if version string or vector versionA is smaller than
+% version string or vector versionB.
+    env = getEnvironment;
+    vA = versionArray(versionA);
+    vB = versionArray(versionB);
 
-  isBelow = false;
-  for i = 1:min(length(vA), length(vB))
-    if vA(i) > vB(i)
-      isBelow = false;
-      break;
-    elseif vA(i) < vB(i)
-      isBelow = true;
-      break
+    isBelow = false;
+    for i = 1:min(length(vA), length(vB))
+        if vA(i) > vB(i)
+            isBelow = false;
+            break;
+        elseif vA(i) < vB(i)
+            isBelow = true;
+            break
+        end
     end
-  end
-
 end
 % =========================================================================
 function arr = versionArray(str)
@@ -203,22 +202,17 @@ function arr = versionArray(str)
   else
     arr = str;
   end
-
 end
 % ==============================================================================
 function userInfo(verbose, message, varargin)
   % Display usage information.
+  if verbose
+      mess = sprintf(message, varargin{:});
 
-  if ~verbose
-      return
+      % Replace '\n' by '\n *** ' and print.
+      mess = strrep( mess, sprintf('\n'), sprintf('\n *** ') );
+      fprintf( ' *** %s\n', mess );
   end
-
-  mess = sprintf(message, varargin{:});
-
-  % Replace '\n' by '\n *** ' and print.
-  mess = strrep( mess, sprintf('\n'), sprintf('\n *** ') );
-  fprintf( ' *** %s\n', mess );
-
 end
 % =========================================================================
 function list = rdirfiles(rootdir)

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -31,44 +31,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
   fileExchangeUrl = about.website;
   version = about.version;
 
-  % Read in the Github releases page
-  url = 'https://github.com/matlab2tikz/matlab2tikz/releases/';
-  try
-      html = urlread(url);
-  catch %#ok
-      % Couldn't load the URL -- never mind.
-      html = '';
-  end
-
-  % Parse tag names which are the version number in the format ##.##.##
-  % It assumes that releases will always be tagged with the version number
-  expression = '(?<=matlab2tikz\/matlab2tikz\/releases\/tag\/)\d+\.\d+\.\d+';
-  tags       = regexp(html, expression, 'match');
-  ntags      = numel(tags);
-
-  % Keep only new releases
-  inew = false(ntags,1);
-  for ii = 1:ntags
-      inew(ii) = isVersionBelow(env, version, tags{ii});
-  end
-  nnew = nnz(inew);
-
-  % One new release
-  if nnew == 1
-      mostRecentVersion = tags{inew};
-  % Several new release, pick latest
-  elseif nnew > 1
-      tags   = tags(inew);
-      tagnum = zeros(nnew,1);
-      for ii = 1:nnew
-          tagnum(ii) = [10000,100,1] * versionArray(env, tags{ii});
-      end
-      [~, imax]         = max(tagnum);
-      mostRecentVersion = tags{imax};
-  % No new
-  else
-      mostRecentVersion = '';
-  end
+  mostRecentVersion = determineLatestRelease(env, version);
 
   upgradeSuccess = false;
   if ~isempty(mostRecentVersion)
@@ -98,7 +61,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
           targetPath = fullfile(pathstr, '..', '..');
 
           % Let the user know where the .zip is downloaded to
-          userInfo(verbose, 'Downloading and unzipping to ''%s'' ...\n', targetPath);
+          userInfo(verbose, 'Downloading and unzipping to ''%s'' ...', targetPath);
 
           % Try upgrading
           try
@@ -151,6 +114,47 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
           end
       end
       userInfo(verbose, '');
+  end
+end
+% ======================
+function mostRecentVersion = determineLatestRelease(env, version)
+  % Read in the Github releases page
+  url = 'https://github.com/matlab2tikz/matlab2tikz/releases/';
+  try
+      html = urlread(url);
+  catch %#ok
+      % Couldn't load the URL -- never mind.
+      html = '';
+  end
+
+  % Parse tag names which are the version number in the format ##.##.##
+  % It assumes that releases will always be tagged with the version number
+  expression = '(?<=matlab2tikz\/matlab2tikz\/releases\/tag\/)\d+\.\d+\.\d+';
+  tags       = regexp(html, expression, 'match');
+  ntags      = numel(tags);
+
+  % Keep only new releases
+  inew = false(ntags,1);
+  for ii = 1:ntags
+      inew(ii) = isVersionBelow(env, version, tags{ii});
+  end
+  nnew = nnz(inew);
+
+  % One new release
+  if nnew == 1
+      mostRecentVersion = tags{inew};
+  % Several new release, pick latest
+  elseif nnew > 1
+      tags   = tags(inew);
+      tagnum = zeros(nnew,1);
+      for ii = 1:nnew
+          tagnum(ii) = [10000,100,1] * versionArray(env, tags{ii});
+      end
+      [~, imax]         = max(tagnum);
+      mostRecentVersion = tags{imax};
+  % No new
+  else
+      mostRecentVersion = '';
   end
 end
 % =========================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -39,20 +39,20 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
       % Couldn't load the URL -- never mind.
       html = '';
   end
-  
+
   % Parse tag names which are the version number in the format ##.##.##
   % It assumes that releases will always be tagged with the version number
   expression = '(?<=matlab2tikz\/matlab2tikz\/releases\/tag\/)\d+\.\d+\.\d+';
   tags       = regexp(html, expression, 'match');
   ntags      = numel(tags);
-  
+
   % Keep only new releases
   inew = false(ntags,1);
   for ii = 1:ntags
       inew(ii) = isVersionBelow(env, version, tags{ii});
   end
   nnew = nnz(inew);
-  
+
   % One new release
   if nnew == 1
       mostRecentVersion = tags{inew};
@@ -65,17 +65,17 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
       end
       [~, imax]         = max(tagnum);
       mostRecentVersion = tags{imax};
-  % No new 
+  % No new
   else
       mostRecentVersion = '';
   end
-  
+
   upgradeSuccess = false;
   if ~isempty(mostRecentVersion)
       userInfo(verbose, '**********************************************\n');
       userInfo(verbose, 'New version available! (%s)\n', mostRecentVersion);
       userInfo(verbose, '**********************************************\n');
-      
+
       userInfo(verbose, 'By upgrading you may lose any custom changes.\n');
       reply = input([' *** Would you like ', name, ' to self-upgrade? y/n [n]:'],'s');
       if strcmpi(reply, 'y')
@@ -96,7 +96,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
           % and that matlab2tikz.m is not symlinked from some other place.
           pathstr    = fileparts(mfilename('fullpath'));
           targetPath = fullfile(pathstr, '..', '..');
-          
+
           % Let the user know where the .zip is downloaded to
           if ispc
               printPath = strrep(targetPath,'\','\\');
@@ -104,12 +104,12 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
               printPath = targetPath;
           end
           userInfo(verbose, ['Downloading and unzipping to ''', printPath, ''' ...']);
-          
+
           % Try upgrading
           try
               % List current folder structure. Will use last for cleanup
               currentFolderFiles = rdirfiles(targetPath);
-              
+
               % The FEX now forwards the download request to Github.
               % Go through the forwarding to update the download count and
               % unzip
@@ -117,15 +117,15 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
               expression    = '(?<=\<a href=")[\w\-\/:\.]+(?=">redirected)';
               url           = regexp(html, expression,'match','once');
               unzippedFiles = unzip(url, targetPath);
-              
-              % The folder structure is additionally packed into the 
-              % 'MATLAB Search Path' folder defined in FEX. Retrieve the 
+
+              % The folder structure is additionally packed into the
+              % 'MATLAB Search Path' folder defined in FEX. Retrieve the
               % top folder name
               tmp          = strrep(unzippedFiles,[targetPath, filesep],'');
               tmp          = regexp(tmp, filesep,'split','once');
               tmp          = cat(1,tmp{:});
               topZipFolder = unique(tmp(:,1));
-              
+
               % If packed into the top folder, overwrite files into m2t
               % main directory
               if numel(topZipFolder) == 1
@@ -136,7 +136,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
                   % Add topZipFolder to current folder structure
                   currentFolderFiles = [currentFolderFiles; fullfile(targetPath, topZipFolder{1})];
               end
-              
+
               % Cleanup
               newFolderStructure = [getFolders(unzippedFilesTarget);  unzippedFilesTarget];
               deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
@@ -148,7 +148,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
                       rmdir(x,'s');
                   end
               end
-              
+
               upgradeSuccess = true; %~isempty(unzippedFiles);
               userInfo(verbose, 'UPDATED: the current conversion will be terminated. Please, re-run it.');
           catch
@@ -215,26 +215,26 @@ function list = rdirfiles(rootdir)
   % Recursive files listing
   s    = dir(rootdir);
   list = {s.name}';
-  
+
   % Exclude .git, .svn, . and ..
   [list, idx] = setdiff(list, {'.git','.svn','.','..'});
-  
+
   % Add root
   list = fullfile(rootdir, list);
-  
+
   % Loop for sub-directories
   pdir = find([s(idx).isdir]);
   for ii = pdir
       list = [list; rdirfiles(list{ii})]; %#ok<AGROW>
   end
-  
+
   % Drop directories
   list(pdir) = [];
 end
 % =========================================================================
-function list = getFolders(list) 
+function list = getFolders(list)
   % Extract the folder structure from a list of files and folders
-  
+
   for ii = 1:numel(list)
       if exist(list{ii},'file') == 2
           list{ii} = fileparts(list{ii});

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -1,4 +1,4 @@
-function upgradeSuccess = m2tUpdater(about, verbose, env)
+function upgradeSuccess = m2tUpdater(about, verbose)
 %UPDATER   Auto-update matlab2tikz.
 %   Only for internal usage.
 
@@ -31,7 +31,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
   fileExchangeUrl = about.website;
   version = about.version;
 
-  mostRecentVersion = determineLatestRelease(env, version);
+  mostRecentVersion = determineLatestRelease(version);
 
   upgradeSuccess = false;
   if ~isempty(mostRecentVersion)
@@ -116,8 +116,8 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
       userInfo(verbose, '');
   end
 end
-% ======================
-function mostRecentVersion = determineLatestRelease(env, version)
+% ==============================================================================
+function mostRecentVersion = determineLatestRelease(version)
   % Read in the Github releases page
   url = 'https://github.com/matlab2tikz/matlab2tikz/releases/';
   try
@@ -136,7 +136,7 @@ function mostRecentVersion = determineLatestRelease(env, version)
   % Keep only new releases
   inew = false(ntags,1);
   for ii = 1:ntags
-      inew(ii) = isVersionBelow(env, version, tags{ii});
+      inew(ii) = isVersionBelow(version, tags{ii});
   end
   nnew = nnz(inew);
 
@@ -148,7 +148,7 @@ function mostRecentVersion = determineLatestRelease(env, version)
       tags   = tags(inew);
       tagnum = zeros(nnew,1);
       for ii = 1:nnew
-          tagnum(ii) = [10000,100,1] * versionArray(env, tags{ii});
+          tagnum(ii) = [10000,100,1] * versionArray(tags{ii});
       end
       [~, imax]         = max(tagnum);
       mostRecentVersion = tags{imax};
@@ -157,13 +157,13 @@ function mostRecentVersion = determineLatestRelease(env, version)
       mostRecentVersion = '';
   end
 end
-% =========================================================================
-function isBelow = isVersionBelow(env, versionA, versionB)
+% ==============================================================================
+function isBelow = isVersionBelow(versionA, versionB)
   % Checks if version string or vector versionA is smaller than
   % version string or vector versionB.
-
-  vA = versionArray(env, versionA);
-  vB = versionArray(env, versionB);
+  env = getEnvironment;
+  vA = versionArray(versionA);
+  vB = versionArray(versionB);
 
   isBelow = false;
   for i = 1:min(length(vA), length(vB))
@@ -178,14 +178,14 @@ function isBelow = isVersionBelow(env, versionA, versionB)
 
 end
 % =========================================================================
-function arr = versionArray(env, str)
+function arr = versionArray(str)
   % Converts a version string to an array, e.g.,
   % '2.62.8.1' to [2, 62, 8, 1].
-
   if ischar(str)
-    if strcmpi(env, 'MATLAB')
+    switch getEnvironment
+      case 'MATLAB'
         split = regexp(str, '\.', 'split');
-    elseif strcmpi(env, 'Octave')
+      case 'Octave'
         split = strsplit(str, '.');
     end
     arr = str2num(char(split)); %#ok
@@ -194,7 +194,7 @@ function arr = versionArray(env, str)
   end
 
 end
-% =========================================================================
+% ==============================================================================
 function userInfo(verbose, message, varargin)
   % Display usage information.
 

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -47,10 +47,10 @@ function shouldUpgrade = askToUpgrade(mostRecentVersion, version, verbose)
       warnAboutUpgradeImplications(version, mostRecentVersion, verbose);
       askToShowChangelog(version);
       reply = input(' *** Would you like to upgrade? y/n [n]:','s');
-      shouldUpgrade = strcmpi(reply(1),'y');
+      shouldUpgrade = ~isempty(reply) && strcmpi(reply(1),'y');
       if ~shouldUpgrade
-        userInfo(verbose, ['To disable the self-updater in the future, add ' ...
-                           '"''checkForUpdates'',false" to the parameters.'] );
+        userInfo(verbose, ['\nTo disable the self-updater in the future, add ' ...
+                           '"''checkForUpdates'',false" to the parameters.\n'] );
       end
   end
 end
@@ -212,7 +212,7 @@ end
 % ==============================================================================
 function warnAboutUpgradeImplications(currentVersion, latestVersion, verbose)
 % This warns the user about the implications of upgrading as dictated by
-% Semantic Versionning.
+% Semantic Versioning.
     switch upgradeSize(currentVersion, latestVersion);
         case 'major'
           % The API might have changed in a backwards incompatible way.

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -42,12 +42,12 @@ function shouldUpgrade = askToUpgrade(mostRecentVersion, version, verbose)
   shouldUpgrade = false;
   if ~isempty(mostRecentVersion)
       userInfo(verbose, '**********************************************\n');
-      userInfo(verbose, 'New version available! (%s)\n', mostRecentVersion);
+      userInfo(verbose, 'New version (%s) available!\n', mostRecentVersion);
       userInfo(verbose, '**********************************************\n');
 
       warnAboutUpgradeImplications(version, mostRecentVersion, verbose);
-      askToShowChangelof(version, mostRecentVersion);
-      reply = input([' *** Would you like ', name, ' to self-upgrade? y/n [n]:'],'s');
+      askToShowChangelog(version);
+      reply = input(' *** Would you like to upgrade? y/n [n]:','s');
       shouldUpgrade = strcmpi(reply(1),'y');
   end
 end
@@ -170,10 +170,10 @@ function mostRecentVersion = determineLatestRelease(version)
   end
 end
 % ==============================================================================
-function askToShowChangelog(currentVersion, latestVersion)
+function askToShowChangelog(currentVersion)
 % Asks whether the user wants to see the changelog and then shows it.
-    reply = input([' *** Would you like to see the changelog? y/n [n]:'],'s');
-    shouldShow = strcmpi(reply(1),'y');
+    reply = input(' *** Would you like to see the changelog? y/n [y]:' ,'s');
+    shouldShow = ~strcmpi(reply(1),'n');
     if shouldShow
         fprintf(1, changelogUntilVersion(currentVersion));
     end
@@ -199,21 +199,21 @@ function warnAboutUpgradeImplications(currentVersion, latestVersion, verbose)
         case 'major'
           % The API might have changed in a backwards incompatible way.
           userInfo(verbose, 'This is a MAJOR upgrade!\n');
-          userInfo(verbose, ' - New features may have been introduced.\n');
+          userInfo(verbose, ' - New features may have been introduced.');
           userInfo(verbose, ' - Some old code/options may no longer work!\n');
 
         case 'minor'
           % The API may NOT have changed in a backwards incompatible way.
           userInfo(verbose, 'This is a MINOR upgrade.\n');
-          userInfo(verbose, ' - New features may have been introduced.\n');
-          userInfo(verbose, ' - Some options may have been deprecated.\n');
+          userInfo(verbose, ' - New features may have been introduced.');
+          userInfo(verbose, ' - Some options may have been deprecated.');
           userInfo(verbose, ' - Old code should continue to work but might produce warnings.\n');
 
         case 'patch'
           % No new functionality is introduced
           userInfo(verbose, 'This is a PATCH.\n');
-          userInfo(verbose, ' - Only bug fixes are included in this upgrade.\n');
-          userInfo(verbose, ' - Old code should continue to work as before.\n')
+          userInfo(verbose, ' - Only bug fixes are included in this upgrade.');
+          userInfo(verbose, ' - Old code should continue to work as before.')
     end
     userInfo(verbose, 'Please check the changelog for detailed information.\n');
     userInfo(verbose, 'By upgrading you may lose any custom changes.\n');
@@ -236,7 +236,6 @@ end
 function isBelow = isVersionBelow(versionA, versionB)
 % Checks if version string or vector versionA is smaller than
 % version string or vector versionB.
-    env = getEnvironment;
     vA = versionArray(versionA);
     vB = versionArray(versionB);
 

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -127,10 +127,12 @@ function cleanupOldFiles(currentFolderFiles, unzippedFilesTarget)
     deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
     for ii = 1:numel(deleteFolderFiles)
         x = deleteFolderFiles{ii};
-        if exist(x, 'file')
-            delete(x);
-        elseif exist(x, 'dir')
+        if exist(x, 'dir')
+            % First check for directories since
+            % `exist(x, 'file')` also checks for directories!
             rmdir(x,'s');
+        elseif exist(x, 'file')
+            delete(x);
         end
     end
 end

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -98,12 +98,7 @@ function upgradeSuccess = m2tUpdater(about, verbose, env)
           targetPath = fullfile(pathstr, '..', '..');
 
           % Let the user know where the .zip is downloaded to
-          if ispc
-              printPath = strrep(targetPath,'\','\\');
-          else
-              printPath = targetPath;
-          end
-          userInfo(verbose, ['Downloading and unzipping to ''', printPath, ''' ...']);
+          userInfo(verbose, 'Downloading and unzipping to ''%s'' ...\n', targetPath);
 
           % Try upgrading
           try

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -112,9 +112,12 @@ function tryToUpgrade(name, fileExchangeUrl, verbose)
 
       cleanupOldFiles(currentFolderFiles, unzippedFilesTarget);
 
-      userInfo(verbose, 'UPDATED: the current conversion will be terminated. Please, re-run it.');
+      userInfo(verbose, 'Upgrade has completed successfully.');
   catch
-      userInfo(verbose, ['FAILED: continuing with the' name ' conversion.']);
+      userInfo(verbose,
+               ['Upgrade has failed.\n', ...
+                'Please install the latest version manually from %s !'], ...
+                fileExchangeUrl);
   end
 end
 % ==============================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -171,15 +171,25 @@ function mostRecentVersion = determineLatestRelease(version)
 end
 % ==============================================================================
 function askToShowChangelog(currentVersion, latestVersion)
-% Prints out the changelog
-    URL = 'https://github.com/matlab2tikz/matlab2tikz/raw/master/CHANGELOG.md';
+% Asks whether the user wants to see the changelog and then shows it.
     reply = input([' *** Would you like to see the changelog? y/n [n]:'],'s');
     shouldShow = strcmpi(reply(1),'y');
     if shouldShow
-        changelog = urlread(URL);
-        %TODO only show the relevant part of the changelog
-        fprintf('Changelog:\n\n%s\n', changelog);
+        fprintf(1, changelogUntilVersion(currentVersion));
     end
+end
+% ==============================================================================
+function str = changelogUntilVersion(currentVersion)
+% This function retrieves the chunk of the changelog until the current version.
+    URL = 'https://github.com/matlab2tikz/matlab2tikz/raw/master/CHANGELOG.md';
+    changelog = urlread(URL);
+    currentVersion = versionString(currentVersion);
+    % Header is "# YYYY-MM-DD Version major.minor.patch [Manager](email)"
+    % Just match for the part until the version number.
+    pattern = ['# (\d-)+ Version ' currentVersion];
+    idxVersion = regexp(changelog, pattern);
+    % return everything before the current version
+    str = changelog(1:idxVersion-1);
 end
 % ==============================================================================
 function warnAboutUpgradeImplications(currentVersion, latestVersion, verbose)
@@ -241,7 +251,17 @@ function isBelow = isVersionBelow(versionA, versionB)
         end
     end
 end
-% =========================================================================
+% ==============================================================================
+function str = versionString(arr)
+% Converts a version array to string
+  if ischar(arr)
+      str = arr;
+  elseif isnumeric(arr)
+      str = sprintf('\d.', arr);
+      str = str(1:end-1); % remove final period
+  end
+end
+% ==============================================================================
 function arr = versionArray(str)
   % Converts a version string to an array, e.g.,
   % '2.62.8.1' to [2, 62, 8, 1].

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -129,11 +129,11 @@ function cleanupOldFiles(currentFolderFiles, unzippedFilesTarget)
     deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
     for ii = 1:numel(deleteFolderFiles)
         x = deleteFolderFiles{ii};
-        if exist(x, 'dir')
+        if exist(x, 'dir') == 7
             % First check for directories since
             % `exist(x, 'file')` also checks for directories!
             rmdir(x,'s');
-        elseif exist(x, 'file')
+        elseif exist(x, 'file') == 2
             delete(x);
         end
     end
@@ -238,7 +238,7 @@ function warnAboutUpgradeImplications(currentVersion, latestVersion, verbose)
           userInfo(verbose, ' - Old code should continue to work as before.')
     end
     userInfo(verbose, 'Please check the changelog for detailed information.\n');
-    userInfo(verbose, 'By upgrading you may lose any custom changes.\n');
+    userWarn(verbose, '\n!! By upgrading you will lose any custom changes !!\n');
 end
 % ==============================================================================
 function cls = upgradeSize(currentVersion, latestVersion)
@@ -256,14 +256,24 @@ function cls = upgradeSize(currentVersion, latestVersion)
 end
 % ==============================================================================
 function userInfo(verbose, message, varargin)
-  % Display usage information.
-  if verbose
-      mess = sprintf(message, varargin{:});
-
-      % Replace '\n' by '\n *** ' and print.
-      mess = strrep( mess, sprintf('\n'), sprintf('\n *** ') );
-      fprintf( ' *** %s\n', mess );
-  end
+    % Display information (i.e. to stdout)
+    if verbose
+        userPrint(1, message, varargin{:});
+    end
+end
+function userWarn(verbose, message, varargin)
+    % Display warnings (i.e. to stderr)
+    if verbose
+        userPrint(2, message, varargin{:});
+    end
+end
+function userPrint(fid, message, varargin)
+    % Print messages (info/warnings) to a stream/file.
+    mess = sprintf(message, varargin{:});
+    
+    % Replace '\n' by '\n *** ' and print.
+    mess = strrep( mess, sprintf('\n'), sprintf('\n *** ') );
+    fprintf(fid, ' *** %s\n', mess );
 end
 % =========================================================================
 function list = rdirfiles(rootdir)

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -105,22 +105,27 @@ function tryToUpgrade(name, fileExchangeUrl, verbose)
           currentFolderFiles = [currentFolderFiles; fullfile(targetPath, topZipFolder{1})];
       end
 
-      % Cleanup
-      newFolderStructure = [getFolders(unzippedFilesTarget);  unzippedFilesTarget];
-      deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
-      for ii = 1:numel(deleteFolderFiles)
-          x = deleteFolderFiles{ii};
-          if exist(x, 'file')
-              delete(x);
-          elseif exist(x, 'dir')
-              rmdir(x,'s');
-          end
-      end
+      cleanupOldFiles(currentFolderFiles, unzippedFilesTarget);
 
       userInfo(verbose, 'UPDATED: the current conversion will be terminated. Please, re-run it.');
   catch
       userInfo(verbose, ['FAILED: continuing with the' name ' conversion.']);
   end
+end
+% ==============================================================================
+function cleanupOldFiles(currentFolderFiles, unzippedFilesTarget)
+% Delete files that were there in the old folder, but that are no longer
+% present in the new release.
+    newFolderStructure = [getFolders(unzippedFilesTarget);  unzippedFilesTarget];
+    deleteFolderFiles  = setdiff(currentFolderFiles, newFolderStructure);
+    for ii = 1:numel(deleteFolderFiles)
+        x = deleteFolderFiles{ii};
+        if exist(x, 'file')
+            delete(x);
+        elseif exist(x, 'dir')
+            rmdir(x,'s');
+        end
+    end
 end
 % ==============================================================================
 function mostRecentVersion = determineLatestRelease(version)

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -49,6 +49,10 @@ function shouldUpgrade = askToUpgrade(mostRecentVersion, version, verbose)
       askToShowChangelog(version);
       reply = input(' *** Would you like to upgrade? y/n [n]:','s');
       shouldUpgrade = strcmpi(reply(1),'y');
+      if ~shouldUpgrade
+        userInfo(verbose, ['To disable the self-updater in the future, add ' ...
+                           '"''checkForUpdates'',false" to the parameters.'] );
+      end
   end
 end
 % ==============================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -195,7 +195,7 @@ function changelog = changelogUntilVersion(currentVersion)
     URL = 'https://github.com/matlab2tikz/matlab2tikz/raw/master/CHANGELOG.md';
     changelog = urlread(URL);
     currentVersion = versionString(currentVersion);
-    
+
     % Header is "# YYYY-MM-DD Version major.minor.patch [Manager](email)"
     % Just match for the part until the version number. Here, we're actually
     % matching a tiny bit too broad due to the periods in the version number

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -27,13 +27,12 @@ function m2tUpdater(about, verbose)
 %   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 %   POSSIBILITY OF SUCH DAMAGE.
 % =========================================================================
-  name = about.name;
   fileExchangeUrl = about.website;
   version = about.version;
 
-  mostRecentVersion = determineLatestRelease(version);
+  mostRecentVersion = determineLatestRelease(version, fileExchangeUrl);
   if askToUpgrade(mostRecentVersion, version, verbose)
-      tryToUpgrade(name, fileExchangeUrl, verbose);
+      tryToUpgrade(fileExchangeUrl, verbose);
       userInfo(verbose, '');
   end
 end
@@ -56,7 +55,7 @@ function shouldUpgrade = askToUpgrade(mostRecentVersion, version, verbose)
   end
 end
 % ==============================================================================
-function tryToUpgrade(name, fileExchangeUrl, verbose)
+function tryToUpgrade(fileExchangeUrl, verbose)
   % Download the files and unzip its contents into two folders
   % above the folder that contains the current script.
   % This assumes that the file structure is something like
@@ -114,7 +113,7 @@ function tryToUpgrade(name, fileExchangeUrl, verbose)
 
       userInfo(verbose, 'Upgrade has completed successfully.');
   catch
-      userInfo(verbose,
+      userInfo(verbose, ...
                ['Upgrade has failed.\n', ...
                 'Please install the latest version manually from %s !'], ...
                 fileExchangeUrl);
@@ -136,7 +135,7 @@ function cleanupOldFiles(currentFolderFiles, unzippedFilesTarget)
     end
 end
 % ==============================================================================
-function mostRecentVersion = determineLatestRelease(version)
+function mostRecentVersion = determineLatestRelease(version, fileExchangeUrl)
   % Read in the Github releases page
   url = 'https://github.com/matlab2tikz/matlab2tikz/releases/';
   try
@@ -144,6 +143,11 @@ function mostRecentVersion = determineLatestRelease(version)
   catch %#ok
       % Couldn't load the URL -- never mind.
       html = '';
+      warning('m2tUpdate:siteNotFound', ...
+              ['Cannot determine the latest version.\n', ...
+               'Either your internet is down or something went wrong.\n', ...
+               'You might want to check for updates by hand at %s.\n'], ...
+               fileExchangeUrl);
   end
 
   % Parse tag names which are the version number in the format ##.##.##

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -1,4 +1,4 @@
-function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, env)
+function upgradeSuccess = m2tUpdater(about, verbose, env)
 %UPDATER   Auto-update matlab2tikz.
 %   Only for internal usage.
 
@@ -27,7 +27,10 @@ function upgradeSuccess = m2tUpdater(name, fileExchangeUrl, version, verbose, en
 %   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 %   POSSIBILITY OF SUCH DAMAGE.
 % =========================================================================
-  
+  name = about.name;
+  fileExchangeUrl = about.website;
+  version = about.version;
+
   % Read in the Github releases page
   url = 'https://github.com/matlab2tikz/matlab2tikz/releases/';
   try

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -113,10 +113,12 @@ function tryToUpgrade(fileExchangeUrl, verbose)
 
       userInfo(verbose, 'Upgrade has completed successfully.');
   catch
+      err = lasterror(); %#ok needed for Octave
+      
       userInfo(verbose, ...
-               ['Upgrade has failed.\n', ...
+               ['Upgrade has failed with error message "%s".\n', ...
                 'Please install the latest version manually from %s !'], ...
-                fileExchangeUrl);
+                err.message, fileExchangeUrl);
   end
 end
 % ==============================================================================

--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -251,50 +251,6 @@ function cls = upgradeSize(currentVersion, latestVersion)
     cls = 'unknown';
 end
 % ==============================================================================
-function isBelow = isVersionBelow(versionA, versionB)
-% Checks if version string or vector versionA is smaller than
-% version string or vector versionB.
-    vA = versionArray(versionA);
-    vB = versionArray(versionB);
-
-    isBelow = false;
-    for i = 1:min(length(vA), length(vB))
-        if vA(i) > vB(i)
-            isBelow = false;
-            break;
-        elseif vA(i) < vB(i)
-            isBelow = true;
-            break
-        end
-    end
-end
-% ==============================================================================
-function str = versionString(arr)
-% Converts a version array to string
-  if ischar(arr)
-      str = arr;
-  elseif isnumeric(arr)
-      str = sprintf('%d.', arr);
-      str = str(1:end-1); % remove final period
-  end
-end
-% ==============================================================================
-function arr = versionArray(str)
-  % Converts a version string to an array, e.g.,
-  % '2.62.8.1' to [2, 62, 8, 1].
-  if ischar(str)
-    switch getEnvironment
-      case 'MATLAB'
-        split = regexp(str, '\.', 'split');
-      case 'Octave'
-        split = strsplit(str, '.');
-    end
-    arr = str2num(char(split)); %#ok
-  else
-    arr = str;
-  end
-end
-% ==============================================================================
 function userInfo(verbose, message, varargin)
   % Display usage information.
   if verbose

--- a/src/private/versionArray.m
+++ b/src/private/versionArray.m
@@ -1,0 +1,18 @@
+function arr = versionArray(str)
+% Converts a version string to an array.
+    if ischar(str)
+        % Translate version string from '2.62.8.1' to [2; 62; 8; 1].
+        switch getEnvironment
+            case 'MATLAB'
+                split = regexp(str, '\.', 'split'); % compatibility MATLAB < R2013a
+            case  'Octave'
+                split = strsplit(str, '.');
+            otherwise
+                errorUnknownEnvironment();
+        end
+        arr = str2num(char(split)); %#ok
+    else
+        arr = str;
+    end
+    arr = arr(:)';
+end

--- a/src/private/versionString.m
+++ b/src/private/versionString.m
@@ -1,0 +1,9 @@
+function str = versionString(arr)
+% Converts a version array to string
+  if ischar(arr)
+      str = arr;
+  elseif isnumeric(arr)
+      str = sprintf('%d.', arr);
+      str = str(1:end-1); % remove final period
+  end
+end


### PR DESCRIPTION
This addresses most of #584, i.e. the updater
 - is Semantic Versioning-aware, 
 - will give a basic interpretation of the upgrade size (i.e. major vs minor vs patch),
 - will show the relevant part of the changelog to the user if they it ask for it,
 - will perform the upgrade *after* TikZ conversion instead of before.

As a cherry on top, I made the code a bit more modular.

What is in #583, but isn't implemented here is the automatic options or the options to upgrade certain versions automatically. I don't think those are nice-to-haves, but not crucial.