### PR TITLE
Fix page border of logo

### DIFF
--- a/logos/matlab2tikz.svg
+++ b/logos/matlab2tikz.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="744.09448819"
-   height="1052.3622047"
+   width="2078.8535"
+   height="846.6734"
    id="svg3051"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="m2t.svg">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="matlab2tikz.svg">
   <defs
      id="defs3053" />
   <sodipodi:namedview
@@ -25,16 +25,20 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.25"
-     inkscape:cx="696.59128"
-     inkscape:cy="461.26734"
+     inkscape:cx="56.708296"
+     inkscape:cy="-3.0561694"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1280"
-     inkscape:window-height="738"
+     inkscape:window-width="1680"
+     inkscape:window-height="949"
      inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1" />
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
   <metadata
      id="metadata3056">
     <rdf:RDF>
@@ -50,22 +54,26 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="translate(91.763877,-109.02549)">
     <path
        style="fill:#ef8200;fill-opacity:1;stroke:none"
        d="m 229.79347,889.91953 c -51.20296,-69.53548 -110.45905,-150.5284 -117.8477,-161.07762 -3.66043,-5.22621 -4.15923,-6.45766 -2.93039,-7.23468 0.81449,-0.51503 2.1559,-0.94763 2.9809,-0.96134 4.45183,-0.074 21.84491,-16.50352 39.70528,-37.5057 64.93246,-76.3547 212.14442,-292.5117 313.27925,-460 28.45805,-47.12908 55.23448,-94.70724 59.01417,-107.81682 2.21373,-7.67817 3.30364,-4.58186 5.54982,7.259 0.84717,4.46595 9.42069,39.94343 19.05225,78.83886 61.4356,248.09709 88.96885,376.22196 95.45994,444.21896 1.34274,14.06576 0.80116,31.67542 -1.06339,34.57694 -0.67969,1.05768 -29.41344,23.07306 -63.85279,48.92306 -46.63668,35.00526 -216.41083,162.82778 -297.77739,224.19582 l -3.13285,2.36286 z"
-       id="path3072" />
+       id="path3072"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#ffd912;fill-opacity:1"
        d="M 828.49628,790.87316 C 751.45425,746.41551 656.62349,689.46978 647.33146,682.08395 c -2.47911,-1.97053 -2.52321,-2.17947 -1.05805,-5.01277 3.18772,-6.16438 4.02557,-14.85566 3.44538,-35.74002 -0.80529,-28.98647 -5.98761,-65.55929 -17.38517,-122.69097 -18.80756,-94.27528 -55.9766,-241.89492 -91.4729,-363.29152 -4.95189,-16.93533 -13.8484,-44.15875 -13.64905,-44.7568 0.19935,-0.59804 7.77507,16.91106 10.71396,23.16944 14.72516,31.35732 169.10504,368.5638 262.04653,572.37888 18.81036,41.25 35.965,78.78344 38.1214,83.40766 2.15641,4.62421 3.80419,8.50202 3.66173,8.61735 -0.14245,0.11533 -6.10901,-3.16608 -13.25901,-7.29204 z"
-       id="path3070" />
+       id="path3070"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#00b0cf;fill-opacity:1"
        d="M 98.496283,712.93087 C 76.224153,691.69469 25.659453,651.42885 -55.133796,590.59166 l -36.630081,-27.58239 14.630081,-4.80606 C 1.4604828e-5,532.86436 84.848253,489.14509 155.49628,438.33721 c 90.71369,-65.23848 211.18904,-171.14032 339.75,-298.65155 14.7125,-14.59237 30.24771,-31.09621 30.24771,-30.65137 0,1.46965 -5.56006,9.74411 -33.50167,53.6059 -117.938,185.13504 -236.74752,364.94776 -300.3065,454.5 -22.45559,31.6391 -46.86362,64.24839 -58.75719,78.5 -10.15154,12.16419 -23.13943,25.02746 -25.20109,24.95928 -0.6772,-0.0224 -4.83126,-3.47326 -9.231257,-7.6686 z"
-       id="path2987" />
+       id="path2987"
+       inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:256.08959961px;font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ef8200;fill-opacity:1;stroke:none;font-family:Monotype Corsiva;-inkscape-font-specification:Monotype Corsiva Bold Italic"
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:256.08959961px;line-height:125%;font-family:'Monotype Corsiva';-inkscape-font-specification:'Monotype Corsiva Bold Italic';letter-spacing:0px;word-spacing:0px;fill:#ef8200;fill-opacity:1;stroke:none"
        x="835.56165"
        y="469.78217"
        id="text3863"
@@ -74,21 +82,21 @@
          id="tspan3865"
          x="835.56165"
          y="469.78217"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;fill-opacity:1;font-family:Liberation Sans;-inkscape-font-specification:Liberation Sans Italic"><tspan
-           style="font-style:normal;-inkscape-font-specification:Liberation Sans"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Italic';fill:#000000;fill-opacity:1"><tspan
+           style="font-style:normal;-inkscape-font-specification:'Liberation Sans'"
            id="tspan2999">MATLAB</tspan><tspan
-           style="font-style:italic;font-weight:bold;-inkscape-font-specification:Liberation Sans Italic"
+           style="font-style:italic;font-weight:bold;-inkscape-font-specification:'Liberation Sans Italic'"
            id="tspan2997">2</tspan></tspan><tspan
          sodipodi:role="line"
          x="835.56165"
          y="789.89417"
          id="tspan3867"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ef8200;fill-opacity:1;font-family:Liberation Sans;-inkscape-font-specification:Liberation Sans"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;font-family:Liberation Sans;-inkscape-font-specification:Liberation Sans"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#ef8200;fill-opacity:1"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#000000"
            id="tspan3875">Ti</tspan><tspan
-           style="font-style:italic;-inkscape-font-specification:Liberation Sans Italic"
+           style="font-style:italic;-inkscape-font-specification:'Liberation Sans Italic'"
            id="tspan2995">k</tspan><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#000000;font-family:Liberation Sans;-inkscape-font-specification:Liberation Sans"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#000000"
            id="tspan3873">Z</tspan></tspan></text>
   </g>
 </svg>

--- a/logos/matlab2tikz.svg
+++ b/logos/matlab2tikz.svg
@@ -9,8 +9,8 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="2078.8535"
-   height="846.6734"
+   width="2083.4766"
+   height="856.6734"
    id="svg3051"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -24,9 +24,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.25"
-     inkscape:cx="56.708296"
-     inkscape:cy="-3.0561694"
+     inkscape:zoom="0.5"
+     inkscape:cx="1424.8959"
+     inkscape:cy="275.08087"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -35,10 +35,10 @@
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5" />
   <metadata
      id="metadata3056">
     <rdf:RDF>
@@ -55,7 +55,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(91.763877,-109.02549)">
+     transform="translate(96.763877,-104.02549)">
     <path
        style="fill:#ef8200;fill-opacity:1;stroke:none"
        d="m 229.79347,889.91953 c -51.20296,-69.53548 -110.45905,-150.5284 -117.8477,-161.07762 -3.66043,-5.22621 -4.15923,-6.45766 -2.93039,-7.23468 0.81449,-0.51503 2.1559,-0.94763 2.9809,-0.96134 4.45183,-0.074 21.84491,-16.50352 39.70528,-37.5057 64.93246,-76.3547 212.14442,-292.5117 313.27925,-460 28.45805,-47.12908 55.23448,-94.70724 59.01417,-107.81682 2.21373,-7.67817 3.30364,-4.58186 5.54982,7.259 0.84717,4.46595 9.42069,39.94343 19.05225,78.83886 61.4356,248.09709 88.96885,376.22196 95.45994,444.21896 1.34274,14.06576 0.80116,31.67542 -1.06339,34.57694 -0.67969,1.05768 -29.41344,23.07306 -63.85279,48.92306 -46.63668,35.00526 -216.41083,162.82778 -297.77739,224.19582 l -3.13285,2.36286 z"


### PR DESCRIPTION
This makes sure that other SVG editors show the whole logo, not only a part.
Not high-priority, but it bothered me every time I opened the file.

I don't know how well most SVG editors support font fallbacks, so I didn't have a go at that to also make sure that rendering is better when Liberation Sans is not installed (e.g. Illustrator CS6 dislikes it when not all fonts are installed on your system).