### PR TITLE
Cleanfigure vectorize prune outside box

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -320,7 +320,7 @@ function out = segmentVisible(data, dataIsInBox, xLim, yLim)
     end
 end
 % =========================================================================
-function out = segmentsIntersect(data, dataDiff, X3, X4)
+function out = segmentsIntersect(X1, diffX2X1, X3, X4)
   % Checks whether the segments X1--X2 and X3--X4 intersect.
   % Given four points X_k=(x_k,y_k), k\in{1,2,3,4}, and the two lines defined
   % by those,
@@ -336,22 +336,18 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
   %
   % for lambda1 and lambda2.
 
-  % NOTE: We could vectorize this function. Now data is a matrix containing
-  % all points X1 and dataDiff is a matrix containing the differences
+  % NOTE: We could vectorize this function. Now X1 is a matrix containing
+  % all points X1 and diffX2X1 is a matrix containing the differences
   % X2-X1 for all points X1 and X2
   % n is the number of segments (not points in the plot!)
-  n   = size(dataDiff, 1);
+  n   = size(diffX2X1, 1);
   out = false(n, 1);
-  
-  % Rotational matrix with sign flip. It transforms a given vector [a,b] by 
-  % Rotate * [a,b] = [-b,a] as required for calculation of invA and detA  
-  Rotate = [0, -1; 1, 0];   
   
   % Calculate the determinant of A = [X2-X1, -(X4-X3)];
   % detA = -(X2(1)-X1(1))*(X4(2)-X3(2)) + (X2(2)-X1(2))*(X4(1)-X3(1))
   % NOTE: Vectorized this is equivalent to the matrix multiplication
   % [nx2] * [2x2] * [2x1] = [nx1]
-  detA = dataDiff * Rotate * (X4-X3);  
+  detA = -diffX2X1(:,1) .* (X4(2)-X3(2)) + diffX2X1(:,2) .* (X4(1)-X3(1));  
   
   % Get the indexes for nonzero elements
   id_detA = detA~=0;
@@ -360,16 +356,20 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
       % rhs = X3(:) - X1(:)
       % NOTE: Originaly this was a [2x1] vector. However as we vectorize the 
       % calculation it is beneficial to treat it as an [nx2] matrix rather than a [2xn]
-      rhs = bsxfun(@minus, X3', data(1:end-1, :));
+      rhs = bsxfun(@minus, X3', X1(1:end-1, :));
       
       % Calculate the inverse of A and lambda
       % invA=[-(X4(2)-X3(2)), X4(1)-X3(1);...
       %       -(X2(2)-X1(2)), X2(1)-X1(1)] / detA 
       % lambda = invA * rhs
+  
+      % Rotational matrix with sign flip. It transforms a given vector [a,b] by 
+      % Rotate * [a,b] = [-b,a] as required for calculation of invA  
+      Rotate = [0, -1; 1, 0];   
+
 
       % Rather than calculating invA first and then multiply with rhs to obtain 
-      % lambda, directly calculate the respective terms
-
+      % lambda, directly calculate the respective termsq
       % The upper half of the 2x2 matrix is always the same and is given by:
       % [-(X4(2)-X3(2)), X4(1)-X3(1)] / detA * rhs
       % This is a matrix multiplication of the form [1x2] * [2x1] = [1x1]
@@ -383,7 +383,7 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
       % matrix multiplication leading to a [nx1] vector. Therefore, use the
       % elementwise multiplication and sum over it
       % sum( [nx2] * [2x2] .* [nx2], 2) = sum([nx2],2) = [nx1] 
-      lambda2 = sum(-dataDiff(id_detA, :) * Rotate .* rhs(id_detA, :), 2)./detA(id_detA);
+      lambda2 = sum(-diffX2X1(id_detA, :) * Rotate .* rhs(id_detA, :), 2)./detA(id_detA);
 
       % Check whether lambda is in bound
       out(id_detA) = 0.0 < lambda1 & lambda1 < 1.0 & 0.0 < lambda2 & lambda2 < 1.0;

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -237,39 +237,31 @@ function pruneOutsideBox(meta, handle)
       % 'loose' ends may now appear in the figure.
       % To avoid this, add a row of NaNs wherever a block of actual data is
       % removed.
-      chunkIndices = [];
-      k = 1;
-      while k <= numPoints
-          % fast forward to shouldPlot==True
-          while k<=numPoints && ~shouldPlot(k)
-              k = k+1;
-          end
-          kStart = k;
-          % fast forward to shouldPlot==False
-          while k<=numPoints && shouldPlot(k)
-              k = k+1;
-          end
-          kEnd = k-1;
-
-          if kStart <= kEnd
-              chunkIndices = [chunkIndices; ...
-                              [kStart, kEnd]];
-          end
+      
+      % Get the indices of points that should not be plotted
+      id_remove = find(shouldPlot==0);
+            
+      % Find consecutive blocks of data points. For those
+      % diff(id_remove)==1. So only replace the first one with a NaN. Those
+      % indices alwas have diff(id_remove)>=2 as there is at least one
+      % datapoint between this and the next one
+      id_replace = id_remove([2; diff(id_remove)]>=2); 
+      
+      % Get the indices for all data points to be removed
+      id_remove  = id_remove([2; diff(id_remove)]==1); 
+      
+      % Make sure that the first data point is NOT replaced by a NaN
+      if(id_replace(1)==1)
+          id_replace=id_replace(2:end);
       end
-
-      % Create masked data with NaN padding.
-      % Make sure that there are no NaNs at the beginning of the data since
-      % this would be interpreted as column names by Pgfplots.
-      if size(chunkIndices, 1) > 0
-          ci = chunkIndices(1,:);
-          newData = data(ci(1):ci(2), :);
-          n = size(data, 2);
-          for ci = chunkIndices(2:end,:)'
-               newData = [newData; ...
-                          NaN(1, n); ...
-                          data(ci(1):ci(2), :)];
-          end
-          data = newData;
+      
+      % Replace the data points      
+      data(id_replace,:) = NaN(length(id_replace), size(data,2));
+      data(id_remove,:) = [];
+      
+      % If last point would be NaN remove it too 
+      if (isnan(data(end,:)))
+          data(end,:)=[];
       end
   end
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -300,8 +300,8 @@ function out = segmentVisible(data, dataIsInBox, xLim, yLim)
     % Only check if there is more than 1 point    
     if n>1
         % One of the neighbors is inside the box and the other is finite
-        nextVisible = (dataIsInBox(2:end)   & all(isfinite(data(1:end-1)),2));
-        thisVisible = (dataIsInBox(1:end-1) & all(isfinite(data(2:end)),2));
+        nextVisible = (dataIsInBox(2:end)   & all(isfinite(data(1:end-1)), 2));
+        thisVisible = (dataIsInBox(1:end-1) & all(isfinite(data(2:end)), 2));
 
         % Get the corner coordinates
         [bottomLeft, topLeft, bottomRight, topRight] = corners(xLim, yLim);
@@ -339,12 +339,13 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
   % NOTE: We could vectorize this function. Now data is a matrix containing
   % all points X1 and dataDiff is a matrix containing the differences
   % X2-X1 for all points X1 and X2
-  n   = size(dataDiff,1);
-  out = false(n,1);
+  % n is the number of segments (not points in the plot!)
+  n   = size(dataDiff, 1);
+  out = false(n, 1);
   
   % Rotational matrix with sign flip. It transforms a given vector [a,b] by 
   % Rotate * [a,b] = [-b,a] as required for calculation of invA and detA  
-  Rotate = [0, -1; 1, 0 ];   
+  Rotate = [0, -1; 1, 0];   
   
   % Calculate the determinant of A = [X2-X1, -(X4-X3)];
   % detA = -(X2(1)-X1(1))*(X4(2)-X3(2)) + (X2(2)-X1(2))*(X4(1)-X3(1))
@@ -359,7 +360,7 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
       % rhs = X3(:) - X1(:)
       % NOTE: Originaly this was a [2x1] vector. However as we vectorize the 
       % calculation it is beneficial to treat it as an [nx2] matrix rather than a [2xn]
-      rhs = bsxfun(@minus, X3', data(1:end-1,:));
+      rhs = bsxfun(@minus, X3', data(1:end-1, :));
       
       % Calculate the inverse of A and lambda
       % invA=[-(X4(2)-X3(2)), X4(1)-X3(1);...
@@ -382,10 +383,10 @@ function out = segmentsIntersect(data, dataDiff, X3, X4)
       % matrix multiplication leading to a [nx1] vector. Therefore, use the
       % elementwise multiplication and sum over it
       % sum( [nx2] * [2x2] .* [nx2], 2) = sum([nx2],2) = [nx1] 
-      lambda2 = sum(-dataDiff(id_detA,:) * Rotate .* rhs(id_detA,:), 2)./detA(id_detA);
+      lambda2 = sum(-dataDiff(id_detA, :) * Rotate .* rhs(id_detA, :), 2)./detA(id_detA);
 
       % Check whether lambda is in bound
-      out(id_detA) = lambda1 > 0.0 & lambda1 < 0.0 & lambda2 > 0.0 & lambda2 < 1.0;
+      out(id_detA) = 0.0 < lambda1 & lambda1 < 1.0 & 0.0 < lambda2 & lambda2 < 1.0;
   end
 end
 % =========================================================================


### PR DESCRIPTION
This is a small attempt to simplify the logic in pruneOutsideBox. The previous code utilized some while loops and complicated code.

Now it is much easier to understand which points are replaced and which are removed. As this vectorizes the process it should be faster too.

# MATLAB 8.5 (Linux  3.13.0-62-generic) commit 47dee78b12 

## Unreliable tests
These do not cause the build to fail.

|   Testcase |                   Name |                       OK |                                                                      Status |
| :--------- | :--------------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(1)` |     `multiline_labels` | :heavy_exclamation_mark: | hash 21a208748863224355861184cf9910f7 != (01d4eeae27254d91a0f8316897e23e81) |
|  `ACID(6)` | `sine_with_annotation` | :heavy_exclamation_mark: | hash 995cd2a901446c59f85552d48025ba27 != (7d415c014eec35c249802eb3a3ee519e) |
| `ACID(10)` |       `peaks_contourf` | :heavy_exclamation_mark: | hash 1241fa010c4c53ab967f1e61931b596f != (77bfa3a9f07e49b9061d919551ad0a0f) |
| `ACID(16)` |              `logplot` |       :white_check_mark: |                                                                             |
| `ACID(18)` |           `legendplot` | :heavy_exclamation_mark: | hash 30905e01d2507e5902023eabf9fc1466 != (746423d1c0d403421667221a6b0528bf) |
| `ACID(24)` |          `quiver3plot` |       :white_check_mark: |                                                                             |
| `ACID(34)` |                 `bars` |       :white_check_mark: |                                                                             |
| `ACID(38)` |          `subplot2x2b` |       :white_check_mark: |                                                                             |
| `ACID(40)` |        `subplotCustom` |       :white_check_mark: |                                                                             |
| `ACID(42)` |            `bodeplots` | :heavy_exclamation_mark: | hash ca7b2029a08a2a311a94b73339e2128a != (8f6cafc1771cc3a506c8fc46c15ec43e) |
| `ACID(43)` |           `rlocusPlot` | :heavy_exclamation_mark: | hash a8718c58cf1281e70f4e96d99aee2a6b != (f372b9a4004fa45ac96a21014656e143) |
| `ACID(48)` |          `zplanePlot2` | :heavy_exclamation_mark: | hash 4c2f1fea92ce3c969475e3f6b40f87cf != (fb3ba1a4db46c9975cd00e6da99ebe48) |
| `ACID(58)` |            `surfPlot2` | :heavy_exclamation_mark: | hash 520bba1c7a536efb15c82dfcc8ce6a23 != (eb8e6d18db994ba4a90e177bd44b5db3) |
| `ACID(94)` | `stackedBarsWithOther` |       :white_check_mark: |                                                                             |
| `ACID(97)` |     `overlappingPlots` |       :white_check_mark: |                                                                             |

## Reliable tests
Only the reliable tests determine the build outcome.
Passing tests are not shown (only failed and skipped tests).

|   Testcase |              Name |                       OK |                                                                      Status |
| :--------- | :---------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(8)` |   `peaks_contour` | :heavy_exclamation_mark: | hash 4c0f04124b13d5c12351f4875455a67d != (8885c9a4185aaca594ce5d0139aa578b) |
|  `ACID(9)` |    `contourPenny` | :heavy_exclamation_mark: | hash 1bbca20d0029e2e510eb5d7c46222ee7 != (3ee200ec93371666499d72f790ee9bb3) |
| `ACID(12)` | `double_colorbar` | :heavy_exclamation_mark: | hash 44a0d0b4b35ed634d2f2f568e51f2c8a != (6355484ba42b84205cd6a7d6de76711d) |
| `ACID(14)` |     `double_axes` | :heavy_exclamation_mark: | hash a053ed16097389ed6d6cfe6f353a46ab != (331441239c1bb077aebaf5ce8abe55f1) |
| `ACID(15)` |    `double_axes2` | :heavy_exclamation_mark: | hash ec8ccb7d178fd3e0227fd2cf3b210fa0 != (739edbf88cbf57187bea11ef93ebbf9a) |
| `ACID(21)` |            `zoom` | :heavy_exclamation_mark: | hash 4e56ddac18eea72b1a36166429fe8153 != (817b9999d832dc238b89573037cabc81) |
| `ACID(23)` |      `quiverplot` | :heavy_exclamation_mark: | hash 6f6723cafaf167b8e13d62f56b5a0aff != (308f4ce197791f2fd5862768e1157ca8) |
| `ACID(62)` |         `spectro` | :heavy_exclamation_mark: | hash e871a0b852a68fe12d78eead39e3de3b != (4426bb06bb44d08d016595f585fb01da) |
| `ACID(71)` |   `parameterSurf` | :heavy_exclamation_mark: | hash e64030978c54cc260847bf78a8c6ea6a != (12522a58d7e3d8dc7f4e38a0970bf047) |
| `ACID(76)` |       `myBoxplot` | :heavy_exclamation_mark: | hash ab5f495d4d03978ef42dd184d86be9a3 != (ce07c42d9618f6eff69392c66c668c82) |
| `ACID(17)` | `colorbarLogplot` |          :grey_question: |                                                                     SKIPPED |

## Test summary
Test results for m2t commit 47dee78b12 running with MATLAB 8.5 on Linux
 3.13.0-62-generic.

```matlab
suite = @ACID;
alltests = [1:99];
reliable = [2:5 7:9 11:15 17 19:23 25:33 35:37 39 41 44:47 49:57 59:93 95:96 98:99];
unreliable = [1 6 10 16 18 24 34 38 40 42:43 48 58 94 97];
failReliable = [8:9 12 14:15 21 23 62 71 76];
passUnreliable = [16 24 34 38 40 94 97];
skipped = [17];
```

|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    7 |    8 |    0 |    15 |
|   Reliable |   73 |   10 |    1 |    84 |
|      Total |   80 |   18 |    1 |    99 |

Build fails with 10 errors. :heavy_exclamation_mark:

Of the failing tests only 8 failed reliably (shifted by a pixel it seems) This is especially surprising, as it doesn't seem to even enter pruneOutsideBox, at least I wasn't able to set a breakpoint.