### PR TITLE
Cleanfigure project 3D data

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -505,8 +505,8 @@ function simplifyLine(meta, handle, targetResolution)
             lengthSegments = [inan(1); diff(inan); length(xData)-inan(end)];
 
             % Put the NaNs into separate segments
-            lengthSegments = [lengthSegments-1, ones(size(lengthSegments))];
-            lengthSegments = reshape(lengthSegments(1:end), size(lengthSegments));
+            lengthSegments = [lengthSegments-1, ones(size(lengthSegments))]';
+            lengthSegments = reshape(lengthSegments, numel(lengthSegments), 1);
 
             % Account for the last segment that never ends with a NaN
             lengthSegments(end-1) = lengthSegments(end-1)+1;
@@ -516,16 +516,16 @@ function simplifyLine(meta, handle, targetResolution)
         % Split data into segments
         xDataSegments = mat2cell(xData(:), lengthSegments, 1);
         yDataSegments = mat2cell(yData(:), lengthSegments, 1);
-        mask          = cell(length(lengthSegments), 1);
+        mask          = cell(size(lengthSegments));
 
         % Simplify the respective segments
         for ii = 1:length(lengthSegments)
             % Simplify only if there are more than 2 points
-            if length(xDataSegments{ii}) > 2 && length(yDataSegments{ii}) > 2
+            if numel(xDataSegments{ii}) > 2 && numel(yDataSegments{ii}) > 2
                 mask{ii} = opheimSimplify(xDataSegments{ii}, yDataSegments{ii}, tol);
             else
-                % Always print NaNs
-                mask{ii} = true;
+                % Always print NaNs and 2 point segments
+                mask{ii} = true(size(xDataSegments{ii}));
             end
         end
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -181,22 +181,15 @@ end
 function pruneOutsideBox(meta, handle)
   % Some sections of the line may sit outside of the visible box.
 
-  % Check whether this is a 3D plot
-  % If the elevation is not 90° it is a 3D plot
-  [az, el] = view(meta.gca);
-  if el == 90
-    is3D = false;
-  else
-    is3D = true;
-  end
-
-  % Get the data. If it is 3D project it into the image plane
+  % Get the data. If it is 3D, project it into the image plane
   [xData, yData] = getVisibleData(meta, handle);
+
+  % Only do something if there are multiple data points
   if numel(xData) <= 2 || numel(yData) <= 2
       return;
   end
   
-  % Get the limits
+  % Get the (projected) limits
   [xLim, yLim] = getVisibleLimits(meta);
 
   % Merge data vectors
@@ -224,6 +217,9 @@ function pruneOutsideBox(meta, handle)
       % Plot points which are next to an edge which is in the box.
       shouldPlot = shouldPlot | [false; segvis] | [segvis; false];
   end
+
+  % Check whether this is a 3D plot
+  is3D = isAxis3D(meta.gca);
 
   % If some of the data was logarithmic or projected get the original data
   isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
@@ -351,13 +347,7 @@ end
 % =========================================================================
 function [xData, yData] = getVisibleData(meta, handle)
     % Check whether this is a 3D plot
-    % If the elevation is not 90° it is a 3D plot
-    [az, el] = view(meta.gca);
-    if el == 90
-        is3D = false;
-    else
-        is3D = true;
-    end
+    is3D = isAxis3D(meta.gca);
 
     % Extract the data from the current line handle.
     xData = get(handle, 'XData');
@@ -383,6 +373,9 @@ function [xData, yData] = getVisibleData(meta, handle)
 
     % If this is a 3D plot, project the data into the image plane
     if is3D
+        % Get the projection angle
+        [az, el] = view(meta.gca);
+
         % Projection matrix from view
         C        = viewmtx(az, el);
 
@@ -407,13 +400,7 @@ end
 % =========================================================================
 function [xLim, yLim] = getVisibleLimits(meta)
     % Check whether this is a 3D plot
-    % If the elevation is not 90° it is a 3D plot
-    [az, el] = view(meta.gca);
-    if el == 90
-        is3D = false;
-    else
-        is3D = true;
-    end
+    is3D = isAxis3D(meta.gca);
 
     % Get the axis limits
     xLim     = xlim(meta.gca);
@@ -442,6 +429,9 @@ function [xLim, yLim] = getVisibleLimits(meta)
 
     % If this is a 3D plot, project the limits into the image plane
     if is3D
+        % Get the projection angle
+        [az, el] = view(meta.gca);
+
         % Projection matrix from view
         C        = viewmtx(az, el);
 
@@ -472,13 +462,7 @@ function simplifyLine(meta, handle, targetResolution)
     end
 
     % Check whether this is a 3D plot
-    % If the elevation is not 90° it is a 3D plot
-    [az, el] = view(meta.gca);
-    if el == 90
-        is3D = false;
-    else
-        is3D = true;
-    end
+    is3D = isAxis3D(meta.gca);
 
     % Retrieve target figure size in pixels
     [W, H] = getWidthHeightInPixels(targetResolution);

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -432,11 +432,11 @@ function [xLim, yLim] = getVisibleLimits(meta)
     xLim     = xlim(meta.gca);
     yLim     = ylim(meta.gca);
 
-    % In 3D plots the yAxis normally runs from positive to negative
-    % values, so flip it
+    % In 3D plots the yAxis might run from positive to negative
+    % values, so sort it
     if is3D
-        yLim   = [yLim(2), yLim(1)];
-        zLim     = zlim(meta.gca);
+        yLim = sort(yLim);
+        zLim = zlim(meta.gca);
     end
 
     % Check for logarithmic scales

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -377,7 +377,33 @@ function [xData, yData] = getVisibleData(meta, handle)
         [az, el] = view(meta.gca);
 
         % Projection matrix from view
-        C        = viewmtx(az, el);
+        % C        = viewmtx(az, el);
+        % NOTE: This is a subset of the MATLAB viewmtx function, as octave
+        % does not provide such functionality
+        % Make sure az and el are in the correct range.
+        el = rem(rem(el+180,360)+360,360)-180; % Make sure -180 <= el <= 180
+        if el>90,
+          el = 180-el;
+          az = az + 180;
+        elseif el<-90,
+          el = -180-el;
+          az = az + 180;
+        end
+        az = rem(rem(az,360)+360,360); % Make sure 0 <= az <= 360
+
+        % Convert from degrees to radians.
+        az = az*pi/180;
+        el = el*pi/180;
+
+        % View transformation matrix:
+        % Formed by composing two rotations:
+        %   1) Rotate about the z axis -AZ radians
+        %   2) Rotate about the x axis (EL-pi/2) radians
+
+        C = [ cos(az)           sin(az)           0       0
+             -sin(el)*sin(az)   sin(el)*cos(az)   cos(el) 0
+              cos(el)*sin(az)  -cos(el)*cos(az)   sin(el) 0
+              0                 0                 0       1 ];
 
         % Put the data into the 4D datavector used in the projection
         data     = [xData(:),...
@@ -433,7 +459,33 @@ function [xLim, yLim] = getVisibleLimits(meta)
         [az, el] = view(meta.gca);
 
         % Projection matrix from view
-        C        = viewmtx(az, el);
+        % C        = viewmtx(az, el);
+        % NOTE: This is a subset of the MATLAB viewmtx function, as octave
+        % does not provide such functionality
+        % Make sure az and el are in the correct range.
+        el = rem(rem(el+180,360)+360,360)-180; % Make sure -180 <= el <= 180
+        if el>90,
+          el = 180-el;
+          az = az + 180;
+        elseif el<-90,
+          el = -180-el;
+          az = az + 180;
+        end
+        az = rem(rem(az,360)+360,360); % Make sure 0 <= az <= 360
+
+        % Convert from degrees to radians.
+        az = az*pi/180;
+        el = el*pi/180;
+
+        % View transformation matrix:
+        % Formed by composing two rotations:
+        %   1) Rotate about the z axis -AZ radians
+        %   2) Rotate about the x axis (EL-pi/2) radians
+
+        C = [ cos(az)           sin(az)           0       0
+             -sin(el)*sin(az)   sin(el)*cos(az)   cos(el) 0
+              cos(el)*sin(az)  -cos(el)*cos(az)   sin(el) 0
+              0                 0                 0       1 ];
 
         % Project the limits to 2D coordinates
         Limits = C*[xLim(:), yLim(:), zLim(:), [1; 1]]';

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -355,17 +355,16 @@ function [xData, yData] = getVisibleData(meta, handle)
     if is3D
         zData = get(handle, 'ZData');
     end
+
     % Get info about log scaling
     isXlog = strcmp(get(meta.gca, 'XScale'), 'log');
     if isXlog
         xData = log10(xData);
     end
-
     isYlog = strcmp(get(meta.gca, 'YScale'), 'log');
     if isYlog
         yData = log10(yData);
     end
-
     isZlog = strcmp(get(meta.gca, 'ZScale'), 'log');
     if isZlog && is3D
         zData = log10(zData);
@@ -431,11 +430,7 @@ function [xLim, yLim] = getVisibleLimits(meta)
     % Get the axis limits
     xLim     = xlim(meta.gca);
     yLim     = ylim(meta.gca);
-
-    % In 3D plots the yAxis might run from positive to negative
-    % values, so sort it
     if is3D
-        yLim = sort(yLim);
         zLim = zlim(meta.gca);
     end
 
@@ -917,8 +912,8 @@ end
 % =========================================================================
 function out = isInBox(data, xLim, yLim)
 
-  out = data(:,1) > xLim(1) & data(:,1) < xLim(2) ...
-      & data(:,2) > yLim(1) & data(:,2) < yLim(2);
+  out = data(:,1) > min(xLim) & data(:,1) < max(xLim) ...
+      & data(:,2) > min(yLim) & data(:,2) < max(yLim);
 end
 % =========================================================================
 function lambda = crossLines(X1, X2, X3, X4)


### PR DESCRIPTION
So in my defence, I got carried away a little ;)

The logic should be rather straightforward. There are 2 new functions:
```matlab
function [xData, yData] = getVisibleData(meta, handle)
function [xLim, yLim]   = getVisibleLimits(meta)
```
The first checks whether the the data is 3D and returns either the projection of the 3D data onto the image plane or the original data.
The second does the same with the limits.

Now we can utilize this in both pruneOutsideBox and simplifyLine, and handle 3D plots as well.

NOTE that this does not easily work with movePointsCloser. In pruneOutsideBox and simplifyLine we only REMOVE points or NaN them. For movePointsCloser we would need the back transformation. At work we now have MATLAB2015b so I cant really test it that well.

P.S: This also requires PR #761 otherwise the code crashes when one of the dimensions is filled only with NaNs