### PR TITLE
Check for edge visibility of patches

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -2154,6 +2154,12 @@ function [m2t, str] = drawPatch(m2t, handle)
     [m2t, lineOptions] = getLineOptions(m2t, handle);
     drawOptions = opts_merge(drawOptions, lineOptions);
 
+    % If the line is not visible, set edgeColor to none. Otherwise pgfplots
+    % draws it by default
+    if ~isLineVisible(handle)
+       s.edgeColor = 'none';
+    end
+
     % No patch: if one patch and single face/edge color
     isFaceColorFlat = isempty(strfind(opts_get(patchOptions, 'shader'),'interp'));
     if size(Faces,1) == 1 && s.hasOneEdgeColor && isFaceColorFlat


### PR DESCRIPTION
As discussed in #896 the code currently always draws the edge. This was currently shadowed if the edge color was the same as that of the patch and/or if it was set explicitely.

Therefore, add a check for the visibility of a line of patch plots so the edge is only drawn when visible.