### PR TITLE
Fix for GNU/Octave not including legends

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1048,17 +1048,25 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
     % Get legend handle associated with current axis
 
     legendhandle = [];
-    env = getEnvironment();
+    [env, envVersion] = getEnvironment();
     switch env
         case 'Octave'
             % Make sure that m2t.legendHandles is a row vector.
             for lhandle = m2t.legendHandles(:)'
-                ud = get(lhandle, '__appdata__');
+                if isVersionBelow(envVersion, [4,2,2]) % 5865d2fef424
+                  lhandleProp{1}='UserData';
+                  lhandleProp{2}='handle';
+                else
+                  lhandleProp{1}='__appdata__';
+                  lhandleProp{2}='__axes_handle__';
+                end
+                ud = get(lhandle, lhandleProp{1});
                 % Empty if no legend and multiple handles if plotyy
-                if ~isempty(ud) && any(axisHandle == ud.__axes_handle__)
+                if ~isempty(ud) && any(axisHandle == ud.(lhandleProp{2}))
                     legendhandle = lhandle;
                     break
                 end
+                clear lhandleProp
             end
         case 'MATLAB'
             legendhandle = legend(axisHandle);

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1053,9 +1053,9 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
         case 'Octave'
             % Make sure that m2t.legendHandles is a row vector.
             for lhandle = m2t.legendHandles(:)'
-                ud = get(lhandle, 'UserData');
+                ud = get(lhandle, '__appdata__');
                 % Empty if no legend and multiple handles if plotyy
-                if ~isempty(ud) && any(axisHandle == ud.handle)
+                if ~isempty(ud) && any(axisHandle == ud.__axes_handle__)
                     legendhandle = lhandle;
                     break
                 end

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1053,7 +1053,7 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
         case 'Octave'
             % Make sure that m2t.legendHandles is a row vector.
             for lhandle = m2t.legendHandles(:)'
-                if isVersionBelow(envVersion, [4,2,2]) % 5865d2fef424
+                if isVersionBelow(envVersion, [4,2,2]) % Octave commit 5865d2fef424
                   lhandleProp{1}='UserData';
                   lhandleProp{2}='handle';
                 else

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1066,7 +1066,6 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
                     legendhandle = lhandle;
                     break
                 end
-                clear lhandleProp
             end
         case 'MATLAB'
             legendhandle = legend(axisHandle);


### PR DESCRIPTION
Using matlab2tikz in GNU/Octave 4.4.1 would not produce legends in the tikz code.