### PR TITLE
Vectorize pruneOutsideBox

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -258,16 +258,11 @@ function pruneOutsideBox(meta, handle)
   
   % Make sure that there are no NaNs at the beginning of the data since
   % this would be interpreted as column names by Pgfplots.
-  id_first = find(~any(isnan(data),2),1,'first');
-  if(id_first)>1;
-    data = data(id_first:end,:);
-  end  
-  
-  % Drop all NaNs at the end of the data too
-  id_last  = find(~any(isnan(data),2),1,'last');
-  if(id_last)<size(data,1);
-    data = data(1:id_last,:);
-  end  
+  % Also drop all NaNs at the end of the data
+  notnan   = any(~isnan(data),2);
+  id_first = find(notnan,1,'first');
+  id_last  = find(notnan,1,'last');
+  data     = data(id_first:id_last,:);
 
   % Override with the new data.
   set(handle, 'XData', data(:, 1));


### PR DESCRIPTION
This replaces the complex logic in pruneOutsideBox, that replaced non visible data points.
The new code is much easier to understand and faster due to vectorization.

# MATLAB 8.5 (Linux 3.13.0-62-generic) commit a02656c684 

## Unreliable tests
These do not cause the build to fail.

|   Testcase |                   Name |                       OK |                                                                      Status |
| :--------- | :--------------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(1)` |     `multiline_labels` | :heavy_exclamation_mark: | hash 21a208748863224355861184cf9910f7 != (01d4eeae27254d91a0f8316897e23e81) |
|  `ACID(6)` | `sine_with_annotation` | :heavy_exclamation_mark: | hash 995cd2a901446c59f85552d48025ba27 != (7d415c014eec35c249802eb3a3ee519e) |
| `ACID(10)` |       `peaks_contourf` | :heavy_exclamation_mark: | hash 1241fa010c4c53ab967f1e61931b596f != (77bfa3a9f07e49b9061d919551ad0a0f) |
| `ACID(16)` |              `logplot` |       :white_check_mark: |                                                                             |
| `ACID(18)` |           `legendplot` | :heavy_exclamation_mark: | hash 30905e01d2507e5902023eabf9fc1466 != (746423d1c0d403421667221a6b0528bf) |
| `ACID(24)` |          `quiver3plot` |       :white_check_mark: |                                                                             |
| `ACID(34)` |                 `bars` |       :white_check_mark: |                                                                             |
| `ACID(38)` |          `subplot2x2b` |       :white_check_mark: |                                                                             |
| `ACID(40)` |        `subplotCustom` |       :white_check_mark: |                                                                             |
| `ACID(42)` |            `bodeplots` | :heavy_exclamation_mark: | hash ca7b2029a08a2a311a94b73339e2128a != (8f6cafc1771cc3a506c8fc46c15ec43e) |
| `ACID(43)` |           `rlocusPlot` | :heavy_exclamation_mark: | hash a8718c58cf1281e70f4e96d99aee2a6b != (f372b9a4004fa45ac96a21014656e143) |
| `ACID(48)` |          `zplanePlot2` | :heavy_exclamation_mark: | hash 4c2f1fea92ce3c969475e3f6b40f87cf != (fb3ba1a4db46c9975cd00e6da99ebe48) |
| `ACID(58)` |            `surfPlot2` | :heavy_exclamation_mark: | hash 520bba1c7a536efb15c82dfcc8ce6a23 != (eb8e6d18db994ba4a90e177bd44b5db3) |
| `ACID(94)` | `stackedBarsWithOther` |       :white_check_mark: |                                                                             |
| `ACID(97)` |     `overlappingPlots` |       :white_check_mark: |                                                                             |

## Reliable tests
Only the reliable tests determine the build outcome.
Passing tests are not shown (only failed and skipped tests).

|   Testcase |              Name |                       OK |                                                                      Status |
| :--------- | :---------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(8)` |   `peaks_contour` | :heavy_exclamation_mark: | hash 4c0f04124b13d5c12351f4875455a67d != (8885c9a4185aaca594ce5d0139aa578b) |
|  `ACID(9)` |    `contourPenny` | :heavy_exclamation_mark: | hash 1bbca20d0029e2e510eb5d7c46222ee7 != (3ee200ec93371666499d72f790ee9bb3) |
| `ACID(12)` | `double_colorbar` | :heavy_exclamation_mark: | hash 44a0d0b4b35ed634d2f2f568e51f2c8a != (6355484ba42b84205cd6a7d6de76711d) |
| `ACID(14)` |     `double_axes` | :heavy_exclamation_mark: | hash a053ed16097389ed6d6cfe6f353a46ab != (331441239c1bb077aebaf5ce8abe55f1) |
| `ACID(15)` |    `double_axes2` | :heavy_exclamation_mark: | hash ec8ccb7d178fd3e0227fd2cf3b210fa0 != (739edbf88cbf57187bea11ef93ebbf9a) |
| `ACID(21)` |            `zoom` | :heavy_exclamation_mark: | hash 4e56ddac18eea72b1a36166429fe8153 != (817b9999d832dc238b89573037cabc81) |
| `ACID(23)` |      `quiverplot` | :heavy_exclamation_mark: | hash 6f6723cafaf167b8e13d62f56b5a0aff != (308f4ce197791f2fd5862768e1157ca8) |
| `ACID(62)` |         `spectro` | :heavy_exclamation_mark: | hash e871a0b852a68fe12d78eead39e3de3b != (4426bb06bb44d08d016595f585fb01da) |
| `ACID(71)` |   `parameterSurf` | :heavy_exclamation_mark: | hash e64030978c54cc260847bf78a8c6ea6a != (12522a58d7e3d8dc7f4e38a0970bf047) |
| `ACID(76)` |       `myBoxplot` | :heavy_exclamation_mark: | hash ab5f495d4d03978ef42dd184d86be9a3 != (ce07c42d9618f6eff69392c66c668c82) |
| `ACID(17)` | `colorbarLogplot` |          :grey_question: |                                                                     SKIPPED |

## Test summary
Test results for m2t commit a02656c684 running with MATLAB 8.5 on Linux
 3.13.0-62-generic.

```matlab
suite = @ACID;
alltests = [1:99];
reliable = [2:5 7:9 11:15 17 19:23 25:33 35:37 39 41 44:47 49:57 59:93 95:96 98:99];
unreliable = [1 6 10 16 18 24 34 38 40 42:43 48 58 94 97];
failReliable = [8:9 12 14:15 21 23 62 71 76];
passUnreliable = [16 24 34 38 40 94 97];
skipped = [17];
```

|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    7 |    8 |    0 |    15 |
|   Reliable |   73 |   10 |    1 |    84 |
|      Total |   80 |   18 |    1 |    99 |

Build fails with 10 errors. :heavy_exclamation_mark:

Of those tests that fail only 8 gives a different figure (shifted by a pixel). This is especially surprising, as it doesnt seem to enter pruneOutsideBox at all.