### PR TITLE
Fix seed of RNG in Octave for `texrandom`

### DIFF
--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -68,7 +68,7 @@ surfPlot : 320bd897dc379aed143e22fae4cf4012
 surfPlot2 : 9e9f49e3f6e08837538ab6e05ec43e90
 texInterpreter : 3b2a0db9fd0560151ac349c34cc7650c
 texcolor : 99d828ebc560c48182bcf29b97f8c9c7
-texrandom : d3be1866d7ec69725c713c35b45a0d34
+texrandom : 34db1f8bdcb21d6d85f098569c0eb953
 textAlignment : ab67c21b9a17cb4fc55cf2b112977581
 textext : 9997e18352f9fdc62152d725b88bae1c
 xAxisReversed : 705791f60903c9d90206f124f9da8c7e

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1450,13 +1450,12 @@ end
 % =========================================================================
 function [stat] = texrandom()
   stat.description = 'Random TeX symbols';
-  stat.unreliable = isOctave(); % due to `rng` being unavailable in octave
 
   try
       rng(42); %fix seed
       %TODO: fully test tex conversion instead of a random subsample!
   catch
-      warning('testfuncs:texrandom','Cannot fix seed for random generator!');
+      rand('seed', 42); %#ok (this is deprecated in MATLAB)
   end
 
   num = 20; % number of symbols per line


### PR DESCRIPTION
This fixes the RNG seed in Octave as well. For me, this makes the test reliable, so I marked it as such. Hopefully Travis agrees with me.
This fixes #647 and alleviates #368.