### PR TITLE
fix lineOpts for 'only marks'

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1940,6 +1940,7 @@ function [m2t, lineOpts] = getLineOptions(m2t, h)
     % print no lines
     if isNone(lineStyle) || lineWidth==0
         lineOpts = opts_add(lineOpts, 'draw', 'none');
+        lineOpts = opts_add(lineOpts, 'only marks');
     end
 end
 % ==============================================================================


### PR DESCRIPTION
Using Matlab 2018a and TeX 3.14159265 (TeX Live 2018) I was trying to add a legend entry with a simple 'ko' plot style in Matlab.  The the legend was showing up in the LaTeX document as if I had specified 'ko-', even though the plot was draw correctly.  Here is a snippet of the matlab2tikz file and the resulting plot.
```
\addplot [color=black, line width=0.5pt, draw=none, 
mark size=4.0pt, mark=o, mark options={solid, black}]
  table[row sep=crcr]{%
0	0.0487081835554879\\
};
\addlegendentry{Filtered CBC data}
```
![screen shot 2018-05-09 at 11 36 55 am](https://user-images.githubusercontent.com/4418497/39824431-4e83682e-537d-11e8-98ea-e7fa0969e8a1.png)

Adding `'only marks'` to the lineOpts seemed to fix the problem.  Here is new tikz file and resulting plot.
```
\addplot [color=black, line width=0.5pt, draw=none, only marks, mark size=4.0pt, mark=o, mark options={solid, black}]
  table[row sep=crcr]{%
0	0.0487081835554879\\
};
\addlegendentry{Filtered CBC data}
```
![screen shot 2018-05-09 at 11 39 12 am](https://user-images.githubusercontent.com/4418497/39824558-a8e4806e-537d-11e8-8ae3-e44e884143c4.png)
