### PR TITLE
Contourf matrices

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2358,6 +2358,8 @@ function [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows)
     % group will be a peak. Otherwise, the group will be a valley, and
     % the contours will have to be plotted in reverse order, i.e. from
     % highest (largest) to lowest (narrowest).
+
+    %FIXME: close the contours over the border of the domain, see #723.
     order = NaN(ncont,1);
     ifree = true(ncont,1);
     from  = 1;
@@ -2403,6 +2405,7 @@ function [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows)
     xdata = get(h,'XData');
     ydata = get(h,'YData');
     %FIXME: determine the contour at the zero level not just its bounding box
+    % See also: #721
     zerolevel = [0,          4;
                  min(xdata(:)), min(ydata(:));
                  min(xdata(:)), max(ydata(:));

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2419,6 +2419,8 @@ function [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows)
         zval          = cellcont{ii}(1,1);
         [m2t, xcolor] = getColor(m2t,h,zval,'image');
         drawOpts      = opts_add(drawOpts,'fill',xcolor);
+        lineColor = get(h, 'LineColor');
+        [m2t, drawOpts] = setColor(m2t, h, drawOpts, 'draw', lineColor, 'none');
 
         % Toggle legend entry
         hasLegend = ii == 1 && m2t.currentHandleHasLegend;

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2415,12 +2415,20 @@ function [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows)
     for ii = 1:ncont + 1
         drawOpts = opts_new();
 
-        % Get color
+        % Get fill color
         zval          = cellcont{ii}(1,1);
         [m2t, xcolor] = getColor(m2t,h,zval,'image');
         drawOpts      = opts_add(drawOpts,'fill',xcolor);
+
+        % Get line properties
+        lineStyle = get(h, 'LineStyle');
         lineColor = get(h, 'LineColor');
+        lineWidth = get(h, 'LineWidth');
+
         [m2t, drawOpts] = setColor(m2t, h, drawOpts, 'draw', lineColor, 'none');
+
+        lineOpts = getLineOptions(m2t, lineStyle, lineWidth);
+        drawOpts = opts_merge(drawOpts, lineOpts);
 
         % Toggle legend entry
         hasLegend = ii == 1 && m2t.currentHandleHasLegend;

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2402,11 +2402,12 @@ function [m2t, str] = drawFilledContours(m2t, str, h, contours, istart, nrows)
     % Add zero level fill
     xdata = get(h,'XData');
     ydata = get(h,'YData');
+    %FIXME: determine the contour at the zero level not just its bounding box
     zerolevel = [0,          4;
-                 min(xdata), min(ydata);
-                 min(xdata), max(ydata);
-                 max(xdata), max(ydata);
-                 max(xdata), min(ydata)];
+                 min(xdata(:)), min(ydata(:));
+                 min(xdata(:)), max(ydata(:));
+                 max(xdata(:)), max(ydata(:));
+                 max(xdata(:)), min(ydata(:))];
     cellcont = [zerolevel; cellcont];
 
     % Plot

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -1,5 +1,5 @@
 alphaImage : 5ffff44e94f35a0fe14f51abe5094d60
-alphaTest : 79c4796e4decf9d81d59077ec1181992
+alphaTest : afa639fba35464fd70a2806538c3ec4a
 annotationAll : d3296a9c654ab784ffa9ad04ce62fd43
 annotationSubplots : 61909d56329cf5592dbfbd70b1fddf8a
 annotationText : 8b6f6473459e02681819fbad9b5c4600


### PR DESCRIPTION
This is an intermediate fix for `contourf` plots in HG2 where the `X` and `Y` arguments are matrices.
This allows for the whole contour plot to have special figures as discussed in #721.

What doesn't work yet (as indicated by a `FIXME` in the code), is showing the boundary of the contour surface. We now show the bounding box instead. The actual contours, however, seem alright.

You can try with the following MWE
```matlab
N = 20;
[X,Y] = meshgrid([1:N],[1:N]);
subplot(1,3,1);
contourf(X,Y,peaks(N),50,'edgecolor','blue','linestyle','--')
subplot(1,3,2);
contourf(X+Y/2,Y,peaks(N),50,'edgecolor','none')
subplot(1,3,3);
contourf(X+sin(Y),Y-cos(X),peaks(N),50,'edgecolor','red')
matlab2tikz('test.tikz','standalone',true)
!pdflatex test.tikz
open test.pdf
```

<img width="1331" alt="screen shot 2015-08-11 at 14 12 58" src="https://cloud.githubusercontent.com/assets/177360/9197268/26f3287c-4033-11e5-95b5-be539bfb2176.png">
