### PR TITLE
Fix #966 and #970

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -876,11 +876,7 @@ function m2t = drawAxes(m2t, handle)
         m2t = m2t_addAxisOption(m2t, 'point meta max', sprintf(m2t.ff, clim(2)));
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    % Recurse into the children of this environment.
-    [m2t, childrenEnvs] = handleAllChildren(m2t, handle);
-    m2t.axes{end} = addChildren(m2t.axes{end}, childrenEnvs);
-    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    % The rest of this is handling axes options.
+    % Handle axes options.
     % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     % Get other axis options (ticks, axis color, label,...).
     % This is set here such that the axis orientation indicator in m2t is set
@@ -891,7 +887,15 @@ function m2t = drawAxes(m2t, handle)
     m2t.axes{end}.options = opts_merge(m2t.axes{end}.options, xopts, yopts);
 
     m2t = add3DOptionsOfAxes(m2t, handle);
-
+    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    % Recurse into the children of this environment.
+    [m2t, childrenEnvs] = handleAllChildren(m2t, handle);
+    m2t.axes{end} = addChildren(m2t.axes{end}, childrenEnvs);
+    
+    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    % Some more axes options handling.
+    % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
     if ~isVisible(handle)
         % Setting hide{x,y} axis also hides the axis labels in Pgfplots whereas
         % in MATLAB, they may still be visible. Instead use the following.

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1634,12 +1634,13 @@ function num = date2num(date, axis, options)
     % input line [linNumber]." This warning is issued because the numbers
     % returned by datenum() are relatively large compared to the
     % differences in the data vector, e.g. compare:
-    % > data = datenum(datetime + seconds(0:1));
-    % > min(data), range(data)
+    % >> data = datenum(datetime + seconds(0:1));
+    % >> min(data), range(data)
+    % Note that the resulting order difference is about 10^10.
     % 
-    % pgfplots has trouble plotting the small data range relative to the
-    % large data values and issues the warning and alters the plot range,
-    % which messus up the result.
+    % pgfplots may have trouble plotting the small data range relative to
+    % the large data values and issues the warning and alters the plot
+    % range, which messes up the result.
     % 
     % Fix this by subtracting the lowest value from the axis limits,
     % determined in setAxisLimits(), so that it becomes (nearly) zero and

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1631,7 +1631,7 @@ function num = date2num(date, axis, options)
     % Shift the range of date numbers, because pgfplots may otherwise issue
     % a warning: "Package pgfplots Warning: Axis range for axis [x | y | z]
     % is approximately empty; enlarging it (it is [[newMin]:[newMax]]) on
-    % input line [linNumber]." This warning is issued because the numbers
+    % input line [lineNumber]." This warning is issued because the numbers
     % returned by datenum() are relatively large compared to the
     % differences in the data vector, e.g. compare:
     % >> data = datenum(datetime + seconds(0:1));

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1890,10 +1890,10 @@ function [data] = getXYZDataFromLine(m2t, h)
         yData = get(h, 'Y');
     end
     if isa(xData,'datetime')
-        xData = datenum(xData);
+        xData = date2num(xData, 'x', m2t.axes{end}.options);
     end
     if isa(yData,'datetime')
-        yData = datenum(yData);
+        yData = date2num(yData, 'y', m2t.axes{end}.options);
     end
     is3D  = m2t.axes{end}.is3D;
     if ~is3D
@@ -1901,7 +1901,7 @@ function [data] = getXYZDataFromLine(m2t, h)
     else
         zData = get(h, 'ZData');
         if isa(zData,'datetime')
-            zData = datenum(zData);
+            zData = date2num(zData, 'z', m2t.axes{end}.options);
         end
         data = applyHgTransform(m2t, [xData(:), yData(:), zData(:)]);
     end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1625,6 +1625,30 @@ function isDatetimeTicks = isAxisTicksDateTime(handle, axis)
     end
 end
 % ==============================================================================
+function num = date2num(date, axis, options)
+    % Return a double from a datetime, adjusted for limit shift
+    
+    % Shift the range of date numbers, because pgfplots may otherwise issue
+    % a warning: "Package pgfplots Warning: Axis range for axis [x | y | z]
+    % is approximately empty; enlarging it (it is [[newMin]:[newMax]]) on
+    % input line [linNumber]." This warning is issued because the numbers
+    % returned by datenum() are relatively large compared to the
+    % differences in the data vector, e.g. compare:
+    % > data = datenum(datetime + seconds(0:1));
+    % > min(data), range(data)
+    % 
+    % pgfplots has trouble plotting the small data range relative to the
+    % large data values and issues the warning and alters the plot range,
+    % which messus up the result.
+    % 
+    % Fix this by subtracting the lowest value from the axis limits,
+    % determined in setAxisLimits(), so that it becomes (nearly) zero and
+    % all other values are shifted appropriately.
+    
+    shift = str2double(opts_get(options, [axis, 'shift']));
+    num = datenum(date) - shift;
+end
+% ==============================================================================
 function options = setAxisTicks(m2t, options, axis, ticks, tickLabels,hasMinorTicks, tickDir,isDatetimeTicks)
     % set ticks options
 

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1538,7 +1538,7 @@ function [options] = getAxisTicks(m2t, handle, axis, options)
     % hidden properties are not caught by hasProperties
     isDatetimeTicks = isAxisTicksDateTime(handle, axis);
     if isDatetimeTicks
-        ticks = datenum(ticks);
+        ticks = date2num(ticks, axis, options);
     end
 
     if isempty(ticks)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1867,6 +1867,9 @@ function [data] = getXYZDataFromLine(m2t, h)
         data = [xData(:), yData(:)];
     else
         zData = get(h, 'ZData');
+        if isa(zData,'datetime')
+            zData = datenum(zData);
+        end
         data = applyHgTransform(m2t, [xData(:), yData(:), zData(:)]);
     end
 end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1777,7 +1777,7 @@ function [m2t, str] = drawLine(m2t, h)
     end
 
     % build the data matrix
-    data       = getXYZDataFromLine(m2t, h);
+    [m2t, data]       = getXYZDataFromLine(m2t, h);
     yDeviation = getYDeviations(h);
     if ~isempty(yDeviation)
         data = [data, yDeviation];
@@ -1876,11 +1876,12 @@ function [m2t, str] = writePlotData(m2t, data, drawOptions)
     end
 end
 % ==============================================================================
-function [data] = getXYZDataFromLine(m2t, h)
+function [m2t, data] = getXYZDataFromLine(m2t, h)
     % Retrieves the X, Y and Z (if appropriate) data from a Line object
     %
     % First put them all together in one multiarray.
     % This also implicitly makes sure that the lengths match.
+    options = m2t.axes{end}.options;
     try
         xData = get(h, 'XData');
         yData = get(h, 'YData');
@@ -1890,10 +1891,12 @@ function [data] = getXYZDataFromLine(m2t, h)
         yData = get(h, 'Y');
     end
     if isa(xData,'datetime')
-        xData = date2num(xData, 'x', m2t.axes{end}.options);
+        xData = date2num(xData, 'x', options);
+        options = opts_remove(options, 'xshift');
     end
     if isa(yData,'datetime')
-        yData = date2num(yData, 'y', m2t.axes{end}.options);
+        yData = date2num(yData, 'y', options);
+        options = opts_remove(options, 'yshift');
     end
     is3D  = m2t.axes{end}.is3D;
     if ~is3D
@@ -1901,10 +1904,12 @@ function [data] = getXYZDataFromLine(m2t, h)
     else
         zData = get(h, 'ZData');
         if isa(zData,'datetime')
-            zData = date2num(zData, 'z', m2t.axes{end}.options);
+            zData = date2num(zData, 'z', options);
+            options = opts_remove(options, 'zshift');
         end
         data = applyHgTransform(m2t, [xData(:), yData(:), zData(:)]);
     end
+    m2t.axes{end}.options = options;
 end
 % ==============================================================================
 function [m2t, labelCode] = addLabel(m2t, h)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1708,6 +1708,10 @@ function options = setAxisLimits(m2t, handle, axis, options)
     limits = get(handle, [upper(axis),'Lim']);
     if isa(limits,'datetime')
         limits = datenum(limits);
+        % Convert here already to conserve precision
+        limitShift = num2str(min(limits));  
+        limits = limits - str2double(limitShift);
+        options = opts_add(options, [axis, 'shift'], limitShift);
     end
     if isfinite(limits(1))
         options = opts_add(options, [axis,'min'], sprintf(m2t.ff, limits(1)));


### PR DESCRIPTION
I've fixed #966 and attempted to fix #970. However, I have made substantial changes in [4aba476](https://github.com/matlab2tikz/matlab2tikz/commit/4aba476d71b8892c56fdfb21d0ca19b7a2ef93d0) and I don't know whether or not that will break stuff elsewhere in m2t.

I have no experience with testing m2t. I've tried to run the tests, but both resulted in failure. I'd appreciate it if you thoroughly review my code and test it yourselves. Please elaborate on your methods to run the tests and how you come to the conclusion my PR is ok or not. Thanks!

The code from #970 is repeated here:
```matlab
x = datetime(2017, 1, 1) + seconds(0:10);
y = 0:10;
figure
plot(x, y)
matlab2tikz m2t.tex
```
The result with the changes in this PR:
![m2t-6](https://cloud.githubusercontent.com/assets/19374736/21453243/8aede24a-c90d-11e6-8e06-b7fe010f9166.png)
As you can see, the horizontal axis shows the labels correctly positioned, exactly as in the MATLAB figure.

The actual date label is still missing, for which I'll open another issue.