### PR TITLE
Rework the handling of arrows in quiver plots 

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4300,7 +4300,14 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
 
         userInfo(m2t, ['Please change the "arrowHeadSize" option', ...
             ' if the size of the arrows is incorrect.']);
-        arrowHeadSize = sprintf(m2t.ff, abs(m2t.args.arrowHeadSize));
+        arrowHeadSize = abs(m2t.args.arrowHeadSize);
+
+        % Rescale the head size if MaxHeadSize is changed
+        [headSize, isDefault] = getAndCheckDefault('quiver', h, 'MaxHeadSize', 0.2);
+        if ~isDefault
+             arrowHeadSize = arrowHeadSize * headSize / 0.2;
+        end
+        arrowHeadSize = sprintf(m2t.ff, arrowHeadSize);
 
         % Write out the actual scaling for TikZ.
         % `\pgfplotspointsmetatransformed` is in the range [0, 1000], so
@@ -4327,6 +4334,7 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
     quiverOptions = opts_new();
     quiverOptions = opts_add(quiverOptions, 'u', '\thisrow{u}');
     quiverOptions = opts_add(quiverOptions, 'v', '\thisrow{v}');
+
     if is3D
         quiverOptions = opts_add(quiverOptions, 'w', '\thisrow{w}');
         arrowLength = '{sqrt((\thisrow{u})^2+(\thisrow{v})^2+(\thisrow{w})^2)}';

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4272,33 +4272,6 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
 
     plotOptions = opts_new();
     if showArrowHead
-        plotOptions = opts_add(plotOptions, '-Straight Barb');
-        signalDependency(m2t, 'tikzlibrary', 'arrows.meta');
-    else
-        plotOptions = opts_add(plotOptions, '-');
-    end
-
-    % Append the arrow style to the TikZ options themselves.
-    color = get(h, 'Color');
-    [m2t, lineOptions] = getLineOptions(m2t, h);
-    [m2t, arrowcolor] = getColor(m2t, h, color, 'patch');
-    plotOptions = opts_add(plotOptions, 'color', arrowcolor);
-    plotOptions = opts_merge(plotOptions, lineOptions);
-
-    % Define the quiver settings
-    quiverOptions = opts_new();
-    quiverOptions = opts_add(quiverOptions, 'u', '\thisrow{u}');
-    quiverOptions = opts_add(quiverOptions, 'v', '\thisrow{v}');
-    if is3D
-        quiverOptions = opts_add(quiverOptions, 'w', '\thisrow{w}');
-        arrowLength = '{sqrt((\thisrow{u})^2+(\thisrow{v})^2+(\thisrow{w})^2)}';
-    else
-        arrowLength = '{sqrt((\thisrow{u})^2+(\thisrow{v})^2)}';
-    end
-    plotOptions = opts_add(plotOptions, 'point meta', arrowLength);
-    plotOptions = opts_add(plotOptions, 'point meta min', '0');
-
-    if showArrowHead
         arrowHeadOptions = opts_new();
 
         % In MATLAB (HG1), the arrow head is constructed to have an angle of
@@ -4337,10 +4310,38 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
             ['{' arrowHeadSize '/1000*\pgfplotspointmetatransformed}']);
 
         headStyle = ['-{Straight Barb[' opts_print(arrowHeadOptions) ']}'];
-        quiverOptions = opts_add(quiverOptions, 'every arrow/.append style', ...
-                                 ['{' headStyle '}']);
+        plotOptions = opts_add(plotOptions, headStyle);
+        signalDependency(m2t, 'tikzlibrary', 'arrows.meta');
+    else
+        plotOptions = opts_add(plotOptions, '-');
     end
+
+    % Append the arrow style to the TikZ options themselves.
+    color = get(h, 'Color');
+    [m2t, lineOptions] = getLineOptions(m2t, h);
+    [m2t, arrowcolor] = getColor(m2t, h, color, 'patch');
+    plotOptions = opts_add(plotOptions, 'color', arrowcolor);
+    plotOptions = opts_merge(plotOptions, lineOptions);
+
+    % Define the quiver settings
+    quiverOptions = opts_new();
+    quiverOptions = opts_add(quiverOptions, 'u', '\thisrow{u}');
+    quiverOptions = opts_add(quiverOptions, 'v', '\thisrow{v}');
+    if is3D
+        quiverOptions = opts_add(quiverOptions, 'w', '\thisrow{w}');
+        arrowLength = '{sqrt((\thisrow{u})^2+(\thisrow{v})^2+(\thisrow{w})^2)}';
+    else
+        arrowLength = '{sqrt((\thisrow{u})^2+(\thisrow{v})^2)}';
+    end
+    plotOptions = opts_add(plotOptions, 'point meta', arrowLength);
+    plotOptions = opts_add(plotOptions, 'point meta min', '0');
+
     plotOptions = opts_addSubOpts(plotOptions, 'quiver', quiverOptions);
+
+    % Check whether there is a legend and add a legend image option without scaling
+    if ~isempty(m2t.legendHandles)
+        plotOptions = opts_add(plotOptions, 'legend image post style=-Straight Barb');
+    end
 
     [m2t, table, tableOptions] = makeTable(m2t, variables, data);
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4339,7 +4339,7 @@ function [m2t, str] = drawQuiverGroup(m2t, h)
     plotOptions = opts_addSubOpts(plotOptions, 'quiver', quiverOptions);
 
     % Check whether there is a legend and add a legend image option without scaling
-    if ~isempty(m2t.legendHandles)
+    if m2t.currentHandleHasLegend
         plotOptions = opts_add(plotOptions, 'legend image post style=-Straight Barb');
     end
 

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -787,6 +787,7 @@ function [stat] = quiveroverlap ()
   qvr1 = quiver(x,y,u,v);
   qvr2 = quiver(x,y,2*u,2*v);
   set(qvr2, 'MaxHeadSize', get(qvr1, 'MaxHeadSize')/2);
+  legend({'Normal Headsize', 'Half Headsize'});
 end
 % =========================================================================
 function [stat] = polarplot ()


### PR DESCRIPTION
Currently there is a problem with the scaling of the arrow heads in quiverplots with legend entries. See #931 

To workaround this issue use an unscaled arrowhead in the legend entries. Furthermore rework the way arrowheads are handled to simplify the code.
