### PR TITLE
Timing the test suite

### DIFF
--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -81,12 +81,19 @@ end
 % ------------------------------------------------------------------------------
 function [h] = plotByTestCase(timing, name)
     hold on;
-    h(1) = plot(timing.before, ...
-                'Color', colors.before, ...
-                'DisplayName', 'Before');
-    h(2) = plot(timing.after, ...
+    if size(timing.before, 2) > 1
+        h{3} = plot(timing.before, '.',...
+                    'Color', colors.before, 'HandleVisibility','off');
+        h{4} = plot(timing.after, '.',...
+                    'Color', colors.after, 'HandleVisibility','off');
+    end
+    h{1} = plot(median(timing.before, 2), '-',...
+                    'Color', colors.before, ...
+                    'DisplayName', 'Before');
+    h{2} = plot(median(timing.after, 2), '-',...
                 'Color', colors.after,...
                 'DisplayName', 'After');
+    
     
     ylabel(sprintf('%s runtime [s]', name));
     set(gca,'YScale','log')
@@ -105,8 +112,11 @@ function [h] = plotSpeedup(varargin)
 
         hold on
         speedup = timing.before ./ timing.after;
-        
-        plot(speedup, color{:}, 'DisplayName', name);
+        medSpeedup = median(timing.before,2) ./ median(timing.after,2);
+        if size(speedup, 2) > 1
+            plot(speedup, '.', color{:}, 'HandleVisibility','off');
+        end
+        h{iData} = plot(medSpeedup, color{:}, 'DisplayName', name);
         
         alldata = [alldata; speedup(:)];
     end
@@ -116,7 +126,6 @@ function [h] = plotSpeedup(varargin)
     xlabel('Test case');
     ylabel('Speed-up (t_{before}/t_{after})');
 end
-
     function [names,timings] = splitNameTiming(vararginAsCell)
         names  = vararginAsCell(1:2:end-1);
         timings = vararginAsCell(2:2:end);
@@ -130,8 +139,7 @@ end
         else
             color = {};
         end
-    end
-            
+    end        
 end
 
 

--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -13,21 +13,25 @@ function compareTimings(statusBefore, statusAfter)
 %    N x R cell arrays, each cell contains a status of a test case
 %    where there are N test cases, repeated R times each.
 %
-% A way to build such cells is:
+% You can build such cells, e.g. with the following snippet.
 %
-% suite = @ACID
-% N = numel(suite(0));
-% R = 10;
-% statusBefore = cell(N, R);
-% for r = 1:R
-%     statusBefore(:, r) = testHeadless;
-% end
-% % now check out the after commit
-% statusAfter = cell(N, R);
-% for r = 1:R
-%     statusAfter(:, r) = testHeadless;
-% end
-% compareTimings(statusBefore, statusAfter)
+%     suite = @ACID
+%     N = numel(suite(0)); % number of test cases
+%     R = 10; % number of repetitions of each test case
+%
+%     statusBefore = cell(N, R);
+%     for r = 1:R
+%         statusBefore(:, r) = testHeadless;
+%     end
+%
+%     % now check out the after commit
+%
+%     statusAfter = cell(N, R);
+%     for r = 1:R
+%         statusAfter(:, r) = testHeadless;
+%     end
+%
+%     compareTimings(statusBefore, statusAfter)
 %
 % See also: testHeadless
 

--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -1,40 +1,39 @@
 function compareTimings(statusBefore, statusAfter)
-
-time_cf.before = cellfun(@(s) s.tikzStage.cleanfigure_time, statusBefore,'ErrorHandler', @(varargin) NaN);
-time_cf.after = cellfun(@(s) s.tikzStage.cleanfigure_time, statusAfter,'ErrorHandler', @(varargin) NaN);
-
-time_m2t.before = cellfun(@(s) s.tikzStage.m2t_time, statusBefore,'ErrorHandler', @(varargin) NaN);
-time_m2t.after = cellfun(@(s) s.tikzStage.m2t_time, statusAfter,'ErrorHandler', @(varargin) NaN);
+    
+time_cf  = extract(statusBefore, statusAfter, @(s) s.tikzStage.cleanfigure_time);
+time_m2t = extract(statusBefore, statusAfter, @(s) s.tikzStage.m2t_time);
 
 colors.matlab2tikz = [161  19  46]/255;
 colors.cleanfigure = [  0 113 188]/255;
 colors.before      = [236 176  31]/255;
 colors.after       = [118 171  47]/255;
 
-hax1 = subplot(3,2,1);
+hax(1) = subplot(3,2,1);
 histograms(time_cf, 'cleanfigure');
 legend('show')
 
-hax2 = subplot(3,2,3);
+hax(2) = subplot(3,2,3);
 histograms(time_m2t, 'matlab2tikz');
 legend('show')
-linkaxes([hax1 hax2],'x');
+linkaxes(hax([1 2]),'x');
 
-subplot(3,2,5)
+hax(3) = subplot(3,2,5);
 histogramSpeedup('cleanfigure', time_cf, 'matlab2tikz', time_m2t);
 legend('show');
 
-subplot(3,2,2);
+hax(4) = subplot(3,2,2);
 plotByTestCase(time_cf, 'cleanfigure');
 legend('show')
 
-subplot(3,2,4);
+hax(5) = subplot(3,2,4);
 plotByTestCase(time_m2t, 'matlab2tikz');
 legend('show')
 
-subplot(3,2,6)
+hax(6) = subplot(3,2,6);
 plotSpeedup('cleanfigure', time_cf, 'matlab2tikz', time_m2t);
 legend('show');
+
+linkaxes(hax([4 5 6]), 'x');
 
 % ------------------------------------------------------------------------------
 function [h] = histograms(timing, name)
@@ -83,22 +82,22 @@ function [h] = plotByTestCase(timing, name)
     hold on;
     if size(timing.before, 2) > 1
         h{3} = plot(timing.before, '.',...
-                    'Color', colors.before, 'HandleVisibility','off');
+                    'Color', colors.before, 'HandleVisibility', 'off');
         h{4} = plot(timing.after, '.',...
-                    'Color', colors.after, 'HandleVisibility','off');
+                    'Color', colors.after, 'HandleVisibility', 'off');
     end
     h{1} = plot(median(timing.before, 2), '-',...
-                    'Color', colors.before, ...
-                    'DisplayName', 'Before');
+                'LineWidth', 2, ...
+                'Color', colors.before, ...
+                'DisplayName', 'Before');
     h{2} = plot(median(timing.after, 2), '-',...
+                'LineWidth', 2, ...
                 'Color', colors.after,...
                 'DisplayName', 'After');
-    
     
     ylabel(sprintf('%s runtime [s]', name));
     set(gca,'YScale','log')
 end
-
 function [h] = plotSpeedup(varargin)
     
     [names, timings] = splitNameTiming(varargin);
@@ -116,30 +115,41 @@ function [h] = plotSpeedup(varargin)
         if size(speedup, 2) > 1
             plot(speedup, '.', color{:}, 'HandleVisibility','off');
         end
-        h{iData} = plot(medSpeedup, color{:}, 'DisplayName', name);
+        h{iData} = plot(medSpeedup, color{:}, 'DisplayName', name, ...
+                        'LineWidth', 2);
         
         alldata = [alldata; speedup(:)];
     end
     
+    nTests = size(speedup, 1);
+    plot([-nTests nTests*2], ones(2,1), 'k','HandleVisibility','off');
+    
     legend('show', 'Location','NorthWest')
-    set(gca,'YScale','log','YLim',[min(alldata), max(alldata)].*[0.9 1.1])
+    set(gca,'YScale','log','YLim',[min(alldata), max(alldata)].*[0.9 1.1], ...
+        'XLim', [0 nTests+1])
     xlabel('Test case');
     ylabel('Speed-up (t_{before}/t_{after})');
 end
-    function [names,timings] = splitNameTiming(vararginAsCell)
-        names  = vararginAsCell(1:2:end-1);
-        timings = vararginAsCell(2:2:end);
+% ------------------------------------------------------------------------------
+function color = colorOptionsOfName(name, keyword)
+    if ~exist('keyword','var') || isempty(keyword)
+        keyword = 'Color';
     end
-    function color = colorOptionsOfName(name, keyword)
-        if ~exist('keyword','var') || isempty(keyword)
-            keyword = 'Color';
-        end
-        if isfield(colors,name)
-            color = {keyword, colors.(name)};
-        else
-            color = {};
-        end
-    end        
+    if isfield(colors,name)
+        color = {keyword, colors.(name)};
+    else
+        color = {};
+    end
+end        
 end
 
-
+function timing = extract(statusBefore, statusAfter, func)
+    otherwiseNaN = {'ErrorHandler', @(varargin) NaN};
+    
+    timing.before = cellfun(func, statusBefore, otherwiseNaN{:});
+    timing.after  = cellfun(func, statusAfter, otherwiseNaN{:});
+end
+function [names,timings] = splitNameTiming(vararginAsCell)
+    names  = vararginAsCell(1:2:end-1);
+    timings = vararginAsCell(2:2:end);
+end

--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -14,7 +14,7 @@ function compareTimings(statusBefore, statusAfter)
 %    where there are N test cases, repeated R times each.
 %
 % A way to build such cells is:
-% 
+%
 % suite = @ACID
 % N = numel(suite(0));
 % R = 10;
@@ -25,7 +25,7 @@ function compareTimings(statusBefore, statusAfter)
 % % now check out the after commit
 % statusAfter = cell(N, R);
 % for r = 1:R
-%     statusAfter(;, r) = testHeadless;
+%     statusAfter(:, r) = testHeadless;
 % end
 % compareTimings(statusBefore, statusAfter)
 %
@@ -69,7 +69,7 @@ end
 %% Data processing
 function timing = extract(statusBefore, statusAfter, func)
     otherwiseNaN = {'ErrorHandler', @(varargin) NaN};
-    
+
     timing.before = cellfun(func, statusBefore, otherwiseNaN{:});
     timing.after  = cellfun(func, statusAfter, otherwiseNaN{:});
 end
@@ -94,7 +94,7 @@ function [h] = histograms(timing, name)
     h{2} = myHistogram(timing.after , histostyle{:}, ...
                      'FaceColor', colors.after,...
                      'DisplayName', 'After');
-          
+
     xlabel(sprintf('%s runtime [s]',name))
     ylabel('Empirical PDF');
 end
@@ -110,11 +110,11 @@ function [h] = histogramSpeedup(varargin)
     for iData = 1:nData
         name = names{iData};
         timing = timings{iData};
-        
+
         hold on;
         speedup = timing.before ./ timing.after;
         color = colorOptionsOfName(name, 'FaceColor');
-        
+
         h{iData} = myHistogram(speedup, histostyle{:}, color{:},...
                                'DisplayName', name);
         alldata = [alldata;speedup(:)];
@@ -141,14 +141,14 @@ function [h] = plotByTestCase(timing, name)
                 'LineWidth', 2, ...
                 'Color', colors.after,...
                 'DisplayName', 'After');
-    
+
     ylabel(sprintf('%s runtime [s]', name));
     set(gca,'YScale','log')
 end
 function [h] = plotSpeedup(varargin)
     % plot speed up per test case
     [names, timings] = splitNameTiming(varargin);
-    
+
     nDatasets = numel(names);
     alldata = [];
     for iData = 1:nDatasets
@@ -164,13 +164,13 @@ function [h] = plotSpeedup(varargin)
         end
         h{iData} = plot(medSpeedup, color{:}, 'DisplayName', name, ...
                         'LineWidth', 2);
-        
+
         alldata = [alldata; speedup(:)];
     end
-    
+
     nTests = size(speedup, 1);
     plot([-nTests nTests*2], ones(2,1), 'k','HandleVisibility','off');
-    
+
     legend('show', 'Location','NorthWest')
     set(gca,'YScale','log','YLim',[min(alldata), max(alldata)].*[0.9 1.1], ...
         'XLim', [0 nTests+1])
@@ -185,7 +185,7 @@ function [h] = myHistogram(data, varargin)
         h = histogram(data, varargin{:});
     else % no "histogram" available
         options = struct(varargin{:});
-        
+
         minData = min(data(:));
         maxData = max(data(:));
         if isfield(options, 'BinWidth')
@@ -201,7 +201,7 @@ function [h] = myHistogram(data, varargin)
             counts = counts./sum(counts)/binWidth;
         end
         h = bar(bins, counts, 1);
-        
+
         % transfer properties as well
         names = fieldnames(options);
         for iName = 1:numel(names)
@@ -221,7 +221,7 @@ function colors = colorscheme()
     colors.matlab2tikz = [161  19  46]/255;
     colors.cleanfigure = [  0 113 188]/255;
     colors.before      = [236 176  31]/255;
-    colors.after       = [118 171  47]/255; 
+    colors.after       = [118 171  47]/255;
 end
 function color = colorOptionsOfName(name, keyword)
 % returns a cell array with a keyword (default: 'Color') and a named color
@@ -235,4 +235,4 @@ function color = colorOptionsOfName(name, keyword)
     else
         color = {};
     end
-end        
+end

--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -1,0 +1,137 @@
+function compareTimings(statusBefore, statusAfter)
+
+time_cf.before = cellfun(@(s) s.tikzStage.cleanfigure_time, statusBefore,'ErrorHandler', @(varargin) NaN);
+time_cf.after = cellfun(@(s) s.tikzStage.cleanfigure_time, statusAfter,'ErrorHandler', @(varargin) NaN);
+
+time_m2t.before = cellfun(@(s) s.tikzStage.m2t_time, statusBefore,'ErrorHandler', @(varargin) NaN);
+time_m2t.after = cellfun(@(s) s.tikzStage.m2t_time, statusAfter,'ErrorHandler', @(varargin) NaN);
+
+colors.matlab2tikz = [161  19  46]/255;
+colors.cleanfigure = [  0 113 188]/255;
+colors.before      = [236 176  31]/255;
+colors.after       = [118 171  47]/255;
+
+hax1 = subplot(3,2,1);
+histograms(time_cf, 'cleanfigure');
+legend('show')
+
+hax2 = subplot(3,2,3);
+histograms(time_m2t, 'matlab2tikz');
+legend('show')
+linkaxes([hax1 hax2],'x');
+
+subplot(3,2,5)
+histogramSpeedup('cleanfigure', time_cf, 'matlab2tikz', time_m2t);
+legend('show');
+
+subplot(3,2,2);
+plotByTestCase(time_cf, 'cleanfigure');
+legend('show')
+
+subplot(3,2,4);
+plotByTestCase(time_m2t, 'matlab2tikz');
+legend('show')
+
+subplot(3,2,6)
+plotSpeedup('cleanfigure', time_cf, 'matlab2tikz', time_m2t);
+legend('show');
+
+% ------------------------------------------------------------------------------
+function [h] = histograms(timing, name)
+    histostyle = {'DisplayStyle', 'bar',...
+                  'Normalization','pdf',...
+                  'EdgeColor','none',...
+                  'BinWidth',0.025};
+
+    hold on;
+    h(1) = histogram(timing.before, histostyle{:}, ...
+                     'FaceColor', colors.before, ...
+                     'DisplayName', 'Before');
+    h(2) = histogram(timing.after , histostyle{:}, ...
+                     'FaceColor', colors.after,...
+                     'DisplayName', 'After');
+          
+    xlabel(sprintf('%s runtime [s]',name))
+    ylabel('Empirical PDF');
+end
+function [h] = histogramSpeedup(varargin)
+    histostyle = {'DisplayStyle', 'bar',...
+                  'Normalization','pdf',...
+                  'BinMethod', 'fd', ...
+                  'EdgeColor','none'};
+
+    [names,timings] = splitNameTiming(varargin);
+    nData = numel(timings);
+    alldata = [];
+    for iData = 1:nData
+        name = names{iData};
+        timing = timings{iData};
+        
+        hold on;
+        speedup = timing.before ./ timing.after;
+        color = colorOptionsOfName(name, 'FaceColor');
+        
+        h(iData) = histogram(speedup, histostyle{:}, color{:}, 'DisplayName', name);
+        alldata = [alldata;speedup(:)];
+    end
+    xlabel('Speedup')
+    ylabel('Empirical PDF');
+    set(gca,'XScale','log', 'XLim', [min(alldata) max(alldata)].*[0.9 1.1]);
+end
+% ------------------------------------------------------------------------------
+function [h] = plotByTestCase(timing, name)
+    hold on;
+    h(1) = plot(timing.before, ...
+                'Color', colors.before, ...
+                'DisplayName', 'Before');
+    h(2) = plot(timing.after, ...
+                'Color', colors.after,...
+                'DisplayName', 'After');
+    
+    ylabel(sprintf('%s runtime [s]', name));
+    set(gca,'YScale','log')
+end
+
+function [h] = plotSpeedup(varargin)
+    
+    [names, timings] = splitNameTiming(varargin);
+    
+    nDatasets = numel(names);
+    alldata = [];
+    for iData = 1:nDatasets
+        name = names{iData};
+        timing = timings{iData};
+        color = colorOptionsOfName(name);
+
+        hold on
+        speedup = timing.before ./ timing.after;
+        
+        plot(speedup, color{:}, 'DisplayName', name);
+        
+        alldata = [alldata; speedup(:)];
+    end
+    
+    legend('show', 'Location','NorthWest')
+    set(gca,'YScale','log','YLim',[min(alldata), max(alldata)].*[0.9 1.1])
+    xlabel('Test case');
+    ylabel('Speed-up (t_{before}/t_{after})');
+end
+
+    function [names,timings] = splitNameTiming(vararginAsCell)
+        names  = vararginAsCell(1:2:end-1);
+        timings = vararginAsCell(2:2:end);
+    end
+    function color = colorOptionsOfName(name, keyword)
+        if ~exist('keyword','var') || isempty(keyword)
+            keyword = 'Color';
+        end
+        if isfield(colors,name)
+            color = {keyword, colors.(name)};
+        else
+            color = {};
+        end
+    end
+            
+end
+
+

--- a/test/compareTimings.m
+++ b/test/compareTimings.m
@@ -203,7 +203,6 @@ function [h] = myHistogram(data, varargin)
         h = bar(bins, counts, 1);
         
         % transfer properties as well
-        set(allchild(h),'FaceAlpha', 0.75); % this should look somewhat similar
         names = fieldnames(options);
         for iName = 1:numel(names)
             option = names{iName};
@@ -211,6 +210,8 @@ function [h] = myHistogram(data, varargin)
                 set(h, option, options.(option));
             end
         end
+        set(allchild(h),'FaceAlpha', 0.75); % only supported with OpenGL renderer
+        % but this should look a bit similar with matlab2tikz then...
     end
 end
 

--- a/test/private/execute_tikz_stage.m
+++ b/test/private/execute_tikz_stage.m
@@ -3,9 +3,16 @@ function [status] = execute_tikz_stage(status, ipp)
     testNumber = status.index;
     gen_tex = sprintf('data/converted/test%d-converted.tex', testNumber);
     gen_pdf  = sprintf('data/converted/test%d-converted.pdf', testNumber);
+    cleanfigure_time = NaN;
+    m2t_time = NaN;
+
     % now, test matlab2tikz
     try
+        cleanfigure_time = tic;
         cleanfigure(status.extraCleanfigureOptions{:});
+        cleanfigure_time = toc(cleanfigure_time);
+
+        m2t_time = tic;
         matlab2tikz('filename', gen_tex, ...
             'showInfo', false, ...
             'checkForUpdates', false, ...
@@ -14,6 +21,7 @@ function [status] = execute_tikz_stage(status, ipp)
             ipp.Results.extraOptions{:}, ...
             status.extraOptions{:} ...
             );
+        m2t_time = toc(m2t_time);
     catch %#ok
         e = lasterror('reset'); %#ok
         % Remove (corrupted) output file. This is necessary to avoid that the
@@ -23,4 +31,6 @@ function [status] = execute_tikz_stage(status, ipp)
     end
     status.tikzStage.texFile = gen_tex;
     status.tikzStage.pdfFile = gen_pdf;
+    status.tikzStage.m2t_time = m2t_time;
+    status.tikzStage.cleanfigure_time = cleanfigure_time;
 end


### PR DESCRIPTION
This is my processing script (see #737) for timing the test cases.
This is only the processing, you need to run the test suite yourself (repeatedly, if you want more reliable results).

I haven't fully checked whether there is a burn-in period of the timing results, since each the easies way to get the results, is to run the test suite repeatedly. So possibly, the caches get wiped by the time a test case is run again. If that's the case and a problem, we need to tweak the test framework a bit.

The output looks like this for #737 (after) vs. this branch (before):
<img width="895" alt="screen shot 2015-08-20 at 20 33 05" src="https://cloud.githubusercontent.com/assets/177360/9392075/d2f4fe18-477a-11e5-89d5-504109115fc4.png">
