### PR TITLE
Fix choice of shader for surface

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3490,7 +3490,7 @@ function [m2t, opts, s] = shaderOptsSurfPatch(m2t, handle, opts, s)
         opts = opts_add(opts,'draw opacity',sprintf(m2t.ff,s.edgeAlpha));
     end
 
-    if isNone(s.edgeColor) % Edge 'none'
+    if isNone(s.edgeColor) || isNone(get(handle,'LineStyle')) % Edge 'none'
         [m2t, opts, s] = shaderOptsSurfPatchEdgeNone(m2t, handle, opts, s);
 
     elseif strcmpi(s.edgeColor, 'interp') % Edge 'interp'
@@ -3509,7 +3509,7 @@ function [m2t, opts, s] = shaderOptsSurfPatchEdgeNone(m2t, handle, opts, s)
     s.hasOneEdgeColor = true; % consider void as true
     if strcmpi(s.faceColor, 'flat')
         opts = opts_add(opts,'shader','flat');
-    elseif strcmpi(s.faceColor, 'interp');
+    elseif strcmpi(s.faceColor, 'interp')
         opts = opts_add(opts,'shader','interp');
     else
         s.hasOneFaceColor = true;


### PR DESCRIPTION
Line style none gets ignored and `shader=interp faceted` is picked, resulting in **wrong image** and very **heavy .pdfs**.

![capture](https://cloud.githubusercontent.com/assets/3731173/21148479/49db9686-c150-11e6-93bc-acc66ede77a5.PNG)

```
h = ribbon(randn(3,1));
set(h,'CData', get(h,'ZData'),'FaceColor','interp','LineStyle','none')
view(0,90)
```
For this example, the size of the pdf is negligible. On other figures, I get figures > 1MB while with the correct `shader=interp` they are reduced to about 100KB, so an **order of magnitude** better!
