### PR TITLE
Only mkdir when directory name is specified

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -434,7 +434,7 @@ function fid = fileOpenForWrite(m2t, filename)
     fid = -1;
 
     [filepath] = fileparts(filename);
-    if ~exist(filepath,'dir')
+    if ~exist(filepath,'dir') && ~isempty(filepath)
         mkdir(filepath);
     end
     


### PR DESCRIPTION
MATLAB warns that `mkdir('')` may stop working in the future.
As such, only do the `mkdir` part when an actual directory is provided.

This PR makes sure that this warning no longer occurs.