### PR TITLE
Only add forget plot if it is not the last plot of an axis

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1764,7 +1764,7 @@ function [m2t, str] = writePlotData(m2t, data, drawOptions)
             % entry for the *last* occurrence of the plot series.
             % Hence the condition k<length(xDataCell).
             %if ~isempty(m2t.legendHandles) && (~m2t.currentHandleHasLegend || k < length(dataCell))
-            if ~m2t.currentHandleHasLegend || k < length(dataCell)
+            if ~m2t.currentHandleHasLegend && k < length(dataCell)
                 % No legend entry found. Don't include plot in legend.
                 hiddenDrawOptions = maybeShowInLegend(false, drawOptions);
                 opts = opts_print(m2t, hiddenDrawOptions, ',');


### PR DESCRIPTION
It seems, that the intention was, that the last plot of an axis never gets an "forget plot" however, this requires an && rather than a ||.

As far as I know this fixes #799 and #855 