### PR TITLE
Put text removal into own function and prepare deprecation

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -87,6 +87,19 @@ function recursiveCleanup(meta, h, targetResolution, pruneText)
     % Get the type of the current figure handle
     type = get(h, 'Type');
 
+    %display(sprintf([repmat(' ',1,indent), type, '->']))
+
+    % Don't try to be smart about quiver groups.
+    % NOTE:
+    % A better way to write `strcmp(get(h,...))` would be to use
+    %     isa(handle(h), 'specgraph.quivergroup').
+    % The handle() function isn't supported by Octave, though, so let's stick
+    % with strcmp().
+    if strcmp(type, 'specgraph.quivergroup')
+        %if strcmp(class(handle(h)), 'specgraph.quivergroup')
+        return;
+    end
+
     % Update the current axes.
     if strcmp(type, 'axes')
         meta.gca = h;


### PR DESCRIPTION
Hi,

as the title says, this puts text removal into its own subfunction, considerably cleaning up revursiveCleanup.

While we are at it, removed the intent parameter from recursiveCleanup, that might have some historic origin. Additionally, the early return for quiverplots seems to be nonfunctional. Remove it was well.