### PR TITLE
Fix legend position layout

### DIFF
--- a/src/matlab2tikz.m
+++ b/src/matlab2tikz.m
@@ -5470,10 +5470,10 @@ function [lStyle] = getLegendPosition(m2t, handle, lStyle)
         case 'southwestoutside'
             position = [-dist, 0];
             anchor = 'south east';
-        case 'none'
+        case {'none', 'layout'}
             legendPos = get(handle, 'Position');
             unit = get(handle, 'Units');
-            if isequal(unit, 'normalized')
+            if isequal(unit, 'normalized') && ~isequal(lower(loc), 'layout')
                 position = legendPos(1:2);
             else
                 % Calculate where the legend is located w.r.t. the axes.


### PR DESCRIPTION
Fixes #1123

This implementation uses the fact that the `Position` field is still properly populated when specifying a `layout` position for a legend.
However, note that the `Unit` is then `normalized` (meaning it should be normalized within the figure, not axis!). Because of this, it needs special treatment in the if condition afterwards.