### PR TITLE
Fixed incorrect accounting for previous line segments in simplifyLine

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -491,8 +491,8 @@ function simplifyLine(meta, handle, targetResolution)
             if numel(x) > 2
                 mask      = opheimSimplify(x, y, tol);
                 % Remove all those with mask==0 respecting the number of
-                % data points in the previoous segments
-                id_remove = find(mask==0) + lineStart(ii) -1;
+                % data points in the previous segments
+                id_remove = find(mask==0) + lineStart(ii) - 1;
             end
         end
     end

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -481,8 +481,7 @@ function simplifyLine(meta, handle, targetResolution)
         lineEnd   = find(id_diff == -1)-1;
         numLines = numel(lineStart);
 
-        % Count the number of data points in the previous segments
-        countData = 0;
+        % Simplify the line segments
         for ii = 1:numLines
             % Actual data that inherits the simplifications
             x = xData(lineStart(ii):lineEnd(ii));
@@ -493,11 +492,8 @@ function simplifyLine(meta, handle, targetResolution)
                 mask      = opheimSimplify(x, y, tol);
                 % Remove all those with mask==0 respecting the number of
                 % data points in the previoous segments
-                id_remove = find(mask==0) + countData;
+                id_remove = find(mask==0) + lineStart(ii) -1;
             end
-
-            % Update the number of processed data points
-            countData = countData + lineEnd(ii) - lineStart(ii);
         end
     end
 

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -53,7 +53,7 @@ plotyyLegends : 8e439c4b17afabd8cc915932d798c97a
 polarplot : 621d3d9332bc75ad246c1d20fad94346
 quiver3plot : 8d74c782c57b27be844585d37328d3cf
 quiveroverlap : a5c76200c93b83f2480aca8563626bf9
-quiverplot : 6e2d74dd2d73bfa916c571bf704e360b
+quiverplot : 94a731e082e6a8726647247af9b1c2de
 randomWithLines : 8095aa52dd58fae39a8d5718eebe55d5
 rectanglePlot : f63538597348033398ef9cc37dcf57cd
 roseplot : d4c8506bd33b885bc6d0c1c4e7394b96


### PR DESCRIPTION
This fixes an awkward bug in simplifyLine that I actually thought I had fixed o.O.

In the end the accounting for the elements of the previous line segments was bogus and completely overcomplicated.