### PR TITLE
Fix arrow and doublearrow annotation not being drawn in final output

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -715,6 +715,12 @@ function [m2t, pgfEnvironments] = handleAllChildren(m2t, h)
 
             case 'rectangle'
                 [m2t, str] = handleObject(m2t, child, @drawRectangle);
+		
+	    case 'doubleendarrowshape'
+                [m2t, str] = handleObject(m2t, child, @drawArrow);
+	
+	    case 'arrowshape'
+                [m2t, str] = handleObject(m2t, child, @drawArrow);
 
             case 'histogram'
                 [m2t, str] = handleObject(m2t, child, @drawHistogram);


### PR DESCRIPTION
Added support for "arrowshape" and "doubleendarrowshape" type objects in handleAllChildren fcn