### PR TITLE
Move simplifyLine after pruneOutsideBox and movePointsCloser.

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -118,11 +118,13 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
       %display(sprintf([repmat(' ',1,indent), '  handle this']))
 
       if strcmp(type, 'line')
-          simplifyLine(meta, h, targetResolution);
           pruneOutsideBox(meta, h);
           % Move some points closer to the box to avoid TeX:DimensionTooLarge
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);
+          % NOTE: Always remove invisible points before simplifying the
+          % line. Otherwise it will generate additional line segments
+          simplifyLine(meta, h, targetResolution);
       elseif strcmpi(type, 'stair')
           pruneOutsideBox(meta, h);
       elseif strcmp(type, 'text')

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -118,12 +118,13 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
       %display(sprintf([repmat(' ',1,indent), '  handle this']))
 
       if strcmp(type, 'line')
+          % NOTE: Always remove invisible points before simplifying the
+          % line. Otherwise it will generate additional line segments
           pruneOutsideBox(meta, h);
           % Move some points closer to the box to avoid TeX:DimensionTooLarge
           % errors. This may involve inserting extra points.
           movePointsCloser(meta, h);
-          % NOTE: Always remove invisible points before simplifying the
-          % line. Otherwise it will generate additional line segments
+          % Simplify the lines by removing superflous points
           simplifyLine(meta, h, targetResolution);
       elseif strcmpi(type, 'stair')
           pruneOutsideBox(meta, h);


### PR DESCRIPTION
This is a clean version of #761 

@okomarov  simplifyLine does operate on a different set of data points than pruneOutsideBox or movePointsCloser. The former acts on isInBox and the latter two on ~isInBox. Therefore they should be easily replacable