### PR TITLE
Cleanfigure restructure

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -96,7 +96,7 @@ function indent = recursiveCleanup(meta, h, targetResolution, indent)
 
   % Update the current axes.
   if strcmp(get(h, 'Type'), 'axes')
-      meta.gca  = h;
+      meta.gca = h;
   end
 
   children = get(h, 'Children');
@@ -384,7 +384,7 @@ function movePointsCloser(meta, handle)
 
       % Put the cells together, right points first, then the possible NaN
       % and then the left points      
-      dataInsert = cellfun(@(x,y,z) [x; y; z],...
+      dataInsert = cellfun(@(a,b,c) [a; b; c],...
                             dataInsert_second,...
                             dataInsert_NaN,...
                             dataInsert_first,...
@@ -396,7 +396,8 @@ function movePointsCloser(meta, handle)
   
   % Get the indices of the to be removed points respecting the now inserted
   % data points
-  id_remove = id_replace + cumsum(cellfun(@(x) size(x,1), [cell(1);dataInsert(1:end-2)]));
+  numPointsInserted = cellfun(@(x) size(x,1), [cell(1);dataInsert(1:end-2)]);
+  id_remove = id_replace + cumsum(numPointsInserted);
   
   % Remove the data point that should be replaced. 
   removeData(meta, handle, id_remove);
@@ -799,8 +800,8 @@ function replaceData(handle, id_replace, dataReplace)
   yData = get(handle, 'YData');
 
   % Update the data indicated by id_update
-  xData(id_replace) = dataReplace(:,1);
-  yData(id_replace) = dataReplace(:,2);
+  xData(id_replace) = dataReplace(:, 1);
+  yData(id_replace) = dataReplace(:, 2);
 
   % Set the new (masked) data.
   set(handle, 'XData', xData);

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -51,9 +51,9 @@ peaks_contourf : 957fcc67221ce5c54b1981b2675348a1
 pixelLegend : 26c3af8f30df0fefcb56697b534b8516
 plain_cos : 6743ec5be29b98ee072b5ce23dc26b2a
 polarplot : 1108f4018f5f14ad3bff73865caafb98
-quiver3plot : 1e2266cae37d6565e96e1f0466540d6c
+quiver3plot : 8d74c782c57b27be844585d37328d3cf
 quiveroverlap : a5c76200c93b83f2480aca8563626bf9
-quiverplot : 0cc7aef48dddc2c9075a079eaf580700
+quiverplot : 6e2d74dd2d73bfa916c571bf704e360b
 randomWithLines : 8095aa52dd58fae39a8d5718eebe55d5
 rectanglePlot : f63538597348033398ef9cc37dcf57cd
 roseplot : 10c269e1ff65975791d794b489ebbed9


### PR DESCRIPTION
So when I was writing the 3D projection part in #779, I realized, that I had to do a lot of restructuring. 

To keep it "cleaner" I decided to pull it out and make a new PR. So there are some new functions:

```matlab
[xData, yData] = getVisualData(meta, handle)
[xLim, yLim] = getVisualLimits(meta)

replaceData(handle, id_replace, dataReplace)
insertData(handle, id_insert, dataInsert)
removeData(meta, handle, id_remove)

removeNaNs(meta, handle)
```

I believe their names are rather self explanatory. To get them working i had to restructure our simplification functions slightly. In the end I decided, that every function should generate lists of indices e.g. id_replace for all the data that should be replaced and removed and so on.

This unifies the data handling and should help us to maintain the stuff easier.

I have also renamed some of the output when it was a mask rather out