### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: c++
 # command to install dependencies
 before_install:
+  - sudo apt-get install -y gdb # to capture backtrace of eventual failures
   - sudo add-apt-repository -y ppa:octave/stable
   - sudo apt-get update -qq
   - sudo apt-get install octave
   - sudo apt-get purge libopenblas-base # fixes PPA Octave 4.0 crash on Travis
+before_script:
+- ulimit -c unlimited -S                # enable core dumps for Octave crash debugging
 script:
   - cd test && /usr/bin/octave -q --eval runMatlab2TikzTests.m
 notifications:
   hipchat: f4c2c5f87adc85025545e5b59b3fbe@Matlab2tikz
+after_failure:
+- COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
+- gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - sudo add-apt-repository -y ppa:octave/stable
   - sudo apt-get update -qq
   - sudo apt-get install octave
+  - sudo apt-get purge libopenblas-base # fixes PPA Octave 4.0 crash on Travis
 script:
   - cd test && /usr/bin/octave -q --eval runMatlab2TikzTests.m
 notifications:

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -408,9 +408,17 @@ function bool = isColorDefinitions(colors)
 end
 % ==============================================================================
 function fid = fileOpenForWrite(m2t, filename)
-    encoding = switchMatOct({'native', m2t.cmdOpts.Results.encoding}, {});
+    % Set the encoding of the output file.
+    % Currently only MATLAB supports different encodings.
+    fid = -1;
 
-    fid      = fopen(filename, 'w', encoding{:});
+    if strcmpi(getEnvironment, 'MATLAB')
+        encoding = {'native', m2t.cmdOpts.Results.encoding};
+        fid      = fopen(filename, 'w', encoding{:});
+    elseif strcmpi(getEnvironment, 'Octave')
+        fid      = fopen(filename, 'w');
+    end       
+
     if fid == -1
         error('matlab2tikz:fileOpenError', ...
             'Unable to open file ''%s'' for writing.', filename);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -548,7 +548,7 @@ function str = generateColorDefinitions(names, specs, colorFormat)
             % make sure to append with '%' to avoid spacing woes
             str = [str, ...
                 sprintf(['\\definecolor{%s}{rgb}{', ff, ',', ff, ',', ff,'}%%\n'], ...
-                names{k}', specs{k})];
+                names{k}, specs{k})];
         end
         str = [str sprintf('%%\n')];
     end

--- a/src/private/getEnvironment.m
+++ b/src/private/getEnvironment.m
@@ -1,23 +1,23 @@
 function [env, versionString] = getEnvironment()
-% Checks if we are in MATLAB or Octave.
+% Determine environment (Octave, MATLAB) and version string
+% TODO: Unify the inline and the two pivate functions!
     persistent cache
 
-    alternatives = {'MATLAB', 'Octave'};
     if isempty(cache)
-        for iCase = 1:numel(alternatives)
-            env   = alternatives{iCase};
+        isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+        if isOctave
+            env = 'Octave';
+            versionString = OCTAVE_VERSION;
+        else
+            env = 'MATLAB';
             vData = ver(env);
-            if ~isempty(vData) % found the right environment
-                versionString = vData.Version;
-                % store in cache
-                cache.env = env;
-                cache.versionString = versionString;
-                return;
-            end
+            versionString = vData.Version;
         end
-        % fall-back values
-        env = '';
-        versionString = '';
+
+        % store in cache
+        cache.env = env;
+        cache.versionString = versionString;
+
     else
         env = cache.env;
         versionString = cache.versionString;

--- a/test/private/getEnvironment.m
+++ b/test/private/getEnvironment.m
@@ -1,25 +1,25 @@
 function [env, versionString] = getEnvironment()
-% Checks if we are in MATLAB or Octave.
+% Determine environment (Octave, MATLAB) and version string
+% TODO: Unify the inline and the two pivate functions!
     persistent cache
-    
-    alternatives = {'MATLAB', 'Octave'};
+
     if isempty(cache)
-        for iCase = 1:numel(alternatives)
-            env   = alternatives{iCase};
+        isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+        if isOctave
+            env = 'Octave';
+            versionString = OCTAVE_VERSION;
+        else
+            env = 'MATLAB';
             vData = ver(env);
-            if ~isempty(vData) % found the right environment
-                versionString = vData.Version;
-                % store in cache
-                cache.env = env;
-                cache.versionString = versionString;
-                return;
-            end
+            versionString = vData.Version;
         end
-        % fall-back values
-        env = '';
-        versionString = '';
+
+        % store in cache
+        cache.env = env;
+        cache.versionString = versionString;
+
     else
         env = cache.env;
         versionString = cache.versionString;
-    end    
+    end
 end

--- a/test/private/m2tstrjoin.m
+++ b/test/private/m2tstrjoin.m
@@ -5,6 +5,8 @@ function [ newstr ] = m2tstrjoin( cellstr, delimiter )
 % one is not available before R2013a.
 %
 % See also: strjoin
+%
+% TODO: Unify the inline `join` and pivate `m2tstrjoin` function!
 
     %FIXME: differs from src/private/m2tstrjoin in functionality !!!
 

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -1,5 +1,8 @@
 alphaImage : cbb2cf8ab5ccd1c4d27bb40cf8617214
 alphaTest : 93ad050f365faee18ae25a4f8ec067bc
+annotationSubplots : ade91307f28a9454f8aee10e651c62d4
+annotationText : 5b8562e0f9abd0407f19ca818ba9cd8c
+annotationTextUnits : 3533cf9b077689ab9b3c2a365882609c
 areaPlot : 6c70f6b2908ee95ec8d3e65280e8b86a
 axesColors : 21d1871d2f0b2a389ea6ffbbac43172e
 axesLocation : d1c194e852fd96c1db95ba5b23684860
@@ -8,6 +11,7 @@ besselImage : 0ffc3e10adb87029b44cbeb4bc435e07
 colorbarLabelTitle : d3c0aa0e9481c5ace5d64eeb50932e38
 colorbarLogplot : cb326bbb54e486a40d387acfe82f1b72
 compassplot : 76471346722595e1b113f3af59a6c91b
+contourPenny : e4af017e07881bc878b075f4b413d367
 customLegend : 3ce7c2ab5bc34f9825cb8eb91e282170
 decayingharmonic : e750cbafc69a0077b3fffe7cd077c3f0
 double_axes : fcbe776c394dec6dade8a6885cbaa0ac

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -1093,7 +1093,8 @@ function [stat] = zplanePlot1()
   stat.unreliable = isMATLAB('<', [8,4]); % FIXME: investigate
 
   % check of the signal processing toolbox is installed
-  if length(ver('signal')) ~= 1
+  verInfo = ver('signal');
+  if isempty(verInfo) || isempty(verInfo.Name)
       fprintf( 'Signal toolbox not found. Skip.\n\n' );
       stat.skip = true;
 
@@ -1111,7 +1112,8 @@ function [stat] = zplanePlot2()
   stat.closeall = true;
 
   % check of the signal processing toolbox is installed
-  if length(ver('signal')) ~= 1
+  verInfo = ver('signal');
+  if isempty(verInfo) || isempty(verInfo.Name)
       fprintf( 'Signal toolbox not found. Skip.\n\n' );
       stat.skip = true;
       return
@@ -1129,7 +1131,8 @@ function [stat] = freqResponsePlot()
   stat.unreliable = isMATLAB('<', [8,4]); % FIXME: investigate
 
   % check of the signal processing toolbox is installed
-  if length(ver('signal')) ~= 1
+  verInfo = ver('signal');
+  if isempty(verInfo) || isempty(verInfo.Name)
       fprintf( 'Signal toolbox not found. Skip.\n\n' );
       stat.skip = true;
       return

--- a/test/suites/private/getEnvironment.m
+++ b/test/suites/private/getEnvironment.m
@@ -1,25 +1,25 @@
 function [env, versionString] = getEnvironment()
-% Checks if we are in MATLAB or Octave.
+% Determine environment (Octave, MATLAB) and version string
+% TODO: Unify the two pivate functions!
     persistent cache
-    
-    alternatives = {'MATLAB', 'Octave'};
+
     if isempty(cache)
-        for iCase = 1:numel(alternatives)
-            env   = alternatives{iCase};
+        isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+        if isOctave
+            env = 'Octave';
+            versionString = OCTAVE_VERSION;
+        else
+            env = 'MATLAB';
             vData = ver(env);
-            if ~isempty(vData) % found the right environment
-                versionString = vData.Version;
-                % store in cache
-                cache.env = env;
-                cache.versionString = versionString;
-                return;
-            end
+            versionString = vData.Version;
         end
-        % fall-back values
-        env = '';
-        versionString = '';
+
+        % store in cache
+        cache.env = env;
+        cache.versionString = versionString;
+
     else
         env = cache.env;
         versionString = cache.versionString;
-    end    
+    end
 end


### PR DESCRIPTION
Fixes #745 (Octave 4.0 PPA crash on Travis) by purging OpenBlas.

Adds also stacktrace info if crash occurs (inspired by http://jsteemann.github.io/blog/2014/10/30/getting-core-dumps-of-failed-travisci-builds/) 
