### PR TITLE
Prevent extra legend labels in newer MATLAB

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1068,7 +1068,7 @@ function legendhandle = getAssociatedLegend(m2t, axisHandle)
                 end
             end
         case 'MATLAB'
-            legendhandle = legend(axisHandle);
+            legendhandle = axisHandle.Legend;
     end
 
     % NOTE: there is a BUG in HG1 and Octave. Setting the box off sets the


### PR DESCRIPTION
MATLAB 2017a changed the default behavior of how legends work:
https://www.mathworks.com/help/matlab/release-notes.html?rntext=legend&startrelease=R2017a&endrelease=R2017a&category=Graphics&groupby=release&sortby=descending&searchHighlight=legend

That results in a bug where plots without legends get one generated anyway and the legend labels get filled in with names like "data1" and "data2", etc. That's been documented as bug #1056 ; this should fix that and close out the bug.