### PR TITLE
Enable to configure mark size explicitly

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -76,6 +76,9 @@ function matlab2tikz(varargin)
     %   MATLAB2TIKZ('extraTikzpictureOptions',CHAR or CELLCHAR,...)
     %   explicitly adds extra options to the tikzpicture environment. (default: [])
     %
+    %   MATLAB2TIKZ('markerSize', CHAR, ...)
+    %   explicitly specify a speicific 'mark size' to 'mark options={}'. (default: '')
+    %
     %   MATLAB2TIKZ('encoding',CHAR,...) sets the encoding of the output file.
     %
     %   MATLAB2TIKZ('floatFormat',CHAR,...) sets the format used for float values.
@@ -203,6 +206,7 @@ function matlab2tikz(varargin)
     ipp = ipp.addParamValue(ipp, 'extraCodeAtEnd', {}, @isCellOrChar);
     ipp = ipp.addParamValue(ipp, 'extraAxisOptions', {}, @isCellOrChar);
     ipp = ipp.addParamValue(ipp, 'extraTikzpictureOptions', {}, @isCellOrChar);
+    ipp = ipp.addParamValue(ipp, 'markerSize', {}, @ischar);
     ipp = ipp.addParamValue(ipp, 'floatFormat', '%.15g', @ischar);
     ipp = ipp.addParamValue(ipp, 'automaticLabels', false, @islogical);
     ipp = ipp.addParamValue(ipp, 'addLabels', false, @islogical);
@@ -2003,6 +2007,8 @@ function [m2t, drawOptions] = getMarkerOptions(m2t, h)
         if m2t.args.strict || ~isDefault
             drawOptions = opts_add(drawOptions, 'mark size', ...
                                    sprintf('%.1fpt', tikzMarkerSize));
+        elseif ~isNone(m2t.args.markerSize)
+            drawOptions = opts_add(drawOptions, 'mark size', m2t.args.markerSize);
         end
 
         markOptions = opts_new();


### PR DESCRIPTION
This enables me to make these plots:

![Screenshot from 2020-08-17 20-50-02](https://user-images.githubusercontent.com/10998835/90427507-25ba7a80-e0b2-11ea-92eb-7120a4e2e8ef.png)

Look like this:

![Screenshot from 2020-08-17 20-51-37](https://user-images.githubusercontent.com/10998835/90427631-526e9200-e0b2-11ea-8fb1-1c0ae6a48336.png)

Without doing this hacky thing after I run `matlab2tikz`:

```matlab
	fid = fopen(plot_fname,'r');
	f=fread(fid,'*char')';
	fclose(fid);
	fid = fopen(plot_fname,'w');
	fprintf(fid,'%s',regexprep(f,'mark options={solid, ','mark options={solid,  mark size=0.4pt, '));
	fclose(fid);

```

-----

My dearest thank you, for creating matlab2tikz, it's impressively built and it has made me proud of my lab reports.

Regards.