### PR TITLE
try to fix locale to something else than `C`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ before_script:
   - ulimit -c unlimited -S                # enable core dumps for Octave crash debugging
   - locale -a	# debug only (TODO: remove)
   - locale		# debug only (TODO: remove)
-  - export LANG=en_US.utf8
 script:
-  - cd test && /usr/bin/octave -q --eval runMatlab2TikzTests.m
+  - cd test && LANG=en_US.utf8 LANGUAGE=en_US.utf8 /usr/bin/octave -q --eval runMatlab2TikzTests.m
 notifications:
   hipchat: f4c2c5f87adc85025545e5b59b3fbe@Matlab2tikz
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ before_install:
   - sudo apt-get install octave
   - sudo apt-get purge libopenblas-base # fixes PPA Octave 4.0 crash on Travis
 before_script:
-- ulimit -c unlimited -S                # enable core dumps for Octave crash debugging
+  - ulimit -c unlimited -S                # enable core dumps for Octave crash debugging
+  - locale -a	# debug only (TODO: remove)
+  - locale		# debug only (TODO: remove)
+  - export LANG=en_US.utf8
 script:
   - cd test && /usr/bin/octave -q --eval runMatlab2TikzTests.m
 notifications:

--- a/test/runMatlab2TikzTests.m
+++ b/test/runMatlab2TikzTests.m
@@ -6,6 +6,9 @@ function statusAll = runMatlab2TikzTests(varargin)
 CI_MODE = strcmpi(getenv('CONTINUOUS_INTEGRATION'),'true') || strcmp(getenv('CI'),'true');
 isJenkins = ~isempty(getenv('JENKINS_URL'));
 
+getenv('LANG')		% debug only (TODO: remove)
+getenv('LANGUAGE')	% debug only (TODO: remove)
+
 %% Set path
 addpath(fullfile(pwd,'..','src'));
 addpath(fullfile(pwd,'suites'));


### PR DESCRIPTION
current ACID(1) fails on Travis due to:
```
warning: ft_render: failed to decode string `one ° ∞ three' with locale `C'
```

Setting the locale to an existing language should solve this.