### PR TITLE
figure2dot: also show "Axes" property

### DIFF
--- a/src/figure2dot.m
+++ b/src/figure2dot.m
@@ -84,6 +84,7 @@ function figure2dot(filename, varargin)
             end
             label = addProperty(label, 'Handle', sprintf('%g', double(h)));
             label = addHGProperty(label, h, 'Title', '');
+            label = addHGProperty(label, h, 'Axes', []);
             label = addHGProperty(label, h, 'String', '');
             label = addHGProperty(label, h, 'Tag', '');
             label = addHGProperty(label, h, 'DisplayName', '');
@@ -124,6 +125,9 @@ function label = addHGProperty(label, h, propName, default)
         if numel(propValue) == 1 && ishghandle(propValue) && isprop(propValue, 'String')
             % dereference Titles, labels, ...
             propValue = get(propValue, 'String');
+        elseif ishghandle(propValue)
+            % dereference other HG objects to their raw handle value (double)
+            propValue = double(propValue);
         elseif iscell(propValue)
             propValue = ['{' m2tstrjoin(propValue,',') '}'];
         end


### PR DESCRIPTION
@okomarov What you wanted, I hope :smile: 
This shows the related Axes for legend objects.
Confirmed working in both HG1 and HG2 (don't know about Octave).

E.g. for 
```matlab
hold all
plot(1:10)
plot(2:11)
plot(3:12)
legend('a','b')
```

![untitled 3](https://cloud.githubusercontent.com/assets/177360/12848683/abe62d6c-cc1b-11e5-86ca-7d84ecf7cda3.png)


this produces the following DOT figure in HG2 (HG1 also shows the property, but the overall data structure is more complicated). The green highlight is what this PR adds: