### PR TITLE
Fix #963, i.e. datetime ticks in R2016b 

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1602,21 +1602,22 @@ end
 % ==============================================================================
 function isDatetimeTicks = isAxisTicksDateTime(handle, axis)
     % returns true when the axis has DateTime ticks
-    try
-        % If R2016b or above
-        if isa(get(handle, [upper(axis), 'Tick']),'datetime')
-            isDatetimeTicks = true;
-        else
+
+    % If R2016b or above
+    if isa(get(handle, [upper(axis), 'Tick']),'datetime')
+        isDatetimeTicks = true;
+    else
+        try
             % Get hidden properties of the datetime axes manager
             dtsManager = get(handle, 'DatetimeDurationPlotAxesListenersManager');
             oldState   = warning('off','MATLAB:structOnObject');
             dtsManager = struct(dtsManager);
             warning(oldState);
-            
+
             isDatetimeTicks = dtsManager.([upper(axis) 'DateTicks']) == 1;
+        catch
+            isDatetimeTicks = false;
         end
-    catch
-        isDatetimeTicks = false;
     end
 end
 % ==============================================================================

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1844,6 +1844,12 @@ function [data] = getXYZDataFromLine(m2t, h)
         xData = get(h, 'X');
         yData = get(h, 'Y');
     end
+    if isa(xData,'datetime')
+        xData = double(xData);
+    end
+    if isa(yData,'datetime')
+        yData = double(yData);
+    end
     is3D  = m2t.axes{end}.is3D;
     if ~is3D
         data = [xData(:), yData(:)];

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1604,7 +1604,7 @@ function isDatetimeTicks = isAxisTicksDateTime(handle, axis)
     % returns true when the axis has DateTime ticks
 
     % If R2016b or above
-    if isa(get(handle, [upper(axis), 'Tick']),'datetime')
+    if isa(get(handle, [upper(axis), 'Tick']), 'datetime')
         isDatetimeTicks = true;
     else
         try


### PR DESCRIPTION
In R2016b datetime ticks are used directly rather than in just rendering the ticks labels. Convert `datetime` ticks to `datenum`. 

The test for versions below R2016b has still to go through the undocumented property, hence the try catch remains. 

Fixes #963 