### PR TITLE
Only marks for legend consistency

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1734,8 +1734,8 @@ function [m2t, str] = drawLine(m2t, h)
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
 
     % Only marks for legend consistency
-    noLine = opts_has(lineOptions, 'draw') && isNone(opts_get(lineOptions, 'draw'));
-    if ~isempty(markerOptions) && noLine
+    hasNoLine = opts_has(lineOptions, 'draw') && isNone(opts_get(lineOptions, 'draw'));
+    if ~isempty(markerOptions) && hasNoLine
         lineOptions = opts_remove(lineOptions, 'draw');
         lineOptions = opts_add(lineOptions, 'only marks', []);
     end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1733,6 +1733,13 @@ function [m2t, str] = drawLine(m2t, h)
     [m2t, lineOptions]   = getLineOptions(m2t, h);
     [m2t, markerOptions] = getMarkerOptions(m2t, h);
 
+    % Only marks for legend consistency
+    noLine = opts_has(lineOptions, 'draw') && isNone(opts_get(lineOptions, 'draw'));
+    if ~isempty(markerOptions) && noLine
+        lineOptions = opts_remove(lineOptions, 'draw');
+        lineOptions = opts_add(lineOptions, 'only marks', []);
+    end
+
     drawOptions = opts_new();
     drawOptions = opts_add(drawOptions, 'color', xcolor);
     drawOptions = opts_merge(drawOptions, lineOptions, markerOptions);


### PR DESCRIPTION
Fixes #954.

Replace `'draw=none'` with `'only marks'`. when we have markers. 