### PR TITLE
Implement horizontal error bars

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -1974,31 +1974,27 @@ function [m2t, labelCode] = addLabel(m2t, h)
 end
 % ==============================================================================
 function [m2t,str] = plotLine2d(m2t, opts, errorBarOpts, data, errDir)
-    errorbarModeX = strcmp(errDir, 'x'); % is (optional) xDeviation given?
-    errorbarModeY = strcmp(errDir, 'y'); % is (optional) yDeviation given?
-    errorbarModeXY = strcmp(errDir, 'xy'); % are (optional) both xDeviation and yDeviation given?
 
     errorBar = '';
-    if errorbarModeX || errorbarModeY || errorbarModeXY
+    if ~isempty(errDir)
         m2t      = needsPgfplotsVersion(m2t, [1,9]);
         errorBar = sprintf('plot [%s]\n', errorBarOpts);
     end
 
     % Convert to string array then cell to call sprintf once (and no loops).
     [m2t, table, tableOptions] = makeTable(m2t, repmat({''}, size(data,2)), data);
-    if errorbarModeX
-        tableOptions = opts_add(tableOptions, 'x error plus index', '2');
-        tableOptions = opts_add(tableOptions, 'x error minus index', '3');
-    end
-    if errorbarModeY
-        tableOptions = opts_add(tableOptions, 'y error plus index', '2');
-        tableOptions = opts_add(tableOptions, 'y error minus index', '3');
-    end
-    if errorbarModeXY
-        tableOptions = opts_add(tableOptions, 'x error plus index', '2');
-        tableOptions = opts_add(tableOptions, 'x error minus index', '3');
-        tableOptions = opts_add(tableOptions, 'y error plus index', '4');
-        tableOptions = opts_add(tableOptions, 'y error minus index', '5');
+    switch errDir
+        case 'x'
+            tableOptions = opts_add(tableOptions, 'x error plus index', '2');
+            tableOptions = opts_add(tableOptions, 'x error minus index', '3');
+        case 'y'
+            tableOptions = opts_add(tableOptions, 'y error plus index', '2');
+            tableOptions = opts_add(tableOptions, 'y error minus index', '3');
+        case 'xy'
+            tableOptions = opts_add(tableOptions, 'x error plus index', '2');
+            tableOptions = opts_add(tableOptions, 'x error minus index', '3');
+            tableOptions = opts_add(tableOptions, 'y error plus index', '4');
+            tableOptions = opts_add(tableOptions, 'y error minus index', '5');
     end
 
     % Print out


### PR DESCRIPTION
This PR implements horizontal error bars and is an updated version of #1019. Closes #1016.

This `*.m` script
```matlab
%% data
x = [1, 2];
y = [1, 2];
dneg = [0.2, NaN];
dpos = [0.1, 0.4];

%% no errorbar
fig = figure;
subplot(2,2,1);
plot(x, y, 'marker', 'o');
title('none');
axis([0.5, 2.5, 0.5, 2.5]);
legend('location', 'northwest');

%% only y errorbar

subplot(2,2,2);
errorbar(x, y, dneg, dpos, 'vertical', 'marker', 'o');
title('vertical');
axis([0.5, 2.5, 0.5, 2.5]);
legend('location', 'northwest');

%% only x errorbar

subplot(2,2,3);
errorbar(x, y, dneg, dpos, 'horizontal', 'marker', 'o');
title('horizontal');
axis([0.5, 2.5, 0.5, 2.5]);
legend('location', 'northwest');

%% both x and y errorbar

subplot(2,2,4);
errorbar(x, y, dneg, dpos, 'both', 'marker', 'o');
title('both');
axis([0.5, 2.5, 0.5, 2.5]);
legend('location', 'northwest');

matlab2tikz('testm2terrorbar.tikz');
```
produces a plot which looks like this (directly exported to PNG):
![Matlab_reference](https://user-images.githubusercontent.com/2496460/216995410-8ab54517-9c7e-4550-b38a-8594b4b6d56d.png)

Current master produces this TikZ file:
```latex
% This file was created by matlab2tikz.
%
%The latest updates can be retrieved from
%  http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz
%where you can also make suggestions and rate matlab2tikz.
%
\definecolor{mycolor1}{rgb}{0.00000,0.44700,0.74100}%
%
\begin{tikzpicture}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(0.758in,2.554in)},
scale only axis,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={none},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
  table[row sep=crcr]{%
1	1\\
2	2\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(3.327in,2.554in)},
scale only axis,
unbounded coords=jump,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={vertical},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
 plot [error bars/.cd, y dir=both, y explicit, error bar style={line width=0.5pt}, error mark options={line width=0.5pt, mark size=6.0pt, rotate=90}]
 table[row sep=crcr, y error plus index=2, y error minus index=3]{%
1	1	0.1	0.2\\
2	2	0.4	nan\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(0.758in,0.481in)},
scale only axis,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={horizontal},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
  table[row sep=crcr]{%
1	1\\
2	2\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(3.327in,0.481in)},
scale only axis,
unbounded coords=jump,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={both},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
 plot [error bars/.cd, y dir=both, y explicit, error bar style={line width=0.5pt}, error mark options={line width=0.5pt, mark size=6.0pt, rotate=90}]
 table[row sep=crcr, y error plus index=2, y error minus index=3]{%
1	1	0.1	0.2\\
2	2	0.4	nan\\
};
\addlegendentry{data1}

\end{axis}
\end{tikzpicture}%
```
which compiles to this PDF where the horizontal error bars are missing:
![testm2terrorbar_old](https://user-images.githubusercontent.com/2496460/216995757-0f1bcd7f-73b3-4f88-99bc-02e8524ee553.png)

With this PR, the same Matlab file now produces this TikZ file:
```latex
% This file was created by matlab2tikz.
%
%The latest updates can be retrieved from
%  http://www.mathworks.com/matlabcentral/fileexchange/22022-matlab2tikz-matlab2tikz
%where you can also make suggestions and rate matlab2tikz.
%
\definecolor{mycolor1}{rgb}{0.00000,0.44700,0.74100}%
%
\begin{tikzpicture}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(0.758in,2.554in)},
scale only axis,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={none},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
  table[row sep=crcr]{%
1	1\\
2	2\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(3.327in,2.554in)},
scale only axis,
unbounded coords=jump,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={vertical},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
 plot [error bars/.cd, y dir=both, y explicit, error bar style={line width=0.5pt}, error mark options={line width=0.5pt, mark size=6.0pt, rotate=90}]
 table[row sep=crcr, y error plus index=2, y error minus index=3]{%
1	1	0.1	0.2\\
2	2	0.4	nan\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(0.758in,0.481in)},
scale only axis,
unbounded coords=jump,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={horizontal},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
 plot [error bars/.cd, x dir=both, x explicit, error bar style={line width=0.5pt}, error mark options={line width=0.5pt, mark size=6.0pt, rotate=90}]
 table[row sep=crcr, x error plus index=2, x error minus index=3]{%
1	1	0.1	0.2\\
2	2	0.4	nan\\
};
\addlegendentry{data1}

\end{axis}

\begin{axis}[%
width=1.952in,
height=1.493in,
at={(3.327in,0.481in)},
scale only axis,
unbounded coords=jump,
xmin=0.5,
xmax=2.5,
ymin=0.5,
ymax=2.5,
axis background/.style={fill=white},
title style={font=\bfseries},
title={both},
legend style={at={(0.03,0.97)}, anchor=north west, legend cell align=left, align=left, draw=white!15!black}
]
\addplot [color=mycolor1, mark=o, mark options={solid, mycolor1}]
 plot [error bars/.cd, x dir=both, x explicit, y dir=both, y explicit, error bar style={line width=0.5pt}, error mark options={line width=0.5pt, mark size=6.0pt, rotate=90}]
 table[row sep=crcr, x error plus index=2, x error minus index=3, y error plus index=4, y error minus index=5]{%
1	1	0.1	0.2	0.1	0.2\\
2	2	0.4	nan	0.4	nan\\
};
\addlegendentry{data1}

\end{axis}
\end{tikzpicture}%
```
that render to this PDF with horizontal error bars:
![testm2terrorbar_new](https://user-images.githubusercontent.com/2496460/216996328-3065077a-3f35-44cc-8844-0e0b7cb4a5f6.png)

