### PR TITLE
Maintainer change

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,8 +24,8 @@ Thanks for patches, suggestions, and other contributions go to:
   * [Lucas Jeub](https://github.com/LJeub)
   * Martin Kiefel
   * [Andreas Kloeckner](https://github.com/akloeckner)
-  * [Oleg Komarov](https://github.com/okomarov)
   * Mykel Kochenderfer
+  * [Oleg Komarov](https://github.com/okomarov)
   * Henk Kortier
   * [Tom Lankhorst](https://github.com/tomlankhorst)
   * [Burkart Lingner](https://github.com/burkart)
@@ -34,9 +34,9 @@ Thanks for patches, suggestions, and other contributions go to:
   * [Jason Monschke](https://github.com/jam4375)
   * Francesco Montorsi
   * Ricardo Santiago Mozos
-  * [Peter Pablo](https://github.com/PeterPablo)
   * Johannes Mueller-Roemer
   * [Ali Ozdagli](https://github.com/aliirmak)
+  * [Peter Pablo](https://github.com/PeterPablo)
   * Julien Ridoux
   * [Christoph Rüdiger](https://github.com/mredd)
   * Carlos Russo

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,8 @@
-Nico Schlömer designed and implemented the intial version and is the current maintainer.
+# Maintainer
+  * Egon Geerardyn is the current maintainer.
+  * Nico Schlömer designed and implemented the intial version and was the first maintainer.
 
+# Contributors
 Thanks for patches, suggestions, and other contributions go to:
 
   * Martijn Aben (The MathWorks)
@@ -27,6 +30,7 @@ Thanks for patches, suggestions, and other contributions go to:
   * Julien Ridoux
   * Christoph Rüdiger
   * Carlos Russo
+  * Nico Schlömer
   * Johannes Schmitz
   * Michael Schoeberl
   * Donghua Wang
@@ -35,6 +39,7 @@ Thanks for patches, suggestions, and other contributions go to:
   * Bastiaan Zuurendonk (The MathWorks)
   * _and many more!_
 
+# Acknowledgements
 Matlab2tikz has once greatly profited from its ancestor:
 
   * [Matfig2PGF](http://www.mathworks.com/matlabcentral/fileexchange/12962) written by Paul Wagenaars.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,43 +1,55 @@
 # Maintainer
-  * Egon Geerardyn is the current maintainer.
-  * Nico Schlömer designed and implemented the intial version and was the first maintainer.
+  * [Egon Geerardyn](https://github.com/egeerardyn) is the current maintainer.
+  * [Nico Schlömer](https://github.com/nschloe) designed and implemented the intial version and was the first maintainer.
 
 # Contributors
 Thanks for patches, suggestions, and other contributions go to:
 
+  * [Ben Abbott](https://github.com/bpabbott)
   * Martijn Aben (The MathWorks)
-  * Ben Abbott
+  * [Nicolas Alt](https://github.com/nalt)
+  * [Eshwar Andhavarapu](https://github.com/gontadu)
+  * Matt Bauman
   * Eike Blechschmidt
-  * Klaus Broelemann
-  * Katherine Elkington
+  * [Klaus Broelemann](https://github.com/Broele)
+  * [Katherine Elkington](https://github.com/kelkington)
   * Andreas Gäb
-  * Egon Geerardyn
+  * [Egon Geerardyn](https://github.com/egeerardyn)
   * Roman Gesenhues
   * Michael Glasser (The MathWorks)
-  * David Haberthür
-  * Patrick Häcker
-  * David Horsley
-  * Burkart Lingner
-  * Oleg Komarov
+  * [David Haberthür](https://github.com/habi)
+  * [Patrick Häcker](https://github.com/MagicMuscleMan)
+  * [David Horsley](https://github.com/widdma)
+  * Kári Hreinsson
+  * [Lucas Jeub](https://github.com/LJeub)
+  * Martin Kiefel
+  * [Andreas Kloeckner](https://github.com/akloeckner)
+  * [Oleg Komarov](https://github.com/okomarov)
   * Mykel Kochenderfer
   * Henk Kortier
+  * [Tom Lankhorst](https://github.com/tomlankhorst)
+  * [Burkart Lingner](https://github.com/burkart)
   * Theo Markettos
-  * Dragan Mitrevski
+  * [Dragan Mitrevski](https://github.com/nidrosianDeath)
+  * [Jason Monschke](https://github.com/jam4375)
   * Francesco Montorsi
-  * Peter Pablo
   * Ricardo Santiago Mozos
+  * [Peter Pablo](https://github.com/PeterPablo)
   * Johannes Mueller-Roemer
+  * [Ali Ozdagli](https://github.com/aliirmak)
   * Julien Ridoux
-  * Christoph Rüdiger
+  * [Christoph Rüdiger](https://github.com/mredd)
   * Carlos Russo
-  * Nico Schlömer
+  * [Nico Schlömer](https://github.com/nschloe)
   * Johannes Schmitz
   * Michael Schoeberl
+  * [José Vallet](https://github.com/josombio)
+  * [Thomas Wagner](https://github.com/Aikhjarto)
   * Donghua Wang
   * Robert Whittlesey
   * Pooya Ziraksaz
   * Bastiaan Zuurendonk (The MathWorks)
-  * _and many more!_
+  * GitHub users: [theswitch](https://github.com/theswitch)
 
 # Acknowledgements
 Matlab2tikz has once greatly profited from its ancestor:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -36,7 +36,7 @@ Thanks for patches, suggestions, and other contributions go to:
   * Ricardo Santiago Mozos
   * Johannes Mueller-Roemer
   * [Ali Ozdagli](https://github.com/aliirmak)
-  * [Peter Pablo](https://github.com/PeterPablo)
+  * [Peter Ploß](https://github.com/PeterPablo)
   * Julien Ridoux
   * [Christoph Rüdiger](https://github.com/mredd)
   * Carlos Russo

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # Maintainer
-  * [Egon Geerardyn](https://github.com/egeerardyn) is the current maintainer.
-  * [Nico Schlömer](https://github.com/nschloe) designed and implemented the intial version and was the first maintainer.
+  * [Egon Geerardyn](https://github.com/egeerardyn) is the current maintainer (2015 - now).
+  * [Nico Schlömer](https://github.com/nschloe) designed and implemented the intial version and was the first maintainer (2008 - 2015).
 
 # Contributors
 Thanks for patches, suggestions, and other contributions go to:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,8 +52,6 @@ Thanks for patches, suggestions, and other contributions go to:
   * GitHub users: [theswitch](https://github.com/theswitch)
 
 # Acknowledgements
-Matlab2tikz has once greatly profited from its ancestor:
+Matlab2tikz has once greatly profited from its ancestor: [Matfig2PGF](http://www.mathworks.com/matlabcentral/fileexchange/12962) written by Paul Wagenaars.
 
-  * [Matfig2PGF](http://www.mathworks.com/matlabcentral/fileexchange/12962) written by Paul Wagenaars.
-
-Also, the authors would like to thank Christian Feuersänger for the [Pgfplots](http://pgfplots.sourceforge.net) package which forms the basis for the matlab2tikz output on the LaTeX side.
+Also, the authors would like to thank [Christian Feuersänger](https://github.com/cfeuersaenger) for the [Pgfplots](http://pgfplots.sourceforge.net) package which forms the basis for the matlab2tikz output on the LaTeX side.


### PR DESCRIPTION
This PR is a notice that I will take over the job as maintainer from @nschloe, as both of us discussed briefly during the weekend. With this PR, I also want to show my appreciation for the great work that @nschloe has done for `matlab2tikz` (and I hope, that he will continue to do in the future) :+1: .

Nico has also set the gears in motion to transfer the account on FileExchange to @matlab2tikzBot (or rather, the corresponding [FEX user](http://www.mathworks.com/matlabcentral/profile/authors/6696984-matlab2tikz)), but we are waiting for The MathWorks to carry out this change.

My intention with the @matlab2tikzBot accounts (on GitHub, FEX and GMail), is that we can use it as a shared account amongst developers for e.g. integration with third parties (FEX as the most important one, but also possibly Waffle.io, Travis, HipChat, ...). By having such a shared account, I hope to increase our [bus factor](https://en.wikipedia.org/wiki/Bus_factor) and create a more "official" e-mail address for this project.