### PR TITLE
Fix a bug in isAxisMain()

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1229,7 +1229,12 @@ function bool = isAxisMain(h)
             bool       = find(plotyyAxes == h) == 1;
 
         case 'MATLAB'
-            bool = ~isempty(getappdata(h, 'LegendPeerHandle'));
+            % LegendPeerHandle was renamed to LayoutPeers in 9.1 (R2016b)
+            if verLessThan('matlab', '9.1')
+                bool = ~isempty(getappdata(h, 'LegendPeerHandle'));
+            else
+                bool = ~isempty(getappdata(h, 'LayoutPeers'));
+            end
     end
 end
 % ==============================================================================


### PR DESCRIPTION
Hello!

In MATLAB R2016b the LegendPeerHandle appdata field was renamed to
LayoutPeers (I think it is undocumented, the info comes from the docs
of this third party toolbox: ttp://rosa.unipr.it/FSDA/release_notes.html).

I added a version check to ensure that the correct field name is used on
recent MATLAB versions.