### PR TITLE
TickLabels - fix escaping

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1278,11 +1278,14 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
 
     keywordTickLabelMode = [upper(axis), 'TickLabelMode'];
     tickLabelMode = get(handle, keywordTickLabelMode);
-    keywordTickLabel = [upper(axis), 'TickLabel'];
-    tickLabels = cellstr(get(handle, keywordTickLabel));
     if strcmpi(tickLabelMode, 'auto') && ~m2t.cmdOpts.Results.strict
         pgfTickLabels = [];
     else % strcmpi(tickLabelMode,'manual') || m2t.cmdOpts.Results.strict
+        keywordTickLabel = [upper(axis), 'TickLabel'];
+        interpreter = 'none'; % MATLAB only supports 'none'
+        tickLabels = cellstr(get(handle, keywordTickLabel))
+        tickLabels = prettyPrint(m2t, tickLabels, interpreter)
+
         keywordScale = [upper(axis), 'Scale'];
         isAxisLog = strcmpi(getOrDefault(handle,keywordScale, 'lin'), 'log');
         [pgfTicks, pgfTickLabels] = ...

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1283,8 +1283,8 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
     else % strcmpi(tickLabelMode,'manual') || m2t.cmdOpts.Results.strict
         keywordTickLabel = [upper(axis), 'TickLabel'];
         interpreter = 'none'; % MATLAB only supports 'none'
-        tickLabels = cellstr(get(handle, keywordTickLabel))
-        tickLabels = prettyPrint(m2t, tickLabels, interpreter)
+        tickLabels = cellstr(get(handle, keywordTickLabel));
+        tickLabels = prettyPrint(m2t, tickLabels, interpreter);
 
         keywordScale = [upper(axis), 'Scale'];
         isAxisLog = strcmpi(getOrDefault(handle,keywordScale, 'lin'), 'log');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1281,8 +1281,11 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
     if strcmpi(tickLabelMode, 'auto') && ~m2t.cmdOpts.Results.strict
         pgfTickLabels = [];
     else % strcmpi(tickLabelMode,'manual') || m2t.cmdOpts.Results.strict
+        % HG2 allows to set 'TickLabelInterpreter'.
+        % HG1 tacitly uses the interpreter 'none'.
+        % See http://www.mathworks.com/matlabcentral/answers/102053#comment_300079
+        interpreter = getOrDefault(handle, 'TickLabelInterpreter', 'none');
         keywordTickLabel = [upper(axis), 'TickLabel'];
-        interpreter = 'none'; % MATLAB only supports 'none'
         tickLabels = cellstr(get(handle, keywordTickLabel));
         tickLabels = prettyPrint(m2t, tickLabels, interpreter);
 


### PR DESCRIPTION
fixes #710

Note: TickLabels don't currently support different interpreters in MATLAB.