### PR TITLE
Fixed #700, legends of bodeplots not showing

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -751,7 +751,7 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
     legendString = '';
     interpreter  = '';
     hasLegend = false;
-    isGroup   = false;
+    legendRefersToParent = false;
     %FIXME: this part (e.g. fall back objects) should be restructured.
     for legendHandle = m2t.legendHandles(:)'
         ud = get(legendHandle, 'UserData');
@@ -768,9 +768,7 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
             % legends refer to the specgraph.errorbarseries
             % handle which is 'Parent' to the line handle.
             k = find(get(child,'Parent') == plotChildren);
-            if(~isempty(k))
-                isGroup = true;
-            end
+            legendRefersToParent = ~isempty(k);
         end
         if ~isempty(k)
             % Legend entry found. Add it to the plot.
@@ -779,11 +777,11 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
             if ~isempty(ud) && isfield(ud, 'lstrings')
                 legendString = ud.lstrings{k};
             else
-                legendString = get(child, 'DisplayName');
-                % If there is no DisplayName it might be in the parent
-                if isempty(legendString) && isGroup
-                    parent       = get(child, 'Parent');
+                if legendRefersToParent
+                    parent       = get(child,'Parent');
                     legendString = get(parent, 'DisplayName');
+                else
+                    legendString = get(child, 'DisplayName');
                 end
             end
         end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -751,6 +751,7 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
     legendString = '';
     interpreter  = '';
     hasLegend = false;
+    isGroup   = false;
     %FIXME: this part (e.g. fall back objects) should be restructured.
     for legendHandle = m2t.legendHandles(:)'
         ud = get(legendHandle, 'UserData');
@@ -767,6 +768,9 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
             % legends refer to the specgraph.errorbarseries
             % handle which is 'Parent' to the line handle.
             k = find(get(child,'Parent') == plotChildren);
+            if(~isempty(k))
+                isGroup = true;
+            end
         end
         if ~isempty(k)
             % Legend entry found. Add it to the plot.
@@ -776,6 +780,11 @@ function [legendString, interpreter, hasLegend] = findLegendInfoMATLAB(m2t, chil
                 legendString = ud.lstrings{k};
             else
                 legendString = get(child, 'DisplayName');
+                % If there is no DisplayName it might be in the parent
+                if isempty(legendString) && isGroup
+                    parent       = get(child, 'Parent');
+                    legendString = get(parent, 'DisplayName');
+                end
             end
         end
     end


### PR DESCRIPTION
From a first analysis: MATLAB bodeplots consist of groups of two lines (Magnitude, Phase). The lines have no 'DisplayName' but their common parent has one