### PR TITLE
Improve handling of errorbars

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1876,7 +1876,7 @@ function [m2t,str] = plotLine2d(m2t, opts, errorBarOpts, data)
     errorBar = '';
     if errorbarMode
         m2t      = needsPgfplotsVersion(m2t, [1,9]);
-        errorBar = sprintf('plot [error bars/.cd, y dir = both, y explicit,\n%s\n]',...
+        errorBar = sprintf('plot [error bars/.cd, y dir = both, y explicit, %s]\n',...
             errorBarOpts);
     end
 
@@ -2046,24 +2046,27 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
     end
 
     type = getOrDefault(h, 'Type', 'none');
-    %If the current line is of type errorbar
     if strcmp(type, 'errorbar')
-        %Get the 'capSize' size of the errorbar marker and the line width of the
-        %errorbar line.
+        %'capSize' -> errorbar marker size
         capSize = get(h, 'CapSize');
         lineWidth = get(h, 'LineWidth');
-        %Append the 'error bar style' parameter, which determines the style
-        %of the vertical error bar line, to drawOptions
-        drawOptions = opts_add(drawOptions, ...
-            'error bar style', ...
-            sprintf('{line width=%.1fpt}', lineWidth));
 
-        %Append the 'error mark options' parameter, which determines the
-        %style of the error bar 'marker', to drawOptions
-        drawOptions = opts_add(drawOptions, ...
-            'error mark options', ...
-            sprintf('{\nrotate=90,\nmark size=%.1fpt,\nline width=%.1fpt\n}',...
-                capSize, lineWidth));
+        errStyleOptions = opts_new();
+        errStyleOptions = opts_add(errStyleOptions, 'line width',...
+            sprintf('%.1fpt', lineWidth));
+
+        drawOptions = opts_addSubOpts(drawOptions, ...
+            'error bar style', errStyleOptions);
+
+        errMarkOptions = opts_new();
+        errMarkOptions = opts_add(errMarkOptions, 'line width',...
+             sprintf('%.1fpt', lineWidth));
+        errMarkOptions = opts_add(errMarkOptions, 'mark size',...
+             sprintf('%.1fpt', capSize));
+        errMarkOptions = opts_add(errMarkOptions, 'rotate', '90');
+
+        drawOptions = opts_addSubOpts(drawOptions, ...
+            'error mark options', errMarkOptions);
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1796,10 +1796,13 @@ function [m2t, str] = writePlotData(m2t, data, drawOptions)
             %drawOptions
             if (opts_has(drawOptions,'error bar style'))
                 tmpOptions = opts_new();
+                tmpOptions = opts_add(tmpOptions,'error bars/.cd','');
+                tmpOptions = opts_add(tmpOptions,'y dir','both');
+                tmpOptions = opts_add(tmpOptions,'y explicit','');
                 tmpOptions = opts_copy(drawOptions, 'error bar style', tmpOptions);
                 tmpOptions = opts_copy(drawOptions, 'error mark options', tmpOptions);
 
-                errorBarOpts = opts_print(tmpOptions, sprintf(',\n'));
+                errorBarOpts = opts_print(tmpOptions);
 
                 drawOptions = opts_remove(drawOptions, 'error bar style', ...
                     'error mark options');
@@ -1876,8 +1879,7 @@ function [m2t,str] = plotLine2d(m2t, opts, errorBarOpts, data)
     errorBar = '';
     if errorbarMode
         m2t      = needsPgfplotsVersion(m2t, [1,9]);
-        errorBar = sprintf('plot [error bars/.cd, y dir = both, y explicit, %s]\n',...
-            errorBarOpts);
+        errorBar = sprintf('plot [%s]\n', errorBarOpts);
     end
 
     % Convert to string array then cell to call sprintf once (and no loops).
@@ -2048,7 +2050,7 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
     type = getOrDefault(h, 'Type', 'none');
     if strcmp(type, 'errorbar')
         %'capSize' -> errorbar marker size
-        capSize = get(h, 'CapSize');
+        capSize = getOrDefault(h, 'CapSize',get(h,'MarkerSize'));
         lineWidth = get(h, 'LineWidth');
 
         errStyleOptions = opts_new();


### PR DESCRIPTION
Improves handling of Error Bars: it sets 'error bar style' and 'error mark options' appropriately. Solves #960.

Test summary:
In my setup (Matlab 2016b in macOS Sierra) the **untouched**, current (develop da9a24e) version failed in 19 tests:

```
suite = @ACID;
alltests = [1:105];
reliable = [2:5 7:9 11:17 19:23 25:33 35:37 39 41 44:47 50:57 59:77 79:93 95:96 98:105];
unreliable = [1 6 10 18 24 34 38 40 42:43 48:49 58 78 94 97];
failReliable = [8:9 12 20 23 36 45 55:57 61:62 68 70 81:82 95:96 101];
passUnreliable = [34 38 40 49 94 97];
skipped = [17];
```
|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    6 |   10 |    0 |    16 |
|   Reliable |   69 |   19 |    1 |    89 |
|      Total |   75 |   29 |    1 |   105 |
```
Build fails with 19 errors. :heavy_exclamation_mark:
```

My pull request fails (failReliable) in all these and two more no. 74 and no. 37, which both of them include error bar plots, hence they are expected to fail :)
```
suite = @ACID;
alltests = [1:105];
reliable = [2:5 7:9 11:17 19:23 25:33 35:37 39 41 44:47 50:57 59:77 79:93 95:96 98:105];
unreliable = [1 6 10 18 24 34 38 40 42:43 48:49 58 78 94 97];
failReliable = [8:9 12 20 23 36:37 45 55:57 61:62 68 70 74 81:82 95:96 101];
passUnreliable = [34 38 40 49 94 97];
skipped = [17];
```
|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    6 |   10 |    0 |    16 |
|   Reliable |   67 |   21 |    1 |    89 |
|      Total |   73 |   31 |    1 |   105 |
```
Build fails with 21 errors. :heavy_exclamation_mark:
```

Sorry for the big number of fails. Let me know if I have to adjust something in my system configuration and rerun the tests.