### PR TITLE
Restore compatibility with Octave 6.x or newer

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1132,9 +1132,14 @@ function entries = getLegendEntries(m2t)
 
     switch getEnvironment()
         case 'Octave'
-            % See set(hlegend, "deletefcn", {@deletelegend2, ca, [], [], t1, hplots}); in legend.m
-            delfun  = get(legendHandle,'deletefcn');
-            entries = delfun{6};
+            if isappdata(legendHandle,'__peer_objects__')
+                % Octave version 6.x or newer with refactored legend
+                entries = getappdata(legendHandle,'__peer_objects__')
+            else
+                % See set(hlegend, "deletefcn", {@deletelegend2, ca, [], [], t1, hplots}); in legend.m
+                delfun  = get(legendHandle,'deletefcn');
+                entries = delfun{6};
+            end
 
             % Bubble-up legend entry properties from child to hggroup root
             % for guessable objects


### PR DESCRIPTION
The implementation of `legend` was completely overhauled for Octave 6.x. Implementation details have changed.
That causes `matlab2tikz` to fail with these versions of Octave.

The proposed code still uses undocumented implementation details that might change in the future. But I don't know of a documented way to get that information.

See also this bug reported on Octave's bug tracker:
https://savannah.gnu.org/bugs/?61352

I haven't tested these changes myself. But @AndreasStahel reported the updated code works for him.