### PR TITLE
add labels to plot according to Tag property of line

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1763,20 +1763,19 @@ function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar
     if ~exist('generatedCodeSoFar','var') || isempty(generatedCodeSoFar)
         generatedCodeSoFar = '';
     end
+    
     if m2t.cmdOpts.Results.automaticLabels
-        [pathstr, name] = fileparts(m2t.cmdOpts.Results.filename); %#ok
-        labelName = sprintf('addplot:%s%d', name, m2t.automaticLabelIndex);
-        labelCode = sprintf('\\label{%s}\n', labelName);
-        m2t.automaticLabelIndex = m2t.automaticLabelIndex + 1;
-
-        userWarning(m2t, 'Automatically added label ''%s'' for line plot.', labelName);
-        generatedCodeSoFar = [generatedCodeSoFar, labelCode];
-        
         if ~isempty(lineTag)
             labelName = sprintf('%s', lineTag);
-            labelCode = sprintf('\\label{%s}\n', labelName);
-            generatedCodeSoFar = [generatedCodeSoFar, labelCode];
+        else
+            [pathstr, name] = fileparts(m2t.cmdOpts.Results.filename); %#ok
+            labelName = sprintf('addplot:%s%d', name, m2t.automaticLabelIndex);
+            m2t.automaticLabelIndex = m2t.automaticLabelIndex + 1;
         end
+        labelCode = sprintf('\\label{%s}\n', labelName);
+        generatedCodeSoFar = [generatedCodeSoFar, labelCode];
+        
+        userWarning(m2t, 'Automatically added label ''%s'' for line plot.', labelName);
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1653,7 +1653,6 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     lineStyle            = get(h, 'LineStyle');
     lineWidth            = get(h, 'LineWidth');
     lineOptions          = getLineOptions(m2t, lineStyle, lineWidth);
-    lineTag              = get(h,'Tag');
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
 
     drawOptions = opts_new();
@@ -1677,7 +1676,7 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     m2t = jumpAtUnboundCoords(m2t, data);
 
     [m2t, str] = writePlotData(m2t, str, data, drawOptions);
-    [m2t, str] = addLabel(m2t, str, lineTag);
+    [m2t, str] = addLabel(m2t, str, h);
 end
 % ==============================================================================
 function [m2t, str] = specialDrawZplaneUnitCircle(m2t, h, drawOptions)
@@ -1758,13 +1757,14 @@ function [data] = getXYZDataFromLine(m2t, h)
     end
 end
 % ==============================================================================
-function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar, lineTag)
+function [m2t, generatedCodeSoFar] = addLabel(m2t, generatedCodeSoFar, h)
     % conditionally add a LaTeX label after the current plot
     if ~exist('generatedCodeSoFar','var') || isempty(generatedCodeSoFar)
         generatedCodeSoFar = '';
     end
     
     if m2t.cmdOpts.Results.automaticLabels
+        lineTag = get(h,'Tag');
         if ~isempty(lineTag)
             labelName = sprintf('%s', lineTag);
         else

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -102,9 +102,9 @@ function matlab2tikz(varargin)
     %   MATLAB2TIKZ('tikzFileComment',CHAR,...) adds a custom comment to the header
     %   of the output file. (default: '')
     %
-    %   MATLAB2TIKZ('automaticLabels',BOOL,...) determines whether to automatically
-    %   add labels to plots (where applicable) which make it possible to refer
-    %   to them using \ref{...} (e.g., in the caption of a figure). (default: false)
+    %   MATLAB2TIKZ('addLabels',BOOL,...) add labels to plots: using Tag property
+    %   or automatic names (where applicable) which make it possible to refer to
+    %   them using \ref{...} (e.g., in the caption of a figure). (default: false)
     %
     %   MATLAB2TIKZ('standalone',BOOL,...) determines whether to produce
     %   a standalone compilable LaTeX file. Setting this to true may be useful for
@@ -221,6 +221,7 @@ function matlab2tikz(varargin)
     ipp = ipp.addParamValue(ipp, 'extraTikzpictureOptions', {}, @isCellOrChar);
     ipp = ipp.addParamValue(ipp, 'floatFormat', '%.15g', @ischar);
     ipp = ipp.addParamValue(ipp, 'automaticLabels', false, @islogical);
+    ipp = ipp.addParamValue(ipp, 'addLabels', false, @islogical);
     ipp = ipp.addParamValue(ipp, 'showHiddenStrings', false, @islogical);
     ipp = ipp.addParamValue(ipp, 'height', '', @ischar);
     ipp = ipp.addParamValue(ipp, 'width' , '', @ischar);
@@ -262,6 +263,7 @@ function matlab2tikz(varargin)
     %% deprecated parameters (will auto-generate warnings upon parse)
     ipp = ipp.addParamValue(ipp, 'relativePngPath', '', @ischar);
     ipp = ipp.deprecateParam(ipp, 'relativePngPath', 'relativeDataPath');
+    ipp = ipp.deprecateParam(ipp, 'automaticLabels', 'addLabels');
 
     %% Finally parse all the arguments
     ipp = ipp.parse(ipp, varargin{:});
@@ -1763,7 +1765,7 @@ function [m2t, generatedCodeSoFar] = addLabel(m2t, generatedCodeSoFar, h)
         generatedCodeSoFar = '';
     end
     
-    if m2t.cmdOpts.Results.automaticLabels
+    if m2t.cmdOpts.Results.automaticLabels||m2t.cmdOpts.Results.addLabels
         lineTag = get(h,'Tag');
         if ~isempty(lineTag)
             labelName = sprintf('%s', lineTag);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1653,6 +1653,7 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     lineStyle            = get(h, 'LineStyle');
     lineWidth            = get(h, 'LineWidth');
     lineOptions          = getLineOptions(m2t, lineStyle, lineWidth);
+    lineTag              = get(h,'Tag');
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
 
     drawOptions = opts_new();
@@ -1676,7 +1677,7 @@ function [m2t, str] = drawLine(m2t, h, yDeviation)
     m2t = jumpAtUnboundCoords(m2t, data);
 
     [m2t, str] = writePlotData(m2t, str, data, drawOptions);
-    [m2t, str] = addLabel(m2t, str);
+    [m2t, str] = addLabel(m2t, str, lineTag);
 end
 % ==============================================================================
 function [m2t, str] = specialDrawZplaneUnitCircle(m2t, h, drawOptions)
@@ -1757,7 +1758,7 @@ function [data] = getXYZDataFromLine(m2t, h)
     end
 end
 % ==============================================================================
-function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar)
+function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar, lineTag)
     % conditionally add a LaTeX label after the current plot
     if ~exist('generatedCodeSoFar','var') || isempty(generatedCodeSoFar)
         generatedCodeSoFar = '';
@@ -1770,6 +1771,12 @@ function [m2t, generatedCodeSoFar, labelCode] = addLabel(m2t, generatedCodeSoFar
 
         userWarning(m2t, 'Automatically added label ''%s'' for line plot.', labelName);
         generatedCodeSoFar = [generatedCodeSoFar, labelCode];
+        
+        if ~isempty(lineTag)
+            labelName = sprintf('%s', lineTag);
+            labelCode = sprintf('\\label{%s}\n', labelName);
+            generatedCodeSoFar = [generatedCodeSoFar, labelCode];
+        end
     end
 end
 % ==============================================================================


### PR DESCRIPTION
The autolabel option of matlab2tikz is working fine, but if you change your plots, because e.g. you plot an additional line, all labels change.
Therefore, it is convenient to add the label you want to have in tex to the Tag property of your line in matlab. When exporting with autolabels, the original labels are reproduced for compatibility and additionally the Tag will show up as a label.