### PR TITLE
Move pruneOutsideBox before simplifyLine

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -610,16 +610,13 @@ function movePointsCloser(meta, handle)
   
   % Only try to replace points if there are some to replace
   if (~isempty(replaceIndices))
-      % Check whether the points are finite.
-      DataIsFinite = all(isfinite(data(replaceIndices,:)), 2);
-
       % Get the indices of those points, that are the first point in a
       % segment
-      id_first  = replaceIndices(replaceIndices < size(data, 1) & DataIsFinite);
+      id_first  = replaceIndices(replaceIndices < size(data, 1));
 
       % Get the indices of those points, that are the second point in a
       % segment
-      id_second = replaceIndices(replaceIndices > 1  & DataIsFinite);
+      id_second = replaceIndices(replaceIndices > 1);
 
       % Define the vectors of data points for the segments X1--X2
       X1_first  = data(id_first,    :);

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -118,8 +118,8 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
       %display(sprintf([repmat(' ',1,indent), '  handle this']))
 
       if strcmp(type, 'line')
-          simplifyLine(meta, h, targetResolution);
           pruneOutsideBox(meta, h);
+          simplifyLine(meta, h, targetResolution);
           % Move some points closer to the box to avoid TeX:DimensionTooLarge
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);


### PR DESCRIPTION
If simplifyLine comes before pruneOutsideBox, it will tamper inf values.

This simple plot exemplifies the problem:
```
plot(1:5,[1,2,inf,4,5]); 
cleanfigure;
```
Instead first call pruneOutsideBox, that replaces the inf value with a NaN point