### PR TITLE
Check for lines in pruneOutsidebox

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -156,32 +156,28 @@ function pruneOutsideBox(meta, handle)
         return;
     end
 
-    %hasLines = ~strcmp(lineStyle,'none') && lineWidth>0.0;
-    %hasMarkers = ~strcmp(marker,'none');
-    hasLines = true;
-    hasMarkers = true;
+    % Check if the plot has lines
+    hasLines    = ~strcmp(get(handle, 'lineStyle'),'none')...
+                && get(handle, 'lineWidth') > 0.0;
 
     % Extract the visual limits from the current line handle.
-    [xLim, yLim]   = getVisualLimits(meta);
+    [xLim, yLim]= getVisualLimits(meta);
 
     tol = 1.0e-10;
     relaxedXLim = xLim + [-tol, tol];
     relaxedYLim = yLim + [-tol, tol];
 
-    numPoints = size(data, 1);
-
     % Get which points are inside a (slightly larger) box.
     dataIsInBox = isInBox(data, relaxedXLim, relaxedYLim);
 
-    % By default, don't plot any points.
-    shouldPlot = false(numPoints, 1);
-    if hasMarkers
-        shouldPlot = shouldPlot | dataIsInBox;
-    end
+    % Plot all the points inside the box
+    shouldPlot = dataIsInBox;
+    
     if hasLines
-        % Check if the connecting line is in the box.
+        % Check if the connecting line between two data points is visible.
         segvis = segmentVisible(data, dataIsInBox, xLim, yLim);
-        % Plot points which are next to an edge which is in the box.
+        
+        % Plot points which part of an visible line segment.
         shouldPlot = shouldPlot | [false; segvis] | [segvis; false];
     end
 
@@ -189,11 +185,8 @@ function pruneOutsideBox(meta, handle)
     id_replace = [];
     id_remove  = [];
     if ~all(shouldPlot)
-        % There are two options here:
-        %      data = data(shouldPlot, :);
-        % i.e., simply removing the data that isn't supposed to be plotted.
-        % For line plots, this has the disadvantage that the line between two
-        % 'loose' ends may now appear in the figure.
+        % For line plots, simply removing the data has the disadvantage 
+        % that the line between two 'loose' ends may now appear in the figure.
         % To avoid this, add a row of NaNs wherever a block of actual data is
         % removed.
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -157,8 +157,8 @@ function pruneOutsideBox(meta, handle)
     end
 
     % Check if the plot has lines
-    hasLines    = ~strcmp(get(handle, 'lineStyle'),'none')...
-                && get(handle, 'lineWidth') > 0.0;
+    hasLines    = ~strcmp(get(handle, 'LineStyle'),'none')...
+                && get(handle, 'LineWidth') > 0.0;
 
     % Extract the visual limits from the current line handle.
     [xLim, yLim]= getVisualLimits(meta);

--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -67,7 +67,7 @@ quiveroverlap : 33ba3b2e8aed8286a5f58f7ab3cb9e01
 quiverplot : 3f5231d7089336c9aff107db7bed7eaa
 randomWithLines : 98dc43749ff89beeced69ddeac11a4f5
 rectanglePlot : 6b95520cdbb7071cbdb7c7eece7326ca
-removeOusideMarker : 
+removeOutsideMarker : c4ce62a1af84262cafe7c516c0189acd
 rlocusPlot : 993857d5c76e55ac5a190048c1a97699
 roseplot : 9177ce651d7a3789d219b3d6ad1936fa
 scatter3Plot : 13a1e08762ed807506d6eb38b56395f1

--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -67,6 +67,7 @@ quiveroverlap : 33ba3b2e8aed8286a5f58f7ab3cb9e01
 quiverplot : 3f5231d7089336c9aff107db7bed7eaa
 randomWithLines : 98dc43749ff89beeced69ddeac11a4f5
 rectanglePlot : 6b95520cdbb7071cbdb7c7eece7326ca
+removeOusideMarker : 
 rlocusPlot : 993857d5c76e55ac5a190048c1a97699
 roseplot : 9177ce651d7a3789d219b3d6ad1936fa
 scatter3Plot : 13a1e08762ed807506d6eb38b56395f1

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -67,7 +67,7 @@ quiveroverlap : 54a653adc319a2847fed16021dc9bf1f
 quiverplot : 308f4ce197791f2fd5862768e1157ca8
 randomWithLines : c0953a41fd630407744f77bd8f74e5aa
 rectanglePlot : 6b95520cdbb7071cbdb7c7eece7326ca
-removeOusideMarker : 
+removeOutsideMarker : a3b258f0df9a08307e5947262a9db3fb
 rlocusPlot : f372b9a4004fa45ac96a21014656e143
 roseplot : 687b1ba29c15466ce8f55e242a1ec838
 scatter3Plot : 5722839815b6fee4bec8cfa7d2ba94c9

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -67,6 +67,7 @@ quiveroverlap : 54a653adc319a2847fed16021dc9bf1f
 quiverplot : 308f4ce197791f2fd5862768e1157ca8
 randomWithLines : c0953a41fd630407744f77bd8f74e5aa
 rectanglePlot : 6b95520cdbb7071cbdb7c7eece7326ca
+removeOusideMarker : 
 rlocusPlot : f372b9a4004fa45ac96a21014656e143
 roseplot : 687b1ba29c15466ce8f55e242a1ec838
 scatter3Plot : 5722839815b6fee4bec8cfa7d2ba94c9

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -56,6 +56,7 @@ quiveroverlap : a5c76200c93b83f2480aca8563626bf9
 quiverplot : a279c46f4258aeab6f7b0ad599958005
 randomWithLines : 8095aa52dd58fae39a8d5718eebe55d5
 rectanglePlot : f63538597348033398ef9cc37dcf57cd
+removeOusideMarker : 
 roseplot : 53f355c77b1d2c682bd4815e4bdd1f71
 scatter3Plot : 96bd87d3f46beb1a8057f7929df7a254
 scatterPlotMarkers : b46648fe15cd942df897d7f7547c6b32

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -56,8 +56,7 @@ quiveroverlap : a5c76200c93b83f2480aca8563626bf9
 quiverplot : a279c46f4258aeab6f7b0ad599958005
 randomWithLines : 8095aa52dd58fae39a8d5718eebe55d5
 rectanglePlot : f63538597348033398ef9cc37dcf57cd
-removeOutsideMarker : 
-rlocusPlot : 
+removeOutsideMarker : 3859afeaae049b015beb55f2908a3151
 roseplot : 53f355c77b1d2c682bd4815e4bdd1f71
 scatter3Plot : 96bd87d3f46beb1a8057f7929df7a254
 scatterPlotMarkers : b46648fe15cd942df897d7f7547c6b32

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -56,7 +56,8 @@ quiveroverlap : a5c76200c93b83f2480aca8563626bf9
 quiverplot : a279c46f4258aeab6f7b0ad599958005
 randomWithLines : 8095aa52dd58fae39a8d5718eebe55d5
 rectanglePlot : f63538597348033398ef9cc37dcf57cd
-removeOusideMarker : 
+removeOutsideMarker : 
+rlocusPlot : 
 roseplot : 53f355c77b1d2c682bd4815e4bdd1f71
 scatter3Plot : 96bd87d3f46beb1a8057f7929df7a254
 scatterPlotMarkers : b46648fe15cd942df897d7f7547c6b32

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -133,7 +133,8 @@ function [status] = ACID(k)
                            @textAlignment       , ...
                            @overlappingPlots    , ...
                            @histogramPlot       , ...
-                           @alphaTest
+                           @alphaTest           , ...
+                           @removeOutsideMarker
                          };
 
 
@@ -2693,5 +2694,30 @@ function [stat] = alphaTest()
   set(h, 'MarkerSize', 14);
   set(h, 'MarkerEdgeColor', [1 1 0]);
   set(h, 'MarkerFaceColor', [1 0 0]);
+end
+% =========================================================================
+function [stat] = removeOutsideMarker()
+  stat.description = 'remove markers outside of the box';
+  stat.issues      = 788;
+
+  % Create the data and plot it
+  xdata          = -1 : 0.5 : 1.5;
+  ydata_marker   = 1.5 * ones(size(xdata));
+  ydata_line     = 1   * ones(size(xdata));  
+  ydata_combined = 0.5 * ones(size(xdata));
+  plot(xdata, ydata_marker, '*', ...
+       xdata, ydata_line, '-', ...
+       xdata, ydata_combined, '*-');
+  title('Markers at -1 and 0.5 should be removed, the line shortened'); 
+
+  % Change the limits, so one marker is outside the box
+  ylim([0, 2]);
+  xlim([0, 2]);
+  
+  % Remove it
+  cleanfigure;
+  
+  % Change the limits back to check result
+  xlim([-1, 2]);
 end
 % =========================================================================


### PR DESCRIPTION
Previously we didn't check whether it was a line or not #788. This might have the undesired behaviour, that markers outside of the visible box would not be removed.

By checking for lineplots, we can resolve this. Additionally, as markers are only plotted inside the box, we can simplify the code a bit.

This also adds a test that checks the behaviour.