### PR TITLE
Fix text positioning

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3580,6 +3580,8 @@ function [style] = getXYAlignmentOfText(handle, style)
 
     % Set 'align' option that is needed for multiline text
     style = opts_add(style, 'align', HorizontalAlignment);
+    
+    style = opts_add(style, 'inner sep', '0');
 end
 % ==============================================================================
 function [style] = getRotationOfText(m2t, handle, style)

--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -3570,6 +3570,10 @@ function [style] = getXYAlignmentOfText(handle, style)
             horizontal = 'left';
     end
     alignment = strtrim(sprintf('%s %s', vertical, horizontal));
+    if strcmp(VerticalAlignment, 'middle') && strcmp(HorizontalAlignment, 'center')
+        alignment = 'centered';
+    end
+    
     if ~isempty(alignment)
         style = opts_add(style, alignment);
     end


### PR DESCRIPTION
This is an updated version of https://github.com/matlab2tikz/matlab2tikz/pull/1060.

Consider the following Matlab and Tex files:

```Matlab
valign = {'base', 'bottom', 'middle', 'cap', 'top'};
halign = {'left', 'center', 'right'};

figure;
hold on;
ylim([0, 4]);
xlim([0, 6]);
for jj = 1:length(valign)
    for kk = 1:length(halign)
        plot(jj, kk, 'x', 'MarkerSize', 10, 'Linewidth', 2);
        text(jj, kk, 'Matlab', 'HorizontalAlignment', halign{kk}, 'VerticalAlignment', valign{jj});
    end
end
set(gca, 'XTick', 1:length(valign));
set(gca, 'XTickLabels', valign);
xlabel('Vertical Alignment');
set(gca, 'YTick', 1:length(halign));
set(gca, 'YTickLabels', halign);
ylabel('Horizontal alignment');
box on;

matlab2tikz('textPosition.tikz');

```

```Latex
\documentclass[]{standalone}
\usepackage{pgfplots}
\pgfplotsset{compat=newest}
\begin{document}
  \begin{tikzpicture}
    \node[anchor=north west] (text2) at (0,0) {
      \input{textPosition.tikz}
    };
  \end{tikzpicture}
\end{document}
```

The Matlab script produces a plot that looks like this:
![Matlab](https://user-images.githubusercontent.com/2496460/216558612-cb070799-1c1a-43cd-8f63-b6ee8448eaf5.png)


Using the current master version of matlab2tikz you get this `tikz` file:

```tikz
% This file was created by matlab2tikz.
%
%The latest updates can be retrieved from
%  http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz
%where you can also make suggestions and rate matlab2tikz.
%
\definecolor{mycolor1}{rgb}{0.00000,0.44700,0.74100}%
\definecolor{mycolor2}{rgb}{0.85000,0.32500,0.09800}%
\definecolor{mycolor3}{rgb}{0.92900,0.69400,0.12500}%
\definecolor{mycolor4}{rgb}{0.49400,0.18400,0.55600}%
\definecolor{mycolor5}{rgb}{0.46600,0.67400,0.18800}%
\definecolor{mycolor6}{rgb}{0.30100,0.74500,0.93300}%
\definecolor{mycolor7}{rgb}{0.63500,0.07800,0.18400}%
%
\begin{tikzpicture}

\begin{axis}[%
width=4.521in,
height=3.566in,
at={(0.758in,0.481in)},
scale only axis,
xmin=0,
xmax=6,
xtick={1,2,3,4,5},
xticklabels={{base},{bottom},{middle},{cap},{top}},
xlabel style={font=\color{white!15!black}},
xlabel={Vertical Alignment},
ymin=0,
ymax=4,
ytick={1,2,3},
yticklabels={{left},{center},{right}},
ylabel style={font=\color{white!15!black}},
ylabel={Horizontal alignment},
axis background/.style={fill=white}
]
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
1	1\\
};
\node[above right, align=left]
at (axis cs:1,1) {Matlab};
\addplot [color=mycolor2, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor2}, forget plot]
  table[row sep=crcr]{%
1	2\\
};
\node[above, align=center]
at (axis cs:1,2) {Matlab};
\addplot [color=mycolor3, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor3}, forget plot]
  table[row sep=crcr]{%
1	3\\
};
\node[above left, align=right]
at (axis cs:1,3) {Matlab};
\addplot [color=mycolor4, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor4}, forget plot]
  table[row sep=crcr]{%
2	1\\
};
\node[above right, align=left]
at (axis cs:2,1) {Matlab};
\addplot [color=mycolor5, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor5}, forget plot]
  table[row sep=crcr]{%
2	2\\
};
\node[above, align=center]
at (axis cs:2,2) {Matlab};
\addplot [color=mycolor6, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor6}, forget plot]
  table[row sep=crcr]{%
2	3\\
};
\node[above left, align=right]
at (axis cs:2,3) {Matlab};
\addplot [color=mycolor7, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor7}, forget plot]
  table[row sep=crcr]{%
3	1\\
};
\node[right, align=left]
at (axis cs:3,1) {Matlab};
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
3	2\\
};
\node[align=center]
at (axis cs:3,2) {Matlab};
\addplot [color=mycolor2, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor2}, forget plot]
  table[row sep=crcr]{%
3	3\\
};
\node[left, align=right]
at (axis cs:3,3) {Matlab};
\addplot [color=mycolor3, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor3}, forget plot]
  table[row sep=crcr]{%
4	1\\
};
\node[below right, align=left]
at (axis cs:4,1) {Matlab};
\addplot [color=mycolor4, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor4}, forget plot]
  table[row sep=crcr]{%
4	2\\
};
\node[below, align=center]
at (axis cs:4,2) {Matlab};
\addplot [color=mycolor5, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor5}, forget plot]
  table[row sep=crcr]{%
4	3\\
};
\node[below left, align=right]
at (axis cs:4,3) {Matlab};
\addplot [color=mycolor6, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor6}, forget plot]
  table[row sep=crcr]{%
5	1\\
};
\node[below right, align=left]
at (axis cs:5,1) {Matlab};
\addplot [color=mycolor7, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor7}, forget plot]
  table[row sep=crcr]{%
5	2\\
};
\node[below, align=center]
at (axis cs:5,2) {Matlab};
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
5	3\\
};
\node[below left, align=right]
at (axis cs:5,3) {Matlab};
\end{axis}
\end{tikzpicture}%
```

which renders to a PDF that looks like this:
![textPosition_old](https://user-images.githubusercontent.com/2496460/216558895-515c3497-7e63-49d4-9635-95a1c6cb4492.png)

Notice that the text in the center (options center, middle) is not correctly positioned (shifted to the right) and there is spacing between the text and the crosses.

With this PR in place you get 

```tikz
% This file was created by matlab2tikz.
%
%The latest updates can be retrieved from
%  http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz
%where you can also make suggestions and rate matlab2tikz.
%
\definecolor{mycolor1}{rgb}{0.00000,0.44700,0.74100}%
\definecolor{mycolor2}{rgb}{0.85000,0.32500,0.09800}%
\definecolor{mycolor3}{rgb}{0.92900,0.69400,0.12500}%
\definecolor{mycolor4}{rgb}{0.49400,0.18400,0.55600}%
\definecolor{mycolor5}{rgb}{0.46600,0.67400,0.18800}%
\definecolor{mycolor6}{rgb}{0.30100,0.74500,0.93300}%
\definecolor{mycolor7}{rgb}{0.63500,0.07800,0.18400}%
%
\begin{tikzpicture}

\begin{axis}[%
width=4.521in,
height=3.566in,
at={(0.758in,0.481in)},
scale only axis,
xmin=0,
xmax=6,
xtick={1,2,3,4,5},
xticklabels={{base},{bottom},{middle},{cap},{top}},
xlabel style={font=\color{white!15!black}},
xlabel={Vertical Alignment},
ymin=0,
ymax=4,
ytick={1,2,3},
yticklabels={{left},{center},{right}},
ylabel style={font=\color{white!15!black}},
ylabel={Horizontal alignment},
axis background/.style={fill=white}
]
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
1	1\\
};
\node[above right, align=left, inner sep=0]
at (axis cs:1,1) {Matlab};
\addplot [color=mycolor2, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor2}, forget plot]
  table[row sep=crcr]{%
1	2\\
};
\node[above, align=center, inner sep=0]
at (axis cs:1,2) {Matlab};
\addplot [color=mycolor3, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor3}, forget plot]
  table[row sep=crcr]{%
1	3\\
};
\node[above left, align=right, inner sep=0]
at (axis cs:1,3) {Matlab};
\addplot [color=mycolor4, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor4}, forget plot]
  table[row sep=crcr]{%
2	1\\
};
\node[above right, align=left, inner sep=0]
at (axis cs:2,1) {Matlab};
\addplot [color=mycolor5, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor5}, forget plot]
  table[row sep=crcr]{%
2	2\\
};
\node[above, align=center, inner sep=0]
at (axis cs:2,2) {Matlab};
\addplot [color=mycolor6, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor6}, forget plot]
  table[row sep=crcr]{%
2	3\\
};
\node[above left, align=right, inner sep=0]
at (axis cs:2,3) {Matlab};
\addplot [color=mycolor7, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor7}, forget plot]
  table[row sep=crcr]{%
3	1\\
};
\node[right, align=left, inner sep=0]
at (axis cs:3,1) {Matlab};
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
3	2\\
};
\node[centered, align=center, inner sep=0]
at (axis cs:3,2) {Matlab};
\addplot [color=mycolor2, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor2}, forget plot]
  table[row sep=crcr]{%
3	3\\
};
\node[left, align=right, inner sep=0]
at (axis cs:3,3) {Matlab};
\addplot [color=mycolor3, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor3}, forget plot]
  table[row sep=crcr]{%
4	1\\
};
\node[below right, align=left, inner sep=0]
at (axis cs:4,1) {Matlab};
\addplot [color=mycolor4, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor4}, forget plot]
  table[row sep=crcr]{%
4	2\\
};
\node[below, align=center, inner sep=0]
at (axis cs:4,2) {Matlab};
\addplot [color=mycolor5, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor5}, forget plot]
  table[row sep=crcr]{%
4	3\\
};
\node[below left, align=right, inner sep=0]
at (axis cs:4,3) {Matlab};
\addplot [color=mycolor6, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor6}, forget plot]
  table[row sep=crcr]{%
5	1\\
};
\node[below right, align=left, inner sep=0]
at (axis cs:5,1) {Matlab};
\addplot [color=mycolor7, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor7}, forget plot]
  table[row sep=crcr]{%
5	2\\
};
\node[below, align=center, inner sep=0]
at (axis cs:5,2) {Matlab};
\addplot [color=mycolor1, line width=2.0pt, only marks, mark size=5.0pt, mark=x, mark options={solid, mycolor1}, forget plot]
  table[row sep=crcr]{%
5	3\\
};
\node[below left, align=right, inner sep=0]
at (axis cs:5,3) {Matlab};
\end{axis}
\end{tikzpicture}%
``` 

which results in this PDF. The center, middle text is positioning correctly and the text is closer to the crosses
![textPosition_new](https://user-images.githubusercontent.com/2496460/216559198-95a0db3a-03ab-46c1-b4c9-503d93fb59d7.png)

