### PR TITLE
Figure2dot improvements

### DIFF
--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -74,6 +74,7 @@ function figure2dot(filename, varargin)
             catch
                 % don't do anything
             end
+            label = addProperty(label, 'Handle', sprintf('%g', double(h)));
             label = addHGProperty(label, h, 'Title', '');
             label = addHGProperty(label, h, 'String', '');
             label = addHGProperty(label, h, 'Tag', '');

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -69,7 +69,7 @@ function figure2dot(filename, varargin)
             label = {};
             label = addHGProperty(label, h, 'Type', '');
             try
-                hClass = class(handle(child));
+                hClass = class(handle(h));
                 label = addProperty(label, 'Class', hClass);
             catch
                 % don't do anything

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -114,7 +114,7 @@ function label = addHGProperty(label, h, propName, default)
 
     if isprop(h, propName)
         propValue = get(h, propName);
-        if ishghandle(propValue) && isprop(propValue, 'String')
+        if numel(propValue) == 1 && ishghandle(propValue) && isprop(propValue, 'String')
             % dereference Titles, labels, ...
             propValue = get(propValue, 'String');
         elseif iscellstr(propValue)

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -1,6 +1,15 @@
 function figure2dot(filename, varargin)
 %FIGURE2DOT    Save figure in Graphviz (.dot) file.
-%   FIGURE2DOT() saves the current figure as dot-file.
+%  FIGURE2DOT(filename) saves the current figure as dot-file.
+%
+%  FIGURE2DOT(filename, 'object', HGOBJECT) constructs the graph representation
+%  of the specified object (default: gcf)
+%
+%  You can visualize the constructed DOT file using:
+%    - [GraphViz](http://www.graphviz.org) on your computer
+%    - [WebGraphViz](http://www.webgraphviz.com) online
+%    - [Gravizo](http://www.gravizo.com) for your markdown files
+%    - and a lot of other software such as OmniGraffle
 %
 
 %   Copyright (c) 2008--2014, Nico Schlömer <nico.schloemer@gmail.com>
@@ -35,7 +44,6 @@ function figure2dot(filename, varargin)
     ipp = ipp.addParamValue(ipp, 'object', gcf, @ishghandle);
     ipp = ipp.parse(ipp, filename, varargin{:});
     args = ipp.Results;
-    %TODO: improve documentation of parameters of figure2dot
 
     filehandle = fopen(args.filename, 'w');
     finally_fclose_filehandle = onCleanup(@() fclose(filehandle));

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -125,7 +125,7 @@ function label = addHGProperty(label, h, propName, default)
         if numel(propValue) == 1 && ishghandle(propValue) && isprop(propValue, 'String')
             % dereference Titles, labels, ...
             propValue = get(propValue, 'String');
-        elseif iscellstr(propValue)
+        elseif iscell(propValue)
             propValue = ['{' m2tstrjoin(propValue,',') '}'];
         end
 
@@ -138,6 +138,8 @@ function label = addProperty(label, propName, propValue)
     % add a property to a GraphViz node label
     if isnumeric(propValue)
         propValue = num2str(propValue);
+    elseif iscell(propValue)
+        propValue = m2tstrjoin(propValue,sprintf('\n'));
     end
     label = [label, sprintf('%s: %s', propName, propValue)];
 end

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -83,7 +83,8 @@ function figure2dot(filename, varargin)
             label = addHGProperty(label, h, 'HandleVisibility', 'on');
 
             % print node
-            fprintf(fh, 'N%d [label="%s"]\n', node_number, collapse(label, '\n'));
+            fprintf(fh, 'N%d [label="%s"]\n', ...
+                    node_number, m2tstrjoin(label, '\n'));
 
             % connect to the child
             fprintf(fh, 'N%d -> N%d;\n\n', parent_node, node_number);
@@ -117,7 +118,7 @@ function label = addHGProperty(label, h, propName, default)
             % dereference Titles, labels, ...
             propValue = get(propValue, 'String');
         elseif iscellstr(propValue)
-            propValue = ['{' collapse(propValue,',') '}'];
+            propValue = ['{' m2tstrjoin(propValue,',') '}'];
         end
 
         if ~shouldOmit(propValue)
@@ -131,24 +132,5 @@ function label = addProperty(label, propName, propValue)
         propValue = num2str(propValue);
     end
     label = [label, sprintf('%s: %s', propName, propValue)];
-end
-% ==============================================================================
-function newstr = collapse(cellstr, delimiter)
-  % This function collapses a cell of strings to a single string (with a
-  % given delimiter inbetween two strings, if desired).
-  %
-  % Example of usage:
-  %              collapse(cellstr, ',')
-
-  if length(cellstr)<1
-     newstr = [];
-     return
-  end
-
-  newstr = cellstr{1};
-
-  for k = 2:length(cellstr)
-      newstr = [newstr, delimiter, cellstr{k}];
-  end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4879,30 +4879,7 @@ function newstr = join(m2t, cellstr, delimiter)
 %
 % Example of usage:
 %              join(m2t, cellstr, ',')
-    if isempty(cellstr)
-        newstr = '';
-        return
-    end
-
-    % convert all values to strings first
-    nElem = numel(cellstr);
-    for k = 1:nElem
-        if isnumeric(cellstr{k})
-            cellstr{k} = sprintf(m2t.ff, cellstr{k});
-        elseif iscell(cellstr{k})
-            cellstr{k} = join(m2t, cellstr{k}, delimiter);
-            % this will fail for heavily nested cells
-        elseif ~ischar(cellstr{k})
-            error('matlab2tikz:join:NotCellstrOrNumeric',...
-                'Expected cellstr or numeric.');
-        end
-    end
-
-    % inspired by strjoin of recent versions of MATLAB
-    newstr = cell(2,nElem);
-    newstr(1,:)         = reshape(cellstr, 1, nElem);
-    newstr(2,1:nElem-1) = {delimiter}; % put delimiters in-between the elements
-    newstr = [newstr{:}];
+    newstr = m2tstrjoin(cellstr, delimiter, m2t.ff);
 end
 % ==============================================================================
 function [width, height, unit] = getNaturalFigureDimension(m2t)

--- a/src/private/m2tstrjoin.m
+++ b/src/private/m2tstrjoin.m
@@ -30,5 +30,6 @@ function newstr = m2tstrjoin(cellstr, delimiter, floatFormat)
     newstr = cell(2,nElem);
     newstr(1,:)         = reshape(cellstr, 1, nElem);
     newstr(2,1:nElem-1) = {delimiter}; % put delimiters in-between the elements
+    newstr(2,end)       = {''}; % for Octave 4 compatibility
     newstr = [newstr{:}];
 end

--- a/src/private/m2tstrjoin.m
+++ b/src/private/m2tstrjoin.m
@@ -1,0 +1,34 @@
+function newstr = m2tstrjoin(cellstr, delimiter, floatFormat)
+% This function joins a cell of strings to a single string (with a
+% given delimiter in between two strings, if desired).
+    if ~exist('delimiter','var') || isempty(delimiter)
+        delimiter = '';
+    end
+    if ~exist('floatFormat','var') || isempty(floatFormat)
+        floatFormat = '%g';
+    end
+    if isempty(cellstr)
+        newstr = '';
+        return
+    end
+
+    % convert all values to strings first
+    nElem = numel(cellstr);
+    for k = 1:nElem
+        if isnumeric(cellstr{k})
+            cellstr{k} = sprintf(floatFormat, cellstr{k});
+        elseif iscell(cellstr{k})
+            cellstr{k} = m2tstrjoin(cellstr{k}, delimiter, floatFormat);
+            % this will fail for heavily nested cells
+        elseif ~ischar(cellstr{k})
+            error('matlab2tikz:join:NotCellstrOrNumeric',...
+                'Expected cellstr or numeric.');
+        end
+    end
+
+    % inspired by strjoin of recent versions of MATLAB
+    newstr = cell(2,nElem);
+    newstr(1,:)         = reshape(cellstr, 1, nElem);
+    newstr(2,1:nElem-1) = {delimiter}; % put delimiters in-between the elements
+    newstr = [newstr{:}];
+end

--- a/test/private/m2tstrjoin.m
+++ b/test/private/m2tstrjoin.m
@@ -11,6 +11,7 @@ function [ newstr ] = m2tstrjoin( cellstr, delimiter )
     newstr = cell(2,nElem);
     newstr(1,:)         = reshape(cellstr, 1, nElem);
     newstr(2,1:nElem-1) = {delimiter}; % put delimiters in-between the elements
+    newstr(2, end)      = {''}; % for Octave 4 compatibility
     newstr = [newstr{:}];
 
 end


### PR DESCRIPTION
When I was trying to debug some stuff in Octave, I noticed that `figure2dot` doesn't work in Octave. I took the opportunity to clean up the code a bit and add some new features.

This `figure2dot` function allows to translate a HG object into a DOT (GraphViz) file that represents the parent/children relationship and shows some of the relevant properties for each node. This allows to construct figures such as

![test74-tree](https://cloud.githubusercontent.com/assets/177360/9207146/0437e172-406c-11e5-9596-fb8ff2f2c8e6.png)
