### PR TITLE
Bugfix: plotting text in logarithmic scale (Closes #986)

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3722,7 +3722,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
 
         if numel(dataInfo.Size) == 1
             drawOptions = opts_add(drawOptions, 'mark size', ...
-                sprintf('%.4fpt', dataInfo.Size)); % FIXME: investigate whether to use `m2t.ff` 
+                sprintf('%.4fpt', dataInfo.Size)); % FIXME: investigate whether to use `m2t.ff`
         else
             %TODO: warn the user about this. It is not currently supported.
         end
@@ -4840,11 +4840,11 @@ function [cbarTemplate, cbarStyleOptions] = getColorbarPosOptions(handle, cbarSt
             end
 
             % Using positions relative to associated axes
-            calcRelPos = @(pos1,pos2,ext2) (pos1-pos2)/ext2; 
+            calcRelPos = @(pos1,pos2,ext2) (pos1-pos2)/ext2;
             cbarRelPosX = calcRelPos(cbarDim.left,cbarAxesDim.left,cbarAxesDim.width);
             cbarRelPosY = calcRelPos(cbarDim.bottom,cbarAxesDim.bottom,cbarAxesDim.height);
             cbarRelHeight = cbarDim.height/cbarAxesDim.height;
-            
+
             cbarStyleOptions = opts_add(cbarStyleOptions, 'anchor',...
                 'south west');
             cbarStyleOptions = opts_add(cbarStyleOptions, 'at',...
@@ -6696,8 +6696,6 @@ function str = formatDim(value, unit)
     if ~exist('unit','var') || isempty(unit)
         unit = '';
     end
-    tolerance = 1e-7;
-    value  = round(value/tolerance)*tolerance;
     if value == 1 && ~isempty(unit) && unit(1) == '\'
         str = unit; % just use the unit
     else
@@ -6705,7 +6703,7 @@ function str = formatDim(value, unit)
         % but such accuracy is overkill for positioning. We clip to three
         % decimals to overcome numerical rounding issues that tend to be very
         % platform and version dependent. See also #604.
-        str = sprintf('%.3f', value);
+        str = sprintf('%.3e', value);
         str = regexprep(str, '(\d*\.\d*?)0+$', '$1'); % remove trailing zeros
         str = regexprep(str, '\.$', ''); % remove trailing period
         str = [str unit];


### PR DESCRIPTION
As described in the related issue; plotting text in logarithmic scale results in the text position being mapped to zero if the magnitude is less than 10^-3