### PR TITLE
Manual colorbar location

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -4825,8 +4825,17 @@ function [cbarTemplate, cbarStyleOptions] = getColorbarPosOptions(handle, cbarSt
             cbarStyleOptions = opts_add(cbarStyleOptions,...
                 'xticklabel pos', 'upper');
         case 'southoutside'
-
             cbarTemplate = 'horizontal';
+        case 'manual'
+            cbarTemplate = 'right';
+            origUnits = handle.Units;
+            handle.Units = 'centimeters';
+            cbarStyleOptions = opts_add(cbarStyleOptions, 'at',...
+                sprintf('{(%fcm,%fcm)}',handle.Position(1),...
+                handle.Position(2)+handle.Position(4)));
+            cbarStyleOptions = opts_add(cbarStyleOptions, 'height',...
+                sprintf('%fcm',handle.Position(4)));
+            handle.Units = origUnits;
         otherwise
             error('matlab2tikz:getColorOptions:unknownLocation',...
                 'getColorbarOptions: Unknown ''Location'' %s.', loc)

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -12,6 +12,7 @@ besselImage : c9e844f2df048b1607b72ec69f1d23b3
 bodeplots : 1bd08cfef244b0503acfb386f055e6a3
 clownImage : 6e25e0b1428585a265f0f0154104f198
 colorbarLabelTitle : 0fd51b68a0ed09a5dc45395b1fc7acde
+colorbars : 85c2b3530b67fa69b00adc2439bdf58f
 compassplot : f1c85042737b821724935b86060601f3
 contourPenny : 11b3f1178d9585112b4d40f47a334de0
 croppedImage : d5394d34e1f3fd0fc2d091babe47df5f

--- a/test/suites/ACID.MATLAB.8.4.md5
+++ b/test/suites/ACID.MATLAB.8.4.md5
@@ -12,6 +12,10 @@ besselImage : c9e844f2df048b1607b72ec69f1d23b3
 bodeplots : 1bd08cfef244b0503acfb386f055e6a3
 clownImage : 6e25e0b1428585a265f0f0154104f198
 colorbarLabelTitle : 0fd51b68a0ed09a5dc45395b1fc7acde
+colorbarManualLocationLeftIn : bb700daf0d6bc8c90cd4b0853b279046
+colorbarManualLocationLeftOut : 997bc6b2ccb6e8295c0d8ff3ea1311f7
+colorbarManualLocationRightIn : 97de7befe269b1b1e98035e59cdc3589
+colorbarManualLocationRightOut : 2366d7c07ea5d63c3caf8aadcba3af05
 colorbars : 85c2b3530b67fa69b00adc2439bdf58f
 compassplot : f1c85042737b821724935b86060601f3
 contourPenny : 11b3f1178d9585112b4d40f47a334de0

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -134,7 +134,8 @@ function [status] = ACID(k)
                            @overlappingPlots    , ...
                            @histogramPlot       , ...
                            @alphaTest           , ...
-                           @removeOutsideMarker
+                           @removeOutsideMarker , ...
+                           @colorbars
                          };
 
 
@@ -2740,5 +2741,23 @@ function [stat] = removeOutsideMarker()
   
   % Change the limits back to check result
   xlim([-1, 2]);
+end
+% =========================================================================
+function [stat] = colorbars()
+  stat.description = 'Manual positioning of colorbars';
+  stat.issues      = [933 937];
+
+  shift = [0.2 0.8 0.2 0.8];
+  axLoc = {'in','out','out','in'};
+
+  for iAx = 1:4
+    hAx(iAx) = subplot(2,2,iAx);
+    axPos    = get(hAx(iAx), 'Position');
+    cbPos    = [axPos(1)+shift(iAx)*axPos(3), axPos(2), 0.02, 0.2]; 
+
+    hCb(iAx) = colorbar('Position', cbPos, 'AxisLocation', axLoc{iAx});
+    title(sprintf('AxisLocation = %s', axLoc{iAx}));
+    grid('on');
+  end
 end
 % =========================================================================

--- a/test/suites/ACID.m
+++ b/test/suites/ACID.m
@@ -135,7 +135,11 @@ function [status] = ACID(k)
                            @histogramPlot       , ...
                            @alphaTest           , ...
                            @removeOutsideMarker , ...
-                           @colorbars
+                           @colorbars           , ...
+                           @colorbarManualLocationRightOut , ...
+                           @colorbarManualLocationRightIn  , ...
+                           @colorbarManualLocationLeftOut  , ...
+                           @colorbarManualLocationLeftIn
                          };
 
 
@@ -2759,5 +2763,93 @@ function [stat] = colorbars()
     title(sprintf('AxisLocation = %s', axLoc{iAx}));
     grid('on');
   end
+end
+% =========================================================================
+function [stat] = colorbarManualLocationRightOut()
+  stat.description = 'Manual positioning of colorbars';
+  stat.issues      = [933 937];
+
+  axLoc = 'out'; 
+
+  figure('Units','centimeters','Position',[1,1,11,10]);
+  axPos(1,:) = [1,1,8,3];
+  axPos(2,:) = [1,5,8,3];
+  cbPos      = [9.5,1,0.5,7]; 
+
+  hAx(1) = axes('Units','centimeters','Position',axPos(1,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hAx(2) = axes('Units','centimeters','Position',axPos(2,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hCb = colorbar('Units','centimeters','Position', cbPos,...
+                 'AxisLocation', axLoc);
+  hCb.Label.String = (sprintf('AxisLocation = %s', axLoc));
+end
+% =========================================================================
+function [stat] = colorbarManualLocationRightIn()
+  stat.description = 'Manual positioning of colorbars';
+  stat.issues      = [933 937];
+
+  axLoc = 'in'; 
+
+  figure('Units','centimeters','Position',[1,1,11,10]);
+  axPos(1,:) = [1,1,8,3];
+  axPos(2,:) = [1,5,8,3];
+  cbPos      = [10.5,1,0.5,7]; 
+
+  hAx(1) = axes('Units','centimeters','Position',axPos(1,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hAx(2) = axes('Units','centimeters','Position',axPos(2,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hCb = colorbar('Units','centimeters','Position', cbPos,...
+                 'AxisLocation', axLoc);
+  hCb.Label.String = (sprintf('AxisLocation = %s', axLoc));
+end
+% =========================================================================
+function [stat] = colorbarManualLocationLeftOut()
+  stat.description = 'Manual positioning of colorbars';
+  stat.issues      = [933 937];
+
+  axLoc = 'out'; 
+
+  figure('Units','centimeters','Position',[1,1,11,10]);
+  axPos(1,:) = [2.5,1,8,3];
+  axPos(2,:) = [2.5,5,8,3];
+  cbPos      = [1.5,1,0.5,7]; 
+
+  hAx(1) = axes('Units','centimeters','Position',axPos(1,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hAx(2) = axes('Units','centimeters','Position',axPos(2,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hCb = colorbar('Units','centimeters','Position', cbPos,...
+                 'AxisLocation', axLoc);
+  hCb.Label.String = (sprintf('AxisLocation = %s', axLoc));
+end
+% =========================================================================
+function [stat] = colorbarManualLocationLeftIn()
+  stat.description = 'Manual positioning of colorbars';
+  stat.issues      = [933 937];
+
+  axLoc = 'in'; 
+
+  figure('Units','centimeters','Position',[1,1,11,10]);
+  axPos(1,:) = [2.5,1,8,3];
+  axPos(2,:) = [2.5,5,8,3];
+  cbPos      = [0.5,1,0.5,7]; 
+
+  hAx(1) = axes('Units','centimeters','Position',axPos(1,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hAx(2) = axes('Units','centimeters','Position',axPos(2,:));
+  imagesc([1,2,3],[4,5,6],rand(3),[0,1]);
+
+  hCb = colorbar('Units','centimeters','Position', cbPos,...
+                 'AxisLocation', axLoc);
+  hCb.Label.String = (sprintf('AxisLocation = %s', axLoc));
 end
 % =========================================================================


### PR DESCRIPTION
Hi,
I might have found a solution for manual positioning of colorbars with new Matlab versions, see issue #933.
The (undocumented) `Axes` property of a colobar provides a handle for it's associated axes. Comparing the axes' and the colorbar's posititions along with the `AxisLocation` property, we can decide wheather to use the colorbar template "left" or "right".

The following example works for me:
```
ax = subplot(221);
cb = colorbar('Position',[ax.Position(1)+0.3*ax.Position(3),ax.Position(2),0.02,0.2],...
    'AxisLocation','in');
ax = subplot(222);
cb = colorbar('Position',[ax.Position(1)+0.7*ax.Position(3),ax.Position(2),0.02,0.2],...
    'AxisLocation','in');
ax = subplot(223);
cb = colorbar('Position',[ax.Position(1)+0.3*ax.Position(3),ax.Position(2),0.02,0.2],...
    'AxisLocation','out');
ax = subplot(224);
cb = colorbar('Position',[ax.Position(1)+0.7*ax.Position(3),ax.Position(2),0.02,0.2],...
    'AxisLocation','out');

print -dpng cbLocManual.png
matlab2tikz('cbLocManual.tex','standalone',true)
```

Note that setting colorbar positions manually sets it's `Location` to `manual`. In this case only vertical colorbars are suported in Matlab (Documentation of R2016a).

What do you think?
Cheers, Uli