### PR TITLE
Transform semantic ticklabels into a cell of strings

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5167,7 +5167,7 @@ function pTickLabels = formatPgfTickLabels(m2t, plotLabelsNecessary, ...
             % cells containing strings
             if isnumeric(tickLabels{k})
                 tickLabels(k) = num2str(tickLabels{k});
-            else
+            elseif iscell(tickLabels{k})
                 tickLabels(k) = tickLabels{k};
             end
             % If the axis is logscaled, MATLAB does not store the labels,

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5162,18 +5162,18 @@ function pTickLabels = formatPgfTickLabels(m2t, plotLabelsNecessary, ...
         tickLabels, isLogAxis, tickLabelMode)
     % formats the tick labels for pgfplots
     if plotLabelsNecessary
-        % if the axis is logscaled, MATLAB does not store the labels,
-        % but the exponents to 10
-        if isLogAxis
-            for k = 1:length(tickLabels)
-                if isnumeric(tickLabels{k})
-                    str = num2str(tickLabels{k});
-                else
-                    str = tickLabels{k};
-                end
-                if strcmpi(tickLabelMode,'auto')
-                    tickLabels{k} = sprintf('$10^{%s}$', str);
-                end
+        for k = 1:length(tickLabels)
+            % Turn tickLabels from cells containing a cell into 
+            % cells containing strings
+            if isnumeric(tickLabels{k})
+                tickLabels(k) = num2str(tickLabels{k});
+            else
+                tickLabels(k) = tickLabels{k};
+            end
+            % If the axis is logscaled, MATLAB does not store the labels,
+            % but the exponents to 10
+            if isLogAxis && strcmpi(tickLabelMode,'auto')
+                tickLabels{k} = sprintf('$10^{%s}$', str);
             end
         end
         tickLabels = cellfun(@(l)(sprintf('{%s}',l)), tickLabels, ...


### PR DESCRIPTION
Currently ticklabels were cells of a single cell containing a string. This could break the code as sprintf doesnt take a cell. As a workarround  transform it into cells of string as we do for log scaled plots.

This should fix #926.