### PR TITLE
add support for normalized units in Matlab figures

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -6006,6 +6006,12 @@ function dstValue = convertUnits(srcValue, srcUnit, dstUnit)
         return % conversion to the same unit => factor = 1
     end
 
+    if strcmp(srcUnit, 'normalized')
+        srcUnit = 'px';
+        monitorSize = get(0, 'MonitorPositions');
+        srcValue = srcValue .* monitorSize(1, 3:4);
+    end
+
     units  = {srcUnit, dstUnit};
     factor = ones(1,2);
     for ii = 1:numel(factor) % Same code for srcUnit and dstUnit


### PR DESCRIPTION
This PR should solve #819 and #340.

I ran the tests using runMatlab2TikzTests and got the same output as the one in the develop branch:

```
|            | Pass | Fail | Skip | Total |
| :--------- | ---: | ---: | ---: | ----: |
| Unreliable |    2 |   13 |    0 |    15 |
|   Reliable |   45 |   44 |    1 |    90 |
|      Total |   47 |   57 |    1 |   105 |
```