### PR TITLE
Plotting of text in logarithmic scale (Closes #986)

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3722,7 +3722,7 @@ function [m2t, str] = drawScatterPlot(m2t, h)
 
         if numel(dataInfo.Size) == 1
             drawOptions = opts_add(drawOptions, 'mark size', ...
-                sprintf('%.4fpt', dataInfo.Size)); % FIXME: investigate whether to use `m2t.ff` 
+                sprintf('%.4fpt', dataInfo.Size)); % FIXME: investigate whether to use `m2t.ff`
         else
             %TODO: warn the user about this. It is not currently supported.
         end
@@ -4840,11 +4840,11 @@ function [cbarTemplate, cbarStyleOptions] = getColorbarPosOptions(handle, cbarSt
             end
 
             % Using positions relative to associated axes
-            calcRelPos = @(pos1,pos2,ext2) (pos1-pos2)/ext2; 
+            calcRelPos = @(pos1,pos2,ext2) (pos1-pos2)/ext2;
             cbarRelPosX = calcRelPos(cbarDim.left,cbarAxesDim.left,cbarAxesDim.width);
             cbarRelPosY = calcRelPos(cbarDim.bottom,cbarAxesDim.bottom,cbarAxesDim.height);
             cbarRelHeight = cbarDim.height/cbarAxesDim.height;
-            
+
             cbarStyleOptions = opts_add(cbarStyleOptions, 'anchor',...
                 'south west');
             cbarStyleOptions = opts_add(cbarStyleOptions, 'at',...
@@ -6696,8 +6696,6 @@ function str = formatDim(value, unit)
     if ~exist('unit','var') || isempty(unit)
         unit = '';
     end
-    tolerance = 1e-7;
-    value  = round(value/tolerance)*tolerance;
     if value == 1 && ~isempty(unit) && unit(1) == '\'
         str = unit; % just use the unit
     else
@@ -6705,7 +6703,7 @@ function str = formatDim(value, unit)
         % but such accuracy is overkill for positioning. We clip to three
         % decimals to overcome numerical rounding issues that tend to be very
         % platform and version dependent. See also #604.
-        str = sprintf('%.3f', value);
+        str = sprintf('%.3e', value);
         str = regexprep(str, '(\d*\.\d*?)0+$', '$1'); % remove trailing zeros
         str = regexprep(str, '\.$', ''); % remove trailing period
         str = [str unit];

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3360,7 +3360,7 @@ function [m2t,posString] = getPositionOfText(m2t, h)
     end
     posString = cell(1,npos);
     for ii = 1:npos
-        posString{ii} = formatDim(pos(ii), fmtUnit);
+        posString{ii} = formatDim(pos(ii), fmtUnit, true);
     end
 
     posString = sprintf('(%s%s)',type,join(m2t,posString,','));
@@ -6691,7 +6691,10 @@ function str = formatAspectRatio(m2t, values)
     str = join(m2t, strs, ' ');
 end
 % ==============================================================================
-function str = formatDim(value, unit)
+function str = formatDim(value, unit, exp_notation)
+    if nargin < 3
+      exp_notation = false;
+    end
     % format the value for use as a TeX dimension
     if ~exist('unit','var') || isempty(unit)
         unit = '';
@@ -6703,7 +6706,11 @@ function str = formatDim(value, unit)
         % but such accuracy is overkill for positioning. We clip to three
         % decimals to overcome numerical rounding issues that tend to be very
         % platform and version dependent. See also #604.
-        str = sprintf('%.3e', value);
+        if exp_notation
+          str = sprintf('%.3e', value);
+        else
+          str = sprintf('%.3f', value);
+        end
         str = regexprep(str, '(\d*\.\d*?)0+$', '$1'); % remove trailing zeros
         str = regexprep(str, '\.$', ''); % remove trailing period
         str = [str unit];


### PR DESCRIPTION
As described in issue #986, plotting text in logarithmic scale can yield undesired effects. E.g.
`text(0.5, 1E-8, 'hi')` results in 'hi' placed at (0.5, 0) since 
https://github.com/matlab2tikz/matlab2tikz/blob/62a038d9833d4d48581acb630da550e40799338f/src/matlab2tikz.m#L6700
results in value = 0.
If value was 1E-6, then this line would not change value, but
https://github.com/matlab2tikz/matlab2tikz/blob/62a038d9833d4d48581acb630da550e40799338f/src/matlab2tikz.m#L6708
would still print the string '0'. 