### PR TITLE
Fix for GNU/Octave not including legends

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1053,9 +1053,16 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
         case 'Octave'
             % Make sure that m2t.legendHandles is a row vector.
             for lhandle = m2t.legendHandles(:)'
-                ud = get(lhandle, 'UserData');
+                if isVersionBelow(envVersion, [4,2,2]) % Octave commit 5865d2fef424
+                  lhandleProp{1}='UserData';
+                  lhandleProp{2}='handle';
+                else
+                  lhandleProp{1}='__appdata__';
+                  lhandleProp{2}='__axes_handle__';
+                end
+                ud = get(lhandle, lhandleProp{1});
                 % Empty if no legend and multiple handles if plotyy
-                if ~isempty(ud) && any(axisHandle == ud.handle)
+                if ~isempty(ud) && any(axisHandle == ud.(lhandleProp{2}))
                     legendhandle = lhandle;
                     break
                 end


### PR DESCRIPTION
Same as https://github.com/matlab2tikz/matlab2tikz/pull/1048 but for the develop branch.