### PR TITLE
Travis GCE migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: c++
 # command to install dependencies
 before_install:
-  - #sudo apt-get install -y gdb # to capture backtrace of eventual failures
   - sudo add-apt-repository -y ppa:octave/stable
   - sudo apt-get update -qq
+  - sudo apt-get install -y gdb # to capture backtrace of eventual failures
   - sudo apt-get install octave
   - sudo apt-get purge libopenblas-base # fixes PPA Octave 4.0 crash on Travis
 before_script:
@@ -14,4 +14,4 @@ notifications:
   hipchat: f4c2c5f87adc85025545e5b59b3fbe@Matlab2tikz
 after_failure:
 - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
-- #gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace
+- gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: c++
-# command to install dependencies
 before_install:
   - sudo add-apt-repository -y ppa:octave/stable
   - sudo apt-get update -qq
-  - sudo apt-get install -y gdb # to capture backtrace of eventual failures
+  - sudo apt-get install gdb # to capture backtrace of eventual failures
   - sudo apt-get install octave
   - sudo apt-get purge libopenblas-base # fixes PPA Octave 4.0 crash on Travis
 before_script:
-- ulimit -c unlimited -S                # enable core dumps for Octave crash debugging
+  - ulimit -c unlimited -S  # enable core dumps for Octave crash debugging
 script:
   - ./runtests.sh /usr/bin/octave
 notifications:
   hipchat: f4c2c5f87adc85025545e5b59b3fbe@Matlab2tikz
 after_failure:
-- COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
-- gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace
+  - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
+  - gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c++
 # command to install dependencies
 before_install:
-  - sudo apt-get install -y gdb # to capture backtrace of eventual failures
+  - #sudo apt-get install -y gdb # to capture backtrace of eventual failures
   - sudo add-apt-repository -y ppa:octave/stable
   - sudo apt-get update -qq
   - sudo apt-get install octave
@@ -14,4 +14,4 @@ notifications:
   hipchat: f4c2c5f87adc85025545e5b59b3fbe@Matlab2tikz
 after_failure:
 - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1) # find core file
-- gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace
+- #gdb -c "$COREFILE" -ex "thread apply all bt" -ex "set pagination 0" -batch /usr/bin/octave-cli # print stack trace


### PR DESCRIPTION
Travis has [migrated](https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future) from OpenVZ to GCE, so apparently, `gdb` is no longer available.

This PR is to fix this on our end, if we can (this time against `develop` instead of `master`).