### PR TITLE
miscellaneous fixes

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2153,9 +2153,6 @@ function [m2t, str] = drawPatch(m2t, handle)
     % Line options
     [m2t, lineOptions] = getLineOptions(m2t, handle);
     drawOptions = opts_merge(drawOptions, lineOptions);
-    if isNone(handle.Marker) && (isNone(handle.LineStyle) || isNone(handle.EdgeColor))
-        drawOptions = opts_add(drawOptions,'draw opacity','0');
-    end
 
     % No patch: if one patch and single face/edge color
     isFaceColorFlat = isempty(strfind(opts_get(patchOptions, 'shader'),'interp'));
@@ -2290,6 +2287,9 @@ function [m2t, options] = setColor(m2t, handle, options, property, color, noneVa
     % that is set when the color == 'none' (if it is omitted, the property will not
     % be set).
     % TODO: probably this should be integrated with getAndCheckDefault etc.
+    if opts_has(options,property) && isNone(opts_get(options,property))
+        return
+    end
     if ~isNone(color)
         [m2t, xcolor] = getColor(m2t, handle, color, 'patch');
         if ~isempty(xcolor)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1367,6 +1367,18 @@ function [m2t, opts] = getTitleOrLabel_(m2t, handle, opts, labelKind, tikzKeywor
         end
         str = join(m2t, str, '\\[1ex]');
         opts =  opts_add(opts, tikzKeyword, sprintf('{%s}', str));
+    
+        % set color of axis labels
+        color = object.Color;
+        [m2t, col] = getColor(m2t, handle, color, 'patch');
+        if strcmpi(labelKind,'title')
+          % TODO: color titles
+        else
+          opts = ...
+              opts_add(opts, ...
+              ['every axis ',lower(labelKind(1)),' label/.append style'], ...
+              ['{font=\color{',col,'}}']);
+        end
     end
 end
 % ==============================================================================
@@ -1471,11 +1483,6 @@ function [m2t, options] = getAxisOptions(m2t, handle, axis)
             opts_add(options, ...
             ['every ',axis,' tick/.append style'], ...
             ['{',col,'}']);
-        % set color of axis labels
-        options = ...
-            opts_add(options, ...
-            ['every axis ',axis,' label/.append style'], ...
-            ['{font=\color{',col,'}}']);
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % handle the orientation
@@ -2295,7 +2302,11 @@ function [m2t, options] = setColor(m2t, handle, options, property, color, noneVa
         if ~isempty(xcolor)
             % this may happen when color == 'flat' and CData is Nx3, e.g. in
             % scatter plot or in patches
-            options = opts_add(options, property, xcolor);
+            if isempty(property)
+                options = opts_add(options, xcolor);
+            else
+                options = opts_add(options, property, xcolor);
+            end
         end
     else
         if exist('noneValue','var')
@@ -6458,9 +6469,7 @@ function str = opts_print(opts, sep)
     nOpts = size(opts,1);
     c = cell(1,nOpts);
     for k = 1:nOpts
-        if isempty(opts{k,1})
-            c{k} = sprintf('%s', opts{k,2});
-        elseif isempty(opts{k,2})
+        if isempty(opts{k,2})
             c{k} = sprintf('%s', opts{k,1});
         else
             c{k} = sprintf('%s=%s', opts{k,1}, opts{k,2});

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -860,8 +860,8 @@ function m2t = drawAxes(m2t, handle)
     if ~isVisible(handle)
         % Setting hide{x,y} axis also hides the axis labels in Pgfplots whereas
         % in MATLAB, they may still be visible. Instead use the following.
-        m2t = m2t_addAxisOption(m2t, 'axis line style={draw=none}');
-        m2t = m2t_addAxisOption(m2t, 'ticks=none');
+        m2t = m2t_addAxisOption(m2t, 'axis line style', '{draw=none}');
+        m2t = m2t_addAxisOption(m2t, 'ticks', 'none');
         %    % An invisible axes container *can* have visible children, so don't
         %    % immediately bail out here.
         %    children = allchild(handle);


### PR DESCRIPTION
There are a variety of things here:
* corrected the issue noted on 861 around ```hide axis``` (try ```imshow()``` with axis labels)
* added coloring of ticks and axis labels (e.g. test 20)
  * reference: [test20-reference.pdf](https://github.com/matlab2tikz/matlab2tikz/files/206597/test20-reference.pdf)
  * master: [test20-converted.pdf](https://github.com/matlab2tikz/matlab2tikz/files/206596/test20-converted.pdf)
  * now: [test20-converted.pdf](https://github.com/matlab2tikz/matlab2tikz/files/206598/test20-converted.pdf)
* moved the check for ```draw=none``` from ```getMarkerOptions``` to ```getLineOptions```
* switched from using ```draw=red``` for _marker colors_ to using ```mark options={red}``` so as not to fail when line and markers are different colors or when lines are absent
  * in ```setColor()```, prevented attempting to set the color of a line that already has ```draw=none```
  * generalized the allowed syntax for ```opts_print()``` to allow setting marker colors with ```setColor()```
* added limited support for ```stem3()```, still need to handle ```hgtransform``` and baseplane