### PR TITLE
Fix barplots

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3802,7 +3802,7 @@ function [m2t, str] = drawBarseries(m2t, h)
     else
         barType = 'ybar';
     end
-    m2t = m2t_addAxisOption(m2t, barType);
+    m2t = m2t_addAxisOption(m2t, 'bar shift auto');
 
     % Get the draw options for the layout
     [m2t, drawOptions] = setBarLayoutOfBarSeries(m2t, h, barType, drawOptions);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3802,6 +3802,8 @@ function [m2t, str] = drawBarseries(m2t, h)
     else
         barType = 'ybar';
     end
+    % Tthe bar shift auto feature was introduced in pgfplots 1.13
+    m2t = needsPgfplotsVersion(m2t, [1,13]);
     m2t = m2t_addAxisOption(m2t, 'bar shift auto');
 
     % Get the draw options for the layout
@@ -3851,6 +3853,7 @@ end
 function [m2t, drawOptions] = setBarLayoutOfBarSeries(m2t, h, barType, drawOptions)
     % sets the options specific to a bar layour (grouped vs stacked)
     barlayout = get(h, 'BarLayout');
+
     switch barlayout
         case 'grouped'  % grouped bar plots
 
@@ -3893,8 +3896,7 @@ function [m2t, drawOptions] = setBarLayoutOfBarSeries(m2t, h, barType, drawOptio
             drawOptions = opts_add(drawOptions, barType);
 
             % Bar width
-            drawOptions = opts_add(drawOptions, 'bar width', ...
-                                 formatDim(barWidth, ''));
+            drawOptions = opts_add(drawOptions, 'bar width', formatDim(barWidth, ''));
         case 'stacked' % stacked plots
             % Pass option to parent axis & disallow anything but stacked plots
             % Make sure this happens exactly *once*.

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3875,9 +3875,10 @@ function [m2t, drawOptions] = setBarLayoutOfBarSeries(m2t, h, barType, drawOptio
             % and so forth.
             % assumedBarWidth = groupWidth/numBarSeries; % assumption
             % barShift        = (barSeriesId - 0.5) * assumedBarWidth - groupWidth/2;
-            % FIXME #785: The previous version of barshift lead to regressions
+            % FIXME #785: The previous version of barshift lead to
+            % regressions, as the bars were stacked.
             % Instead remove the calculation of barShift and add x/ybar to
-            % the axis.
+            % the axis so that pgf determines it automatically.
 
             % From http://www.mathworks.com/help/techdoc/ref/bar.html:
             % bar(...,width) sets the relative bar width and controls the

--- a/test/suites/ACID.MATLAB.8.3.md5
+++ b/test/suites/ACID.MATLAB.8.3.md5
@@ -38,7 +38,7 @@ legendplot : 1a15a9d38698e0bacc2dfefcb54c60dd
 legendplotBoxoff : 017a096b7da05f0db13e2e25787452b3
 legendsubplots : 23ca6022a333c8b6a2f4e4ef2732e242
 linesWithOutliers : 04e015ca88555d597094a23a875739b1
-logbaseline : 7b688bad27bc979e035e8f824abaeb34
+logbaseline : 982bf0e4475630e2474005ffec2739da
 logicalImage : e2d9da14cb4121727dd0b17b6ae58434
 logplot : 7a666c20b5a828b306e5d40aad81739d
 mandrillImage : 5cfaf3971064af419bb5375ee1dffe41

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -38,7 +38,7 @@ legendplot : 746423d1c0d403421667221a6b0528bf
 legendplotBoxoff : 017a096b7da05f0db13e2e25787452b3
 legendsubplots : bd816762b848e69c356c2dcc78390115
 linesWithOutliers : 04e015ca88555d597094a23a875739b1
-logbaseline : 0387bef302889fb9e33cdc7bc7cd826c
+logbaseline : 5cde72448c0b8ef83f1c161b27a2d0ee
 logicalImage : e2d9da14cb4121727dd0b17b6ae58434
 logplot : 1d7082314f14a3e6d057543046fbe5f6
 mandrillImage : 5cfaf3971064af419bb5375ee1dffe41

--- a/test/suites/ACID.Octave.3.8.0.md5
+++ b/test/suites/ACID.Octave.3.8.0.md5
@@ -30,7 +30,7 @@ legendplot : 45f5eae108b3d13a611561ec6a842922
 legendplotBoxoff : 75b8589690660dd521e8b5577a422cca
 legendsubplots : 5005469bf8cbe365f00ef9c78d955c1b
 linesWithOutliers : ef36fbc79337000b101b8ec7ac09d9f8
-logbaseline : 3493a73c61486f3ce56f636bdb3b5b72
+logbaseline : 340928cdea286b2c2b067487e35e81d6
 logicalImage : 82e9e5ed998aa1ecd78b514d801dc914
 logplot : 8bcec0e793845526f5483335fc830afa
 manualAlignment : 43b5487b026f540057cf11bf16ae7c7f


### PR DESCRIPTION
Hi,

this is a try on #785 and hopefully later also #845 and #840 . 

Currently barplots are stacked on top of each other. This can be avoided by removing the "bar shift" argument and adding "xbar/ybar" to the axis environement, as following the pgfplots manual this calculates the shifts automatically.
```latex
/pgfplots/xbar={<shift for multiple plots>} (style, default 2pt)
This style sets /tikz/xbar and some commonly used options concerning horizontal bars 
for the complete axis. This is automatically done if you provide xbar as argument to an 
axis argument, see above. The xbar style defines shifts if multiple plots are placed 
into one axis. It draws bars adjacent to each other, separated by
 <shift for multiple plots>. Furthermore, it sets the style bar cycle list and sets tick and
legend appearance options.
The style is defined as follows.
```
```latex
\pgfplotsset{
    /pgfplots/xbar/.style={
        /tikz/xbar,
        bar cycle list,
        tick align=outside,
        xbar legend,
       /pgfplots/bar shift auto={#1},
    },
}
```

Also add barplots to octave, as the patch workaround is rather ugly


### TODO
 - [x] Is xbar/ybar in the addplots necessary  ->NO
 - [x] Add bar schift auto?
 - [x] Investigate barplot width (#840) -> Most likely a precision problem
 - [x] Stacked barplots? (#845) -> Seems to stem from outdated pgfplots