### PR TITLE
Fix default minor grid LineStyle

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -954,7 +954,7 @@ function m2t = drawGridOfAxes(m2t, handle)
         gridOpts = opts_new();
         % Get the line style and translate it to pgfplots
         [gridLS, isDefault] = getAndCheckDefault(...
-            'axes', handle, 'GridLineStyle', ':');
+            'axes', handle, 'GridLineStyle', '-');
         if ~isDefault || m2t.args.strict
             gridOpts = opts_add(gridOpts, translateLineStyle(gridLS));
         end
@@ -984,8 +984,8 @@ function m2t = drawGridOfAxes(m2t, handle)
         minorGridOpts = opts_new();
         % Get the line style and translate it to pgfplots
         [minorGridLS, isDefault] = getAndCheckDefault(...
-            'axes', handle, 'MinorGridLineStyle', ':');
-        if ~isDefault || m2t.args.strict
+            'axes', handle, 'MinorGridLineStyle', '-');
+        if ~isDefault || m2t.args.strict || strcmpi(minorGridLS, ':')
             minorGridOpts = opts_add(minorGridOpts, translateLineStyle(minorGridLS));
         end
 


### PR DESCRIPTION
Currently we only check whether the minorGridLS is the matlab default.


However, the one from matlab differs from that of pgfplots. Therefore it would be impossible to get dotted minor grids without manual editing.

Add a check for the matlab default minorGridLS so that we can produce dotted minor grids. While we are at it change the fallback style to that of pgfplots (solid).

This was more or less a side effect from #913 