### PR TITLE
Normalize axis data

### DIFF
--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -23,7 +23,7 @@ function cleanfigure(varargin)
 %   or negative values disable this feature.
 %   (default: 1)
 %   CLEANFIGURE('normalizeAxis','xyz',...)
-%   EXPERIMENTAL: Normalize the data of the dimensions spezified by
+%   EXPERIMENTAL: Normalize the data of the dimensions specified by
 %   'normalizeAxis' to the interval [0, 1]. This might have side effects
 %   with hgtransform and friends. One can directly pass the axis handle to
 %   cleanfigure to ensure that only one axis gets normalized.

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -22,6 +22,13 @@ function cleanfigure(varargin)
 %   Scale the precision the data is represented with. Setting it to 0
 %   or negative values disable this feature.
 %   (default: 1)
+%   CLEANFIGURE('normalizeAxis','xyz',...)
+%   EXPERIMENTAL: Normalize the data of the dimensions spezified by
+%   'normalizeAxis' to the interval [0, 1]. This might have side effects
+%   with hgtransform and friends. One can directly pass the axis handle to
+%   cleanfigure to ensure that only one axis gets normalized.
+%   Usage: Input 'xz' normalizes only x- and zData but not yData
+%   (default: '')
 %
 %   Example
 %      x = -pi:pi/1000:pi;
@@ -1269,6 +1276,10 @@ end
 % ========================================================================
 function normalizeAxis(handle, cmdOpts)
     % Normalizes data from a given axis into the interval [0, 1]
+
+    % Warn about normalizeAxis being experimental
+    warning('cleanfigure:normalizeAxis', ...
+        'Normalization of axis data is experimental!');
     for i=1:length(cmdOpts.normalizeAxis)
         axis = cmdOpts.normalizeAxis(i);
 

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -71,6 +71,7 @@ function cleanfigure(varargin)
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'minimumPointsDistance', 1.0e-10, @isnumeric);
   m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'scalePrecision', 1, @isnumeric);
   m2t.cmdOpts = m2t.cmdOpts.deprecateParam(m2t.cmdOpts, 'minimumPointsDistance', 'targetResolution');
+  m2t.cmdOpts = m2t.cmdOpts.addParamValue(m2t.cmdOpts, 'transformDates', '', @isValidAxis);
   % Finally parse all the elements.
   m2t.cmdOpts = m2t.cmdOpts.parse(m2t.cmdOpts, varargin{:});
 
@@ -107,6 +108,11 @@ function recursiveCleanup(meta, h, cmdOpts)
     % Update the current axes.
     if strcmp(type, 'axes')
         meta.gca = h;
+
+        if ~isempty(cmdOpts.transformDates)
+            % If chosen transform the date axis
+            transform_dateticks(h, cmdOpts);
+        end
     end
 
     children = get(h, 'Children');
@@ -1249,5 +1255,40 @@ end
 % =========================================================================
 function bool = isValidTargetResolution(val)
     bool = isnumeric(val) && ~any(isnan(val)) && (isscalar(val) || numel(val) == 2);
+end
+% =========================================================================
+function bool = isValidAxis(val)
+    bool = strcmp(val, 'x') || strcmp(val, 'y') || strcmp(val, 'z');
+end
+% ========================================================================
+function transform_dateticks(handle, cmdOpts)
+    % Projects MALTAB date coordinates into the interval [0, 1], applying
+    % the transformation to all the relevant data
+    axis = cmdOpts.transformDates;
+
+    % Get the scale needed to set xlim to [0, 1]
+    dateLimits = get(handle, [upper(axis), 'Lim']);
+    dateScale  = 1/diff(dateLimits);
+
+    % Project the ticks
+    ticks = get(handle, [upper(axis), 'Tick']);
+    ticks = (ticks - dateLimits(1))*dateScale;
+
+    % Set the data
+    set(handle, [upper(axis), 'Tick'], ticks);
+    set(handle, [upper(axis), 'Lim'],  [0, 1]);
+
+    % Traverse the children
+    children = get(handle, 'Children');
+    for child = children(:)'
+        type = get(child, 'type');
+        if strcmp(type, 'line') || strcmp(type, 'stair')
+            % Get the data and transform it
+            data = get(child, [upper(axis), 'Data']);
+            data = (data - dateLimits(1))*dateScale;
+            % Set the data again
+            set(child, [upper(axis), 'Data'], data);
+        end
+    end
 end
 % =========================================================================

--- a/src/cleanfigure.m
+++ b/src/cleanfigure.m
@@ -1287,6 +1287,9 @@ function normalizeAxis(handle, cmdOpts)
         dateLimits = get(handle, [upper(axis), 'Lim']);
         dateScale  = 1/diff(dateLimits);
 
+        % Set the TickLabelMode to manual to preserve the labels
+        set(handle, [upper(axis), 'TickLabelMode'], 'manual');
+
         % Project the ticks
         ticks = get(handle, [upper(axis), 'Tick']);
         ticks = (ticks - dateLimits(1))*dateScale;


### PR DESCRIPTION
this is a very hacky try to make datetick compilable for m2t inspired by #905.

The idea is simple. Tacke the rather stupid matlab format and project it into a reasonable range tixz can work with. There is obviously a big drawback, as it is done for all the the axes.

If the xaxis is in datetick one does
```matlab
cleanfigure('transformDates', 'x')
```