### PR TITLE
Rework pixelate

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -554,18 +554,24 @@ function mask = pixelate(x, y, xToPix, yToPix)
     % The resolution is lost only beyond the multiplier magnification
     mult = 2;
 
-    % Convert data to pixel units, magnify and mark only the first
-    % point that occupies a given position
-    mask = [true; diff(round(x * xToPix * mult))~=0];
-    mask = [true; diff(round(y * yToPix * mult))~=0] | mask;
+    % Convert data to pixel units and magnify
+    dataPixel = round([x * xToPix * mult, ...
+                       y * yToPix * mult]);
 
-    % Keep end points or it might truncate whole pixels
+    % Find the unique pixels
+    [~, id_unique, ~] = unique(dataPixel, 'rows');
+
+    % Assume every pixel to be a duplicate
+    mask = false(size(x));
+
+    % Set the first, last, as well as unique pixels to true
+    mask(1)         = true;
+    mask(end)       = true;
+    mask(id_unique) = true(size(id_unique));
+
+    % Set NaNs to true
     inan         = isnan(x) | isnan(y);
-    df           = diff([false; inan; false]);
-    istart       = df == 1;
-    pend         = find(df == -1)-1;
-    mask(istart) = true;
-    mask(pend)   = true;
+    mask(inan)   = true;
 end
 % =========================================================================
 function mask = opheimSimplify(x,y,tol)

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -558,16 +558,19 @@ function mask = pixelate(x, y, xToPix, yToPix)
     dataPixel = round([x * xToPix * mult, ...
                        y * yToPix * mult]);
 
-    % Find the unique pixels
-    [~, id_unique, ~] = unique(dataPixel, 'rows');
+    % Sort the pixels
+    [dataPixelSorted, id_orig] = sortrows(dataPixel);
 
-    % Assume every pixel to be a duplicate
-    mask = false(size(x));
+    % Find the duplicate pixels
+    mask = [true; diff(dataPixelSorted(:,1))~=0 | ...
+                  diff(dataPixelSorted(:,2))~=0];
+
+    % Unwind the sorting
+    mask = mask(id_orig);
 
     % Set the first, last, as well as unique pixels to true
     mask(1)         = true;
     mask(end)       = true;
-    mask(id_unique) = true(size(id_unique));
 
     % Set NaNs to true
     inan         = isnan(x) | isnan(y);

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -562,11 +562,12 @@ function mask = pixelate(x, y, xToPix, yToPix)
     [dataPixelSorted, id_orig] = sortrows(dataPixel);
 
     % Find the duplicate pixels
-    mask = [true; diff(dataPixelSorted(:,1))~=0 | ...
-                  diff(dataPixelSorted(:,2))~=0];
+    mask_sorted = [true; diff(dataPixelSorted(:,1))~=0 | ...
+                         diff(dataPixelSorted(:,2))~=0];
 
     % Unwind the sorting
-    mask = mask(id_orig);
+    mask            = false(size(x));
+    mask(id_orig)   = mask_sorted;
 
     % Set the first, last, as well as unique pixels to true
     mask(1)         = true;

--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -43,7 +43,7 @@ logicalImage : e2d9da14cb4121727dd0b17b6ae58434
 logplot : 75608a2f050cec6bd699ae2f1d2aba3e
 mandrillImage : 5cfaf3971064af419bb5375ee1dffe41
 manualAlignment : 4ef4fe287f77dc4e9cc85ed030b0e8a0
-many_random_points : cb80dfbba6c43bbe4aeaaba5b9a52096
+many_random_points : 6a685346b4339cd0918d91ba70487dfb
 markerSizes : 703bd6d9f3a26af0062adb66493f864f
 markerSizes2 : d6a12826350462efeb1f2194833cb6cc
 meshPlot : 219102d4595a4dad5b6d65ab610fea9e

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -43,7 +43,7 @@ logicalImage : e2d9da14cb4121727dd0b17b6ae58434
 logplot : 75608a2f050cec6bd699ae2f1d2aba3e
 mandrillImage : 5cfaf3971064af419bb5375ee1dffe41
 manualAlignment : 4ef4fe287f77dc4e9cc85ed030b0e8a0
-many_random_points : cb80dfbba6c43bbe4aeaaba5b9a52096
+many_random_points : 6a685346b4339cd0918d91ba70487dfb
 markerSizes : 703bd6d9f3a26af0062adb66493f864f
 markerSizes2 : d6a12826350462efeb1f2194833cb6cc
 meshPlot : 219102d4595a4dad5b6d65ab610fea9e

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -34,7 +34,7 @@ logbaseline : 76f1f5322fc46e6f86ff5be0c46eed87
 logicalImage : 82e9e5ed998aa1ecd78b514d801dc914
 logplot : dc9b1c45dcefb3136cbfc834009a5c23
 manualAlignment : b84ea37c110e0598ecea02f32fa4b204
-many_random_points : 543e78f72692be8050d0cce33bf0b034
+many_random_points : d3520a280c1c817582736b712a6930ba
 markerSizes : bd7c0b27c5a014221a932daefed5e360
 markerSizes2 : 595217ffaffeaaa266ceba4aea8b6398
 meshPlot : 14faaf00c09cfee0da4445e94cc8787f

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -34,7 +34,7 @@ logbaseline : 76f1f5322fc46e6f86ff5be0c46eed87
 logicalImage : 82e9e5ed998aa1ecd78b514d801dc914
 logplot : dc9b1c45dcefb3136cbfc834009a5c23
 manualAlignment : b84ea37c110e0598ecea02f32fa4b204
-many_random_points : 862953f704e6c786cf2d28d61d8f2b05
+many_random_points : 543e78f72692be8050d0cce33bf0b034
 markerSizes : bd7c0b27c5a014221a932daefed5e360
 markerSizes2 : 595217ffaffeaaa266ceba4aea8b6398
 meshPlot : 14faaf00c09cfee0da4445e94cc8787f


### PR DESCRIPTION
Currently pixelate is kind of buggy.

The reason is, that it assumes an explicit order in both dimensions, hidden in the diff(...). Instead use the matlab build in function unique, that finds us the unique pixels without any hassle.

P.S: It is not 100% mathematically correct, as there is the theoretical possibility, that the first and last pixel is duplicated *shrug*.