### PR TITLE
drawBaseline for barplots and stemseries

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3847,7 +3847,7 @@ end
 % ==============================================================================
 function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
     str = '';
-    if isOff(get(hparent,'ShowBaseLine'))
+    if isOff(get(hparent,'ShowBaseLine')) || ~isHG2()
         return
     end
     

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3847,7 +3847,8 @@ end
 % ==============================================================================
 function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
     str = '';
-    if isOff(get(hparent,'ShowBaseLine')) || ~isHG2()
+    baseValue = get(hparent, 'BaseValue');
+    if isOff(get(hparent,'ShowBaseLine')) || ~isHG2() || baseValue ~= 0
         return
     end
     
@@ -3872,11 +3873,11 @@ function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
 
     % Get data
     if isVertical
-        xData = repmat(get(hBaseLine, 'BaseValue'),1,2);
+        xData = repmat(baseValue,1,2);
         yData = get(m2t.currentHandles.gca,'Ylim');
     else
         xData = get(m2t.currentHandles.gca,'Xlim');
-        yData = repmat(get(hBaseLine, 'BaseValue'),1,2);
+        yData = repmat(baseValue,1,2);
     end
     
     [m2t, table, tabOpts] = makeTable(m2t, '', xData, '', yData);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3710,6 +3710,9 @@ function [m2t, str] = drawBarseries(m2t, h)
     str = sprintf('\\addplot[%s] plot table[%s] {%s};\n', ...
                  opts_print(m2t, drawOptions, ','), ...
                  opts_print(m2t, tabOpts, ','), table);
+
+    [m2t, baseline] = drawBaseline(m2t,h,isHoriz);
+    str             = [str, baseline];
 end
 % ==============================================================================
 function [barType, isHorizontal] = getOrientationOfBarSeries(h)
@@ -3842,8 +3845,51 @@ function [m2t, drawOptions] = getFaceColorOfBar(m2t, h, drawOptions)
     [m2t, drawOptions] = setColor(m2t, h, drawOptions, 'fill', faceColor);
 end
 % ==============================================================================
+function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
+    str = '';
+    if isOff(get(hparent,'ShowBaseLine'))
+        return
+    end
+    
+    if ~exist('isVertical','var')
+        isVertical = false;
+    end
+
+    hBaseLine = get(hparent,'BaseLine');
+
+    % Line options of the baseline
+    lineStyle        = get(hBaseLine, 'LineStyle');
+    lineWidth        = get(hBaseLine, 'LineWidth');
+    lineOptions      = getLineOptions(m2t, lineStyle, lineWidth);
+    color            = get(hBaseLine, 'Color');
+    [m2t, lineColor] = getColor(m2t, hBaseLine, color, 'patch');
+
+    drawOptions = opts_new();
+    drawOptions = opts_add(drawOptions, 'forget plot');
+    drawOptions = opts_add(drawOptions, 'color', lineColor);
+    drawOptions = opts_merge(drawOptions, lineOptions);
+    drawOpts    = opts_print(m2t, drawOptions, ',');
+
+    % Get data
+    if isVertical
+        xData = repmat(get(hBaseLine, 'BaseValue'),1,2);
+        yData = get(m2t.currentHandles.gca,'Ylim');
+    else
+        xData = get(m2t.currentHandles.gca,'Xlim');
+        yData = repmat(get(hBaseLine, 'BaseValue'),1,2);
+    end
+    
+    [m2t, table, tabOpts] = makeTable(m2t, '', xData, '', yData);
+
+    str = sprintf('%s\\addplot[%s] plot table[%s] {%s};\n', ...
+        str, drawOpts, opts_print(m2t, tabOpts, ','), table);
+end
+% ==============================================================================
 function [m2t, str] = drawStemSeries(m2t, h)
     [m2t, str] = drawStemOrStairSeries_(m2t, h, 'ycomb');
+    
+    [m2t, baseline] = drawBaseline(m2t,h);
+    str             = [str, baseline];
 end
 function [m2t, str] = drawStairSeries(m2t, h)
     [m2t, str] = drawStemOrStairSeries_(m2t, h, 'const plot');

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3846,14 +3846,27 @@ function [m2t, drawOptions] = getFaceColorOfBar(m2t, h, drawOptions)
 end
 % ==============================================================================
 function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
+% DRAWBASELINE Draws baseline for bar and stem plots
+% 
+% Notes: 
+%   - In HG2, the baseline is a specific object child of a bar or stem
+%     plot. So, handleAllChildren() won't find a line in the axes to plot as
+%     the baseline.
+%   - The baseline is horizontal for vertical bar and stem plots and is
+%     vertical for horixontal barplots. The ISVERTICAL input refers to the
+%     baseline.
+%   - We do not plot baselines with a BaseValue different from 0 because 
+%     pgfplots does not support shifts in the BaseValue, e.g. see #438. 
+%     We either implement our own data shifting or wait for pgfplots.     
+
+    if ~exist('isVertical','var')
+        isVertical = false;
+    end
+
     str = '';
     baseValue = get(hparent, 'BaseValue');
     if isOff(get(hparent,'ShowBaseLine')) || ~isHG2() || baseValue ~= 0
         return
-    end
-    
-    if ~exist('isVertical','var')
-        isVertical = false;
     end
 
     hBaseLine = get(hparent,'BaseLine');
@@ -3879,10 +3892,10 @@ function [m2t,str] = drawBaseline(m2t,hparent,isVertical)
         xData = get(m2t.currentHandles.gca,'Xlim');
         yData = repmat(baseValue,1,2);
     end
-    
+
     [m2t, table, tabOpts] = makeTable(m2t, '', xData, '', yData);
 
-    str = sprintf('%s\\addplot[%s] plot table[%s] {%s};\n', ...
+    str = sprintf('%s\\addplot[%s] table[%s] {%s};\n', ...
         str, drawOpts, opts_print(m2t, tabOpts, ','), table);
 end
 % ==============================================================================

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -79,8 +79,8 @@ spectro : 4426bb06bb44d08d016595f585fb01da
 spherePlot : ac48589d76eab4f6a99dbc2853ead851
 stackedBarsWithOther : 979b797068fb431c57e85e813308a2ea
 stairsplot : 4dbd75c548abff2580c80f904fb86d20
-stemplot : e275f5b85d1f9f2971ffed5bc65cbbb9
-stemplot2 : b33641d5b9e0b8abf5413e438bc873ed
+stemplot : c4f63e2c0a52b2e945b5a3f33e2aa890
+stemplot2 : 01ecbccae535b4c26e3e098e138e2da4
 subplot2x2b : 63cf7ce7f29fef045cc5ab3042c3e89b
 subplotCustom : c3ac3cf225706a3a157a7543c4b72c24
 superkohle : 6a771216ad2a8bc28b346fb2ad4022d1


### PR DESCRIPTION
Now draws baseline in barplots and stemseries plots:

ACID(32)
![capture](https://cloud.githubusercontent.com/assets/3731173/10682105/39ce0cee-7929-11e5-8e92-c0f4e98a6f6f.PNG)
