### PR TITLE
Extract function `guitypes`

### DIFF
--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -106,8 +106,7 @@ end
 function bool = shouldSkip(h)
     %  returns TRUE for objects that can be skipped
     objType = get(h, 'Type');
-    bool = ismember(lower(objType), {'uimenu', 'uitoolbar', 'uicontextmenu'});
-    %FIXME: maybe integrate this in matlab2tikz?
+    bool = ismember(lower(objType), guitypes);
 end
 % ==============================================================================
 function label = addHGProperty(label, h, propName, default)

--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -106,7 +106,7 @@ end
 function bool = shouldSkip(h)
     %  returns TRUE for objects that can be skipped
     objType = get(h, 'Type');
-    bool = ismember(lower(objType), guitypes);
+    bool = ismember(lower(objType), guitypes());
 end
 % ==============================================================================
 function label = addHGProperty(label, h, propName, default)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -681,7 +681,7 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, h)
             case 'histogram'
                 [m2t, str] = drawHistogram(m2t, child);
 
-            case guitypes
+            case guitypes()
                 % don't do anything for GUI objects and their children
                 str = '';
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -681,9 +681,8 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, h)
             case 'histogram'
                 [m2t, str] = drawHistogram(m2t, child);
 
-            case {'uitoolbar', 'uimenu', 'uicontextmenu', 'uitoggletool',...
-                    'uitogglesplittool', 'uipushtool', 'hgjavacomponent'}
-                % don't to anything for these handles and its children
+            case guitypes
+                % don't do anything for GUI objects and their children
                 str = '';
 
             case 'light'

--- a/src/private/guitypes.m
+++ b/src/private/guitypes.m
@@ -4,7 +4,7 @@ function types = guitypes()
 % Syntax
 %   types = guitypes()
 %
-% These types are not ignored by matlab2tikz and figure2dot.
+% These types are ignored by matlab2tikz and figure2dot.
 %
 % See also: matlab2tikz, figure2dot
 

--- a/src/private/guitypes.m
+++ b/src/private/guitypes.m
@@ -1,0 +1,13 @@
+function types = guitypes()
+% GUITYPES returns a cell array of MATLAB/Octave GUI object types
+%
+% Syntax
+%   types = guitypes()
+%
+% These types are not ignored by matlab2tikz and figure2dot.
+%
+% See also: matlab2tikz, figure2dot
+
+types = {'uitoolbar', 'uimenu', 'uicontextmenu', 'uitoggletool',...
+         'uitogglesplittool', 'uipushtool', 'hgjavacomponent'};
+end


### PR DESCRIPTION
This removes the only FIXME from `figure2dot`.

Note: only executed mentally, so wait for Jenkins and Travis to be sure.