### PR TITLE
Update matlab2tikz.m

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -577,7 +577,7 @@ function str = generateColorDefinitions(colorConfig)
         colorDef = cell(1, length(names));
         for k = 1:length(names)
             % Append with '%' to avoid spacing woes in LaTeX
-            FORMAT      = ['\\definecolor{%s}{rgb}{' ff ',' ff ',' ff '}%%\n'];
+            FORMAT      = ['\\providecolor{%s}{rgb}{' ff ',' ff ',' ff '}%%\n'];
             colorDef{k} = sprintf(FORMAT, names{k}, specs{k});
         end
         str = m2tstrjoin([colorDef, sprintf('%%\n')], '');


### PR DESCRIPTION
The xcolor package defines the macro \providecolor in addition to \definecolor.  I think the former is preferable for matlab2tikz's 'extraColors' feature because it allows the resulting figures to be controllable by a (single) master .tex file.  For example, I might create a few figures with the extra color "velocityColor," and then in doc1 want all velocities to be redish, but in a doc2 want them all to be blueish.  If matlab2tikz uses \providecommand, I can set this using a single command in each of the docs, rather than having to change all the figure files for each document--even perhaps changing the color format:

\definecolor{velocityColor}{cmyk}{0,0.50,0.40,0}

\definecolor{velocityColor}{cmyk}{0.50,0.15,0,0}

The price is the xcolor package, which (as far as I know) wasn't previously required by matlab2tikz.