### PR TITLE
Semantical export of lineWidth

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -207,6 +207,10 @@ ipp = ipp.addParamValue(ipp, 'showInfo', true, @islogical);
 ipp = ipp.addParamValue(ipp, 'showWarnings', true, @islogical);
 ipp = ipp.addParamValue(ipp, 'checkForUpdates', true, @islogical);
 
+ipp = ipp.addParamValue(ipp, 'semanticalLineWidth', false, @islogical);
+ipp = ipp.addParamValue(ipp, 'semanticalValueList', [.1,.2,.4,.6,.8,1.2,1.6], @isnumeric);
+ipp = ipp.addParamValue(ipp, 'semanticalStringList', {'ultra thin', 'very thin', 'thin', 'semithick', 'thick', 'very thick', 'ultra thick'}, @isCellOrChar);
+
 ipp = ipp.addParamValue(ipp, 'encoding' , '', @ischar);
 ipp = ipp.addParamValue(ipp, 'standalone', false, @islogical);
 ipp = ipp.addParamValue(ipp, 'tikzFileComment', '', @ischar);
@@ -1591,7 +1595,23 @@ function lineOpts = getLineOptions(m2t, lineStyle, lineWidth)
     matlabDefaultLineWidth = 0.5;
     if m2t.cmdOpts.Results.strict ...
             || ~abs(lineWidth-matlabDefaultLineWidth) <= m2t.tol
-        lineOpts = opts_add(lineOpts, 'line width', sprintf('%.1fpt', lineWidth));
+        if m2t.cmdOpts.Results.semanticalLineWidth
+            semStrID = find(lineWidth == m2t.cmdOpts.Results.semanticalValueList);
+            if isempty(semStrID)
+                lineOpts = opts_add(lineOpts, 'line width', sprintf('%.1fpt', lineWidth));
+            else
+                lineOpts = opts_add(lineOpts, m2t.cmdOpts.Results.semanticalStringList{semStrID}, []);
+            end
+        else
+            lineOpts = opts_add(lineOpts, 'line width', sprintf('%.1fpt', lineWidth));
+        end
+    else % lineWidth = matlabDefaultLineWidth
+        if m2t.cmdOpts.Results.semanticalLineWidth
+            % search for a semanticalStringList entry which match the
+            % default lineWidth
+            semStrID = find(lineWidth == m2t.cmdOpts.Results.semanticalValueList);
+            lineOpts = opts_add(lineOpts, m2t.cmdOpts.Results.semanticalStringList{semStrID}, []);
+        end
     end
 end
 % ==============================================================================


### PR DESCRIPTION
Hello,

actually this is my first pull-request, so I hope I've done nothing wrong.

My additions are on three new optional variables, which can be used to enable and specify the export of line width in a semantic manner.

The default behaviour of the matlab2tikz function is not changed, if semanticalLineWidth=false.


Here is a simple MATLAB code with two examples:
`x = -pi:pi/10:pi; y = tan(sin(x)) - sin(tan(x));`
`x2 = -pi:pi/10:pi; y2 = sin(x);`

`figure; plot(x,y,'--rs');`
`hold on;`
`plot(x2,  y2,'k','LineWidth', 1.2);`
`plot(x2,1-y2,'b','LineWidth', 2);`

`% 1st example: The default line width is translated to the`
`% semantical line width of 'thin' and the value 2pt to 'semithick',`
`% respectively. The line with line width of 1.2 is exported with their`
`% specified value.`
`matlab2tikz('myfile_1.tex',...`
    `'showInfo', false,...`
    `'standalone', true,...`
    `'strict', true,...`
    `'semanticalLineWidth', true,...`
    `'semanticalValueList', [0.5, 2],...`
    `'semanticalStringList', {'thin', 'semithick'});`

`% 2nd example: Only the line with the 1.2 vlaue of width is a 'standard'`
`% value and therefore exported as 'very thick'`
`matlab2tikz('myfile_2.tex',...`
`    'showInfo', false,...`
`    'standalone', true,...`
`    'strict', true,...`
`    'semanticalLineWidth', true);`


One thing missing is a check for the two list variables which need to have the same length. I simple was not sure where to put such a check.

I hope you like it nevertheless :)

Best regards
JTSvejda

Signed-off-by: JTSvejda <jan.svejda@uni-due.de>