### PR TITLE
Allow patchcolor 'none'

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4316,9 +4316,9 @@ function [m2t, xcolor] = patchcolor2xcolor(m2t, color, patchhandle)
                 [m2t, xcolor] = rgb2colorliteral(m2t, color);
 
             case 'none'
-                error('matlab2tikz:anycolor2rgb:ColorModelNoneNotAllowed',...
-                    ['Color model ''none'' not allowed here. ',...
-                    'Make sure this case gets intercepted before.']);
+                % Before, we used to throw an error here. However, probably this
+                % is not necessary and actually harmful (#739).
+                xcolor = 'none';
 
             otherwise
                     error('matlab2tikz:anycolor2rgb:UnknownColorModel',...


### PR DESCRIPTION
Don't throw an error here, to fix #739.
We don't have any test cases that cover this branch anyway.

I really wonder whether that error is really needed. I ran a `git blame`
on this and I tracked along the following commits:

 * 1a0e89ee where I just change some whitespace formatting
 * 20d9fc8e (whitespace above the error)
 * 9fbf9363 where Nico already has a similar error message in place
   but the function is used for a generic color conversion (instead of patches).

So my presumption is that the code was changed, the error message carried over
without a full check on whether it was really needed.

Anyway, the current change MAY cause compile errors if I'm being to quick in
removing the error. I expect we will see some bug reports if that's the case,
so I left a comment in the code to help tracking down this information.