### PR TITLE
Vectorize movePointsCloser

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -687,14 +687,15 @@ function movePointsCloser(meta, handle)
         dataInsert_right = [cell(1); dataInsert_right];
       end
 
-      % Add the new data for right points first, then the possible NaN and then
-      % the new left point
-      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_right, 'UniformOutput', false);
-      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_NaN,   'UniformOutput', false);
-      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_left,  'UniformOutput', false);
+      % Put the cells together, right points first, then the possible NaN
+      % and then the left points
+      dataCell = [dataCell';
+                  dataInsert_right';
+                  dataInsert_NaN';
+                  dataInsert_left'];
 
-      % Put the data matrix back together
-      data     = cell2mat(dataCell);
+      % Merge the cells back together
+      data     = cat(1, dataCell{:});
   end
 
   % Remove consecutive NaNs
@@ -720,11 +721,11 @@ function xNew = moveToBox(x, xRef, xLim, yLim)
   % Returns the vector of points xNew that sits on the line segment between 
   % x and xRef *and* on the box. If several such points exist, take the 
   % closest one to x.
+  n = size(x, 1);
 
   % Find out with which border the line x---xRef intersects, and determine
   % the smallest parameter alpha such that x + alpha*(xRef-x)
-  % sits on the boundary.
-  n = size(x, 1);
+  % sits on the boundary. Otherwise set Alpha to inf.
   minAlpha = inf(n, 1);
   
   % Get the corner points
@@ -753,9 +754,10 @@ function minAlpha = updateAlpha(X1, X2, X3, X4, minAlpha)
   % Check if lambda is in bounds and lambda1 large enough
   id_Alpha           = 0.0 < lambda(:,2) & lambda(:,2) < 1.0 ...
                      & abs(minAlpha) > abs(lambda(:,1));
+
+  % Update alpha when applicable
   minAlpha(id_Alpha) = lambda(id_Alpha,1);
 end
-% =========================================================================
 % =========================================================================
 function out = isInBox(data, xLim, yLim)
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -299,16 +299,17 @@ function out = segmentVisible(data, dataIsInBox, xLim, yLim)
     
     % Only check if there is more than 1 point    
     if n>1
+        % Define the vectors of data points for the segments X1--X2
+        idx= 1:n-1;
+        X1 = data(idx,   :);
+        X2 = data(idx+1, :);
+        
         % One of the neighbors is inside the box and the other is finite
-        nextVisible = (dataIsInBox(2:end)   & all(isfinite(data(1:end-1)), 2));
-        thisVisible = (dataIsInBox(1:end-1) & all(isfinite(data(2:end)), 2));
+        thisVisible = (dataIsInBox(idx)     & all(isfinite(X2), 2));
+        nextVisible = (dataIsInBox(idx+1)   & all(isfinite(X1), 2));
 
         % Get the corner coordinates
         [bottomLeft, topLeft, bottomRight, topRight] = corners(xLim, yLim);
-
-        % Define the vectors of data points for the segments X1--X2
-        X1 = data(1:end-1, :);
-        X2 = data(2:end, :);
 
         % Check if data points intersect with the borders of the plot
         left   = segmentsIntersect(X1, X2, bottomLeft , topLeft);
@@ -626,9 +627,9 @@ function movePointsCloser(meta, handle)
   id_right = id_right(all(isfinite(data(id_right,:)), 2));
   
   % Define the vectors of data points for the segments X1--X2
-  X1_left  = data(id_left, :);
-  X2_left  = data(id_left-1, :);
-  X1_right = data(id_right, :);
+  X1_left  = data(id_left,    :);
+  X2_left  = data(id_left-1,  :);
+  X1_right = data(id_right,   :);
   X2_right = data(id_right+1, :);
   
   % Move the points closer to the large box along the segment 
@@ -675,7 +676,7 @@ function movePointsCloser(meta, handle)
       data     = cell2mat(dataCell);
 
       % Remove the NaN at the end of the last segment
-      data     = data(1:end-1,:);
+      data     = data(1:end-1, :);
   end
 
   % Set the new (masked) data.

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -613,97 +613,94 @@ function movePointsCloser(meta, handle)
   % Count the NaNs as being inside the box.
   dataIsInLargeBox = dataIsInLargeBox | any(isnan(data), 2);
 
-  % Find all points which are to be included in the plot yet do not fit 
+  % Find all points which are to be included in the plot yet do not fit
   % into the extended box, and gather the points by which they are to be
   % replaced.
   replaceIndices = find(~dataIsInLargeBox);  
+  
+  % Only replace Indices of there are some to replace
+  if (~isempty(replaceIndices))
+      % Get the indices of those segments, where the right point might be moved
+      id_right = replaceIndices(replaceIndices > 1);
+      id_right = id_right(all(isfinite(data(id_right,:)), 2));
 
-  % Get the indices of those segments, where the right point might be moved
-  id_right  = replaceIndices(replaceIndices > 1);
-  id_right = id_right(all(isfinite(data(id_right,:)), 2));
-  
-  % Get the indices of those segments where the left point might be moved
-  id_left = replaceIndices(replaceIndices < size(data, 1));
-  id_left = id_left(all(isfinite(data(id_left,:)), 2));
- 
-  % Define the vectors of data points for the segments X1--X2
-  X1_left  = data(id_left,    :);
-  X2_left  = data(id_left+1,  :);
-  X1_right = data(id_right,   :);
-  X2_right = data(id_right-1, :);
-  
-  % Move the points closer to the large box along the segment 
-  newData_left = moveToBox(X1_left,  X2_left,  largeXLim, largeYLim);
-  newData_right= moveToBox(X1_right, X2_right, largeXLim, largeYLim);
-  
-  % Only replace the data if newData_left is finite
-  id_isfinite   = all(isfinite(newData_left), 2);
-  id_left       = id_left(id_isfinite);
-  newData_left  = newData_left(id_isfinite,:);
-  
-  % Only replace the data if newData_right is finite
-  id_isfinite   = all(isfinite(newData_right), 2);
-  id_right      = id_right(id_isfinite);
-  newData_right = newData_right(id_isfinite, :);
-  
-  % Search for conflicts, where a point would be replaced twice
-  % id_conflict marks those data points that should be replaced twice
-  % id_conflictLeft marks their index in id_left
-  [id_conflict, id_conflictLeft, ~] = intersect(id_left, id_right);
-  
-  % Find those newData_left points that have no conflict
-  id_noConflict = id_left;
-  id_noConflict(id_conflictLeft) = [];
-  
-  % Get the indices of id_left without conflicts
-  id_noConflictLeft = 1:size(newData_left,1);
-  id_noConflictLeft(id_conflictLeft) = [];
-    
-  % Replace all newData_right points and the newData_left points without conflict
-  data(id_right, :)      = newData_right;
-  data(id_noConflict, :) = newData_left(id_noConflictLeft,:);
-  
-  % To avoid conflicts, insert a [NaN, NaN] point between the conflicting 
-  % points. In addition to direct conflicts, find those data points, where 
-  % consecutive points would have been replaced and insert a [NaN, NaN]
-  id_insert = sort([id_left; id_right]);
-  
-  % Search for those points, where two consecutive points were replaced (==1) 
-  % or there are conflicts (==0)
-  id_insert = id_insert(diff(id_insert) <= 1);
-   
-  % Insert NaNs and conflicting newData_left points
-  if (~isempty(id_insert))
-      % The data matrix gets cut into length(id_insert)+1 segments. 
-      % Calculate their length
-      length_segments = [id_insert(1); 
-                        diff(id_insert); 
-                        size(data, 1)-id_insert(end)];
+      % Get the indices of those segments where the left point might be moved
+      id_left  = replaceIndices(replaceIndices < size(data, 1));
+      id_left  = id_left(all(isfinite(data(id_left,:)), 2));
+
+      % Define the vectors of data points for the segments X1--X2
+      X1_left  = data(id_left,    :);
+      X2_left  = data(id_left+1,  :);
+      X1_right = data(id_right,   :);
+      X2_right = data(id_right-1, :);
+
+      % Move the points closer to the large box along the segment
+      newData_left = moveToBox(X1_left,  X2_left,  largeXLim, largeYLim);
+      newData_right= moveToBox(X1_right, X2_right, largeXLim, largeYLim);
+
+      % If newData_* is infinite, the segment was not visible. However, as we
+      % move the point closer, it would become visible. So insert a NaN.
+      isInfinite_left  = any(~isfinite(newData_left),  2);
+      isInfinite_right = any(~isfinite(newData_right), 2);
+
+      newData_left(isInfinite_left,  :) = NaN(sum(isInfinite_left),  2);
+      newData_right(isInfinite_right,:) = NaN(sum(isInfinite_right), 2);
+
+      % If a point is part of two segments, that cross the border, we need to
+      % insert a NaN to prevent an additional line segment
+      [~, ~, id_conflict] = intersect(id_left (~isInfinite_left), ...
+                                      id_right(~isInfinite_right));
+
+      % Cut the data into length(replaceIndices)+1 segments.
+      % Calculate the length of the segments
+      length_segments = [replaceIndices(1);
+                         diff(replaceIndices);
+                         size(data, 1)-replaceIndices(end)];
 
       % Cut the data into segments
-      dataCell   = mat2cell(data, length_segments, 2);
-      
-      % Create a cell array of [NaN, NaN] data points for every segment
-      dataInsert = mat2cell(NaN(length(id_insert)+1, 2), ones(length(id_insert)+1,1), 2);
-      
-      % Find those data points, with conflicts 
-      [~,~, id_InsertPoints] = intersect(id_conflict, id_insert);
-      
-      % Cut conflicting newData_left into a cell array
-      dataInsertNew = mat2cell(newData_left(id_conflictLeft,:), ones(length(id_conflictLeft),1), 2);
-      
-      % Add the new data points to the dataInsert cell array
-      dataInsert(id_InsertPoints) = cellfun(@(x, y) vertcat(x, y), dataInsert(id_InsertPoints), dataInsertNew, 'UniformOutput', false);
+      dataCell = mat2cell(data, length_segments, 2);
 
-      % Add dataInsert to the bottom of every segment
-      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert, 'UniformOutput', false);
+      % Remove the last point of every segment except the last one as they
+      % will be replaced
+      dataCell(1:end-1) = cellfun(@(x) x(1:end-1,:), dataCell(1:end-1), 'UniformOutput', false);
+
+      % Create an empty cell array for inserting NaNs and fill it at the
+      % conflict sites
+      dataInsert_NaN   = cell(length(length_segments),1);
+      dataInsert_NaN(id_conflict) = mat2cell(NaN(length(id_conflict), 2),...
+                                             ones(size(id_conflict)), 2);
+
+      % Create a cell array for the moved points
+      dataInsert_left  = mat2cell(newData_left,  ones(size(id_left)),  2);
+      dataInsert_right = mat2cell(newData_right, ones(size(id_right)), 2);
+
+      % Add an empty cell at the end of the last segment
+      dataInsert_left  = [dataInsert_left;  cell(1)];
+      dataInsert_right = [dataInsert_right; cell(1)];
+
+      % If the first or the last point would have been replaced add an empty
+      % cell at the beginning/end
+      if(replaceIndices(end) == size(data, 1))
+        dataInsert_left  = [dataInsert_left; cell(1)];
+      end
+      if(replaceIndices(1) == 1)
+        dataInsert_right = [cell(1); dataInsert_right];
+      end
+
+      % Add the new data for right points first, then the possible NaN and then
+      % the new left point
+      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_right, 'UniformOutput', false);
+      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_NaN,   'UniformOutput', false);
+      dataCell = cellfun(@(x, y) vertcat(x, y), dataCell, dataInsert_left,  'UniformOutput', false);
 
       % Put the data matrix back together
       data     = cell2mat(dataCell);
-
-      % Remove the NaN at the end of the last segment
-      data     = data(1:end-1, :);      
   end
+
+  % Remove consecutive NaNs
+  id_NaN = find(isnan(data(:, 1)));
+  id_NaN = id_NaN(diff(id_NaN) == 1);
+  data(id_NaN, :) = [];
 
   % Set the new (masked) data.
   set(handle, 'XData', data(:, 1));
@@ -734,22 +731,22 @@ function xNew = moveToBox(x, xRef, xLim, yLim)
   [bottomLeft, topLeft, bottomRight, topRight] = corners(xLim, yLim);
 
   % left boundary:
-  minAlpha = UpdateAlpha(x, xRef, bottomLeft, topLeft, minAlpha);
+  minAlpha = updateAlpha(x, xRef, bottomLeft, topLeft, minAlpha);
 
   % bottom boundary:
-  minAlpha = UpdateAlpha(x, xRef, bottomLeft, bottomRight, minAlpha);
+  minAlpha = updateAlpha(x, xRef, bottomLeft, bottomRight, minAlpha);
 
   % right boundary:
-  minAlpha = UpdateAlpha(x, xRef, bottomRight, topRight, minAlpha);
+  minAlpha = updateAlpha(x, xRef, bottomRight, topRight, minAlpha);
   
   % top boundary:
-  minAlpha = UpdateAlpha(x, xRef, topLeft, topRight, minAlpha);
+  minAlpha = updateAlpha(x, xRef, topLeft, topRight, minAlpha);
 
   % Create the new point
   xNew = x + bsxfun(@times ,minAlpha, (xRef-x));
 end
 % =========================================================================
-function minAlpha = UpdateAlpha(X1, X2, X3, X4, minAlpha)
+function minAlpha = updateAlpha(X1, X2, X3, X4, minAlpha)
   % Checks whether the segments X1--X2 and X3--X4 intersect. 
   lambda = crossLines(X1, X2, X3, X4);
   

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -619,18 +619,18 @@ function movePointsCloser(meta, handle)
   replaceIndices = find(~dataIsInLargeBox);  
     
   % Get the indices of those segments where the left point might be moved
-  id_left  = replaceIndices(replaceIndices > 1);
+  id_left = replaceIndices(replaceIndices<size(data, 1));
   id_left  = id_left(all(isfinite(data(id_left,:)), 2));
   
   % Get the indices of those segments, where the right point might be moved
-  id_right = replaceIndices(replaceIndices<size(data, 1));
+  id_right  = replaceIndices(replaceIndices > 1);
   id_right = id_right(all(isfinite(data(id_right,:)), 2));
   
   % Define the vectors of data points for the segments X1--X2
   X1_left  = data(id_left,    :);
-  X2_left  = data(id_left-1,  :);
+  X2_left  = data(id_left+1,  :);
   X1_right = data(id_right,   :);
-  X2_right = data(id_right+1, :);
+  X2_right = data(id_right-1, :);
   
   % Move the points closer to the large box along the segment 
   newPoint_left = moveToBox(X1_left,  X2_left,  largeXLim, largeYLim);


### PR DESCRIPTION
This is an upgrade to pull request #737. 

In addition to the changes there, this vectorizes the movePointsCloser function. The new function is now considerably simpler and we can keep most of the previous structure of the code.

As the last changes were complicated enough i decided to split it into 2 separate pull requests

There is one possible functional change. The old code calculated the xNew point and checked if it would still cross one of the axes. However, per construction this has to be true, otherwise xNew would have not been updated.

The usual tests for MATLAB2015a fail:

# MATLAB 8.5 (Linux 3.13.0-62-generic) commit 9f193c4675 

## Unreliable tests
These do not cause the build to fail.

|   Testcase |                   Name |                       OK |                                                                      Status |
| :--------- | :--------------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(1)` |     `multiline_labels` | :heavy_exclamation_mark: | hash 21a208748863224355861184cf9910f7 != (01d4eeae27254d91a0f8316897e23e81) |
|  `ACID(6)` | `sine_with_annotation` | :heavy_exclamation_mark: | hash 995cd2a901446c59f85552d48025ba27 != (7d415c014eec35c249802eb3a3ee519e) |
| `ACID(10)` |       `peaks_contourf` | :heavy_exclamation_mark: | hash 1241fa010c4c53ab967f1e61931b596f != (77bfa3a9f07e49b9061d919551ad0a0f) |
| `ACID(16)` |              `logplot` |       :white_check_mark: |                                                                             |
| `ACID(18)` |           `legendplot` | :heavy_exclamation_mark: | hash d37d19ba36d911a0db60095db48b08ef != (746423d1c0d403421667221a6b0528bf) |
| `ACID(24)` |          `quiver3plot` |       :white_check_mark: |                                                                             |
| `ACID(34)` |                 `bars` |       :white_check_mark: |                                                                             |
| `ACID(38)` |          `subplot2x2b` |       :white_check_mark: |                                                                             |
| `ACID(40)` |        `subplotCustom` |       :white_check_mark: |                                                                             |
| `ACID(42)` |            `bodeplots` | :heavy_exclamation_mark: | hash ca7b2029a08a2a311a94b73339e2128a != (8f6cafc1771cc3a506c8fc46c15ec43e) |
| `ACID(43)` |           `rlocusPlot` |       :white_check_mark: |                                                                             |
| `ACID(48)` |          `zplanePlot2` | :heavy_exclamation_mark: | hash 4c2f1fea92ce3c969475e3f6b40f87cf != (fb3ba1a4db46c9975cd00e6da99ebe48) |
| `ACID(58)` |            `surfPlot2` | :heavy_exclamation_mark: | hash 520bba1c7a536efb15c82dfcc8ce6a23 != (eb8e6d18db994ba4a90e177bd44b5db3) |
| `ACID(94)` | `stackedBarsWithOther` |       :white_check_mark: |                                                                             |
| `ACID(97)` |     `overlappingPlots` |       :white_check_mark: |                                                                             |

## Reliable tests
Only the reliable tests determine the build outcome.
Passing tests are not shown (only failed and skipped tests).

|   Testcase |               Name |                       OK |                                                                      Status |
| :--------- | :----------------- | :----------------------: | :-------------------------------------------------------------------------- |
|  `ACID(8)` |    `peaks_contour` | :heavy_exclamation_mark: | hash 4c0f04124b13d5c12351f4875455a67d != (8885c9a4185aaca594ce5d0139aa578b) |
|  `ACID(9)` |     `contourPenny` | :heavy_exclamation_mark: | hash 1bbca20d0029e2e510eb5d7c46222ee7 != (3ee200ec93371666499d72f790ee9bb3) |
| `ACID(12)` |  `double_colorbar` | :heavy_exclamation_mark: | hash 44a0d0b4b35ed634d2f2f568e51f2c8a != (6355484ba42b84205cd6a7d6de76711d) |
| `ACID(14)` |      `double_axes` | :heavy_exclamation_mark: | hash a053ed16097389ed6d6cfe6f353a46ab != (331441239c1bb077aebaf5ce8abe55f1) |
| `ACID(15)` |     `double_axes2` | :heavy_exclamation_mark: | hash ec8ccb7d178fd3e0227fd2cf3b210fa0 != (739edbf88cbf57187bea11ef93ebbf9a) |
| `ACID(21)` |             `zoom` | :heavy_exclamation_mark: | hash c64f7b3b3706f195123ca0c46f1de987 != (817b9999d832dc238b89573037cabc81) |
| `ACID(23)` |       `quiverplot` | :heavy_exclamation_mark: | hash 6f6723cafaf167b8e13d62f56b5a0aff != (308f4ce197791f2fd5862768e1157ca8) |
| `ACID(47)` |      `zplanePlot1` | :heavy_exclamation_mark: | hash 484cf570b96ae970b4e36e09d091168e != (03f1e3fabe0d9afe6692d42aa64da78e) |
| `ACID(49)` | `freqResponsePlot` | :heavy_exclamation_mark: | hash 9b96a2b4111965cf9f85a61979aa837f != (396383b779bf45e50cc0561803efb4b3) |
| `ACID(62)` |          `spectro` | :heavy_exclamation_mark: | hash e871a0b852a68fe12d78eead39e3de3b != (4426bb06bb44d08d016595f585fb01da) |
| `ACID(71)` |    `parameterSurf` | :heavy_exclamation_mark: | hash e64030978c54cc260847bf78a8c6ea6a != (12522a58d7e3d8dc7f4e38a0970bf047) |
| `ACID(17)` |  `colorbarLogplot` |          :grey_question: |                                                                     SKIPPED |

## Test summary
Test results for m2t commit 9f193c4675 running with MATLAB 8.5 on Linux
 3.13.0-62-generic.

```matlab
suite = @ACID;
alltests = [1:99];
reliable = [2:5 7:9 11:15 17 19:23 25:33 35:37 39 41 44:47 49:57 59:93 95:96 98:99];
unreliable = [1 6 10 16 18 24 34 38 40 42:43 48 58 94 97];
failReliable = [8:9 12 14:15 21 23 47 49 62 71];
passUnreliable = [16 24 34 38 40 43 94 97];
skipped = [17];
```

|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    8 |    7 |    0 |    15 |
|   Reliable |   72 |   11 |    1 |    84 |
|      Total |   80 |   18 |    1 |    99 |

Build fails with 11 errors. :heavy_exclamation_mark:

However, I have again checked the end result and cannot find any difference between the resulting Images.