### PR TITLE
Github issue numbers -> URL in updater changelog

### DIFF
--- a/src/private/m2tUpdater.m
+++ b/src/private/m2tUpdater.m
@@ -212,6 +212,16 @@ function changelog = changelogUntilVersion(currentVersion)
     else
         % Just show the whole changelog if we don't find the old version.
     end
+    changelog = replaceIssuesWithUrls(changelog);
+end
+% ==============================================================================
+function changelog = replaceIssuesWithUrls(changelog)
+% Replaces GitHub issues ("#...") with URLs
+    baseurl = 'https://github.com/matlab2tikz/matlab2tikz/issues/';
+    if strcmpi(getEnvironment(), 'MATLAB')
+        replacement = sprintf('<a href="%s$1">#$1</a>', baseurl);
+        changelog = regexprep(changelog, '\#(\d+)', replacement);
+    end
 end
 % ==============================================================================
 function warnAboutUpgradeImplications(currentVersion, latestVersion, verbose)


### PR DESCRIPTION
This only works in MATLAB, but brings the github issues
within reach of our users.

Re-PR of #957, against develop this time. CI is worthless in this case, since the updater is not covered anyhow.